### PR TITLE
Fix issue 71 with CDS run

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,9 +1,8 @@
 const cds = require("@sap/cds/lib");
-const NotificationsBuildPlugin = require("./lib/build");
 
 if (cds.cli.command === "build") {
   // register build plugin
-  cds.build?.register?.('notifications', NotificationsBuildPlugin);
+  cds.build?.register?.('notifications', require("./lib/build"));
 }
 
 else cds.once("served", async () => {


### PR DESCRIPTION
Fix #71. Project can't start as `cds.build` class is available and required only when building project.
 