### PR TITLE
Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,20 +16,18 @@
     "@sap/cds-dk": ">=8.0"
   },
   "dependencies": {
-    "@sap-cloud-sdk/connectivity": "^3.13.0",
-    "@sap-cloud-sdk/http-client": "^3.13.0",
-    "@sap-cloud-sdk/util": "^3.13.0"
+    "@sap-cloud-sdk/connectivity": "^4.6.0",
+    "@sap-cloud-sdk/http-client": "^4.6.0",
+    "@sap-cloud-sdk/util": "^4.6.0"
   },
   "devDependencies": {
     "@cap-js/cds-test": ">=0",
+    "@cap-js/cds-types": "^0.16.0",
     "@cap-js/sqlite": "^2.2.0",
-    "@sap/cds": ">=8.0",
-    "@sap/cds-dk": ">=8.0",
-    "chai": "^4.3.10",
     "express": "^5.2.1",
-    "jest": "^29.7.0"
+    "jest": "^30.3.0"
   },
-   "engines": {
+  "engines": {
     "node": ">=20.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@cap-js/cds-test": ">=0",
     "@cap-js/cds-types": "^0.16.0",
     "@cap-js/sqlite": "^2.2.0",
+    "@sap/cds": ">=8.0",
+    "@sap/cds-dk": ">=8.0",
     "express": "^5.2.1",
     "jest": "^30.3.0"
   },

--- a/tests/unit/lib/notificationTypes.test.js
+++ b/tests/unit/lib/notificationTypes.test.js
@@ -2,7 +2,6 @@ const utils = require("../../../lib/utils");
 const httpClient = require("@sap-cloud-sdk/http-client");
 const connectivity = require("@sap-cloud-sdk/connectivity");
 const notificationTypes = require("../../../lib/notificationTypes");
-const assert = require("chai");
 
 jest.mock("../../../lib/utils");
 jest.mock("@sap-cloud-sdk/http-client");

--- a/tests/unit/lib/notifications.test.js
+++ b/tests/unit/lib/notifications.test.js
@@ -1,3 +1,4 @@
+const cds = require('@sap/cds');
 const { getNotificationDestination } = require("../../../lib/utils");
 const { buildHeadersForDestination } = require("@sap-cloud-sdk/connectivity");
 const NotifyToRest = require("../../../srv/notifyToRest");

--- a/tests/unit/srv/notifyToRest.test.js
+++ b/tests/unit/srv/notifyToRest.test.js
@@ -1,3 +1,4 @@
+const cds = require('@sap/cds');
 const { messages, buildNotification } = require("../../../lib/utils");
 const NotifyToRest = require("../../../srv/notifyToRest");
 


### PR DESCRIPTION
Bumping Cloud SDK dependencies. Remove chai as it was unused. Add cds-types for CAP types.