### PR TITLE
Remove JSON requirement

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,6 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const messages = {
-  TYPES_FILE_NOT_EXISTS: "Notification Types file path is incorrect.",
   INVALID_NOTIFICATION_TYPES: "Notification Types must contain the following key: 'NotificationTypeKey'.",
   DESTINATION_NOT_FOUND: "Failed to get destination: ",
   MANDATORY_PARAMETER_NOT_PASSED_FOR_DEFAULT_NOTIFICATION: "Recipients and title are mandatory parameters.",
@@ -100,10 +99,7 @@ function validateCustomNotifyParameters(type, recipients, properties, navigation
 
 function readFile(filePath) {
   const resolvedPath = cds.utils.path.resolve(cds.root, filePath)
-  if (!existsSync(resolvedPath)) {
-    LOG._warn && LOG.warn(messages.TYPES_FILE_NOT_EXISTS)
-    return []
-  }
+  if (!existsSync(resolvedPath)) return []
 
   return JSON.parse(readFileSync(resolvedPath))
 }

--- a/tests/bookshop/test/http/CatalogService.http
+++ b/tests/bookshop/test/http/CatalogService.http
@@ -36,7 +36,4 @@ Authorization: Basic {{username}}:{{password}}
 {
   "book": "201",
   "quantity": 1
-{
-  "book": "201",
-  "quantity": 1
 }

--- a/tests/bookshop/test/http/CatalogService.http
+++ b/tests/bookshop/test/http/CatalogService.http
@@ -34,6 +34,6 @@ Content-Type: application/json
 Authorization: Basic {{username}}:{{password}}
 
 {
-  "book": "65402382-e029-4e04-8ea1-05e9264faa26",
-  "quantity": 94
+  "book": "201",
+  "quantity": 1
 }

--- a/tests/bookshop/test/http/CatalogService.http
+++ b/tests/bookshop/test/http/CatalogService.http
@@ -36,4 +36,7 @@ Authorization: Basic {{username}}:{{password}}
 {
   "book": "201",
   "quantity": 1
+{
+  "book": "201",
+  "quantity": 1
 }


### PR DESCRIPTION
Currently, the project requires that an application MUST include the file `notification-types.json`, the legacy way to add notification annotations. But with the shift toward event types in cds files, this should not be a requirement. Apps that only use cds for types should not be getting a warning.