### PR TITLE
Update package.json description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cap-js/notifications",
   "version": "0.3.0",
-  "description": "CDS plugin providing integration to the SAP BTP Alert Notification Service.",
+  "description": "CDS plugin providing support for business notifications in SAP Build WorkZone.",
   "repository": "cap-js/notifications",
   "author": "SAP SE (https://www.sap.com)",
   "homepage": "https://cap.cloud.sap/",


### PR DESCRIPTION
  Current:
  "description": "CDS plugin providing integration to the SAP BTP Alert Notification Service.",
  Should be:
  "description": "CDS plugin providing support for business notifications in SAP Build WorkZone.",

  This should match the GitHub repo description and README for consistency.