### PR TITLE
Allow plugin to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Support for email templates via `@notification.template.email.subject` and `@notification.template.email.html` in CDS annotations, and `EmailSubject` / `EmailHtml` in JSON templates.
 - i18n support for CDS annotation string values using `{i18n>key}` syntax.
 - Notification types are automatically registered and kept in sync with the notification service on application startup when running in hybrid or production mode.
+- Support for disabling the plugin via `cds.env.requires.notifications.enabled: false`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Support for email templates via `@notification.template.email.subject` and `@notification.template.email.html` in CDS annotations, and `EmailSubject` / `EmailHtml` in JSON templates.
 - i18n support for CDS annotation string values using `{i18n>key}` syntax.
 - Notification types are automatically registered and kept in sync with the notification service on application startup when running in hybrid or production mode.
-- Support for disabling the plugin via `cds.env.requires.notifications.enabled: false`.
+- Support for disabling the plugin via `cds.requires.notifications.enabled: false`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,24 @@ Note, that in order for E-Mail Notifications to be sent for notifications publis
 
 For the Work Zone Authentication Identifier configuration details refer to: [Work Zone Subaccount Settings](https://help.sap.com/docs/build-work-zone-standard-edition/sap-build-work-zone-standard-edition/subaccount-settings)
 
+### Disabling the Plugin
+
+To disable the plugin without removing it, set `enabled: false` in your CDS configuration:
+
+```json
+"cds": {
+  "requires": {
+    "notifications": {
+      "enabled": false
+    }
+  }
+}
+```
+
+This prevents the plugin from registering its hooks — no automatic `this.emit()` interception, no notification type registration, and no build task. This is useful for modules where notifications should not be active.
+
+> **Note:** Direct calls to `cds.connect.to('notifications')` and `notify()` are not affected by this flag, as the underlying notifications service is loaded independently by CDS. The approach of `this.emit()` is recommended over `notify()` directly, so that `enabled: false` can fully suppress notification behavior.
+
 ### Low-level  Notifications API
 
 You can use these two signature to send the custom notification with pre-defined notification types.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  parserOpts: {
+    allowReturnOutsideFunction: true
+  }
+}

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,70 +1,71 @@
 const cds = require("@sap/cds/lib")
 const { buildNotificationFromEvent } = require('./lib/utils')
 
-if (cds.env.requires?.notifications?.enabled !== false) {
+const isEnabled = () => cds.env.requires?.notifications?.enabled !== false
 
-  cds.on("loaded", m => {
-    for (const def of Object.values(m.definitions)) {
-      if (def.kind !== 'event') continue
-      if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) continue
-      if (!def.elements) def.elements = {}
-      if (!def.elements.recipients) {
-        def.elements.recipients = { items: { type: 'cds.String' } }
-      }
+cds.on("loaded", m => {
+  if (!isEnabled()) return
+  for (const def of Object.values(m.definitions)) {
+    if (def.kind !== 'event') continue
+    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) continue
+    if (!def.elements) def.elements = {}
+    if (!def.elements.recipients) {
+      def.elements.recipients = { items: { type: 'cds.String' } }
+    }
+  }
+})
+
+cds.on('serving', service => {
+  if (!isEnabled()) return
+  if (service.name === 'notifications' || service instanceof cds.DatabaseService) return
+  service.on('*', async (req) => {
+    const def = service.events?.[req.event]
+    if (!def || def.kind !== 'event') return
+    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) return
+    const notifications = await cds.connect.to('notifications')
+    const notification = buildNotificationFromEvent(def, req.data)
+    try {
+      await notifications.notify(notification)
+    } catch (err) {
+      const LOG = cds.log('notifications')
+      LOG._error && LOG.error('Failed to send notification for event', def.name, err)
     }
   })
+})
 
-  cds.on('serving', service => {
-    if (service.name === 'notifications' || service instanceof cds.DatabaseService) return
-    service.on('*', async (req) => {
-      const def = service.events?.[req.event]
-      if (!def || def.kind !== 'event') return
-      if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) return
-      const notifications = await cds.connect.to('notifications')
-      const notification = buildNotificationFromEvent(def, req.data)
-      try {
-        await notifications.notify(notification)
-      } catch (err) {
-        const LOG = cds.log('notifications')
-        LOG._error && LOG.error('Failed to send notification for event', def.name, err)
-      }
-    })
-  })
+if (cds.cli.command === "build") {
+  // register build plugin
+  cds.build?.register?.('notifications', require("./lib/build"))
+}
 
-  if (cds.cli.command === "build") {
-    // register build plugin
-    cds.build?.register?.('notifications', require("./lib/build"))
+else cds.once("served", async () => {
+  if (!isEnabled()) return
+  const { validateNotificationTypes, readFile } = require("./lib/utils")
+  const { createNotificationTypesMap } = require("./lib/notificationTypes")
+  const { notificationTypesFromModel } = require("./lib/compile")
+  const production = cds.env.profiles?.includes("production")
+
+  const typesPath = cds.env.requires?.notifications?.types
+  const kind = cds.env.requires?.notifications?.kind
+  const needsProcessing = kind === 'notify-to-rest' || !production
+  if (!needsProcessing) return
+
+  const model = cds.context?.model ?? cds.model
+  const notificationTypes = [
+    ...notificationTypesFromModel(model),
+    ...( typesPath ? readFile(typesPath) : [] )
+  ]
+
+  if (validateNotificationTypes(notificationTypes)) {
+    if (kind === 'notify-to-rest') {
+      const { processNotificationTypes } = require('./lib/notificationTypes')
+      // deploy automatically on startup
+      await processNotificationTypes(notificationTypes)
+    } else if (!production) {
+      const notificationTypesMap = createNotificationTypesMap(notificationTypes, true)
+      cds.notifications = { local: { types: notificationTypesMap } }
+    }
   }
 
-  else cds.once("served", async () => {
-    const { validateNotificationTypes, readFile } = require("./lib/utils")
-    const { createNotificationTypesMap } = require("./lib/notificationTypes")
-    const { notificationTypesFromModel } = require("./lib/compile")
-    const production = cds.env.profiles?.includes("production")
-
-    const typesPath = cds.env.requires?.notifications?.types
-    const kind = cds.env.requires?.notifications?.kind
-    const needsProcessing = kind === 'notify-to-rest' || !production
-    if (!needsProcessing) return
-
-    const model = cds.context?.model ?? cds.model
-    const notificationTypes = [
-      ...notificationTypesFromModel(model),
-      ...( typesPath ? readFile(typesPath) : [] )
-    ]
-
-    if (validateNotificationTypes(notificationTypes)) {
-      if (kind === 'notify-to-rest') {
-        const { processNotificationTypes } = require('./lib/notificationTypes')
-        // deploy automatically on startup
-        await processNotificationTypes(notificationTypes)
-      } else if (!production) {
-        const notificationTypesMap = createNotificationTypesMap(notificationTypes, true)
-        cds.notifications = { local: { types: notificationTypesMap } }
-      }
-    }
-
-    require("@sap-cloud-sdk/util").setGlobalLogLevel("error")
-  })
-
-}
+  require("@sap-cloud-sdk/util").setGlobalLogLevel("error")
+})

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,66 +1,70 @@
 const cds = require("@sap/cds/lib")
 const { buildNotificationFromEvent } = require('./lib/utils')
 
-cds.on("loaded", m => {
-  for (const def of Object.values(m.definitions)) {
-    if (def.kind !== 'event') continue
-    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) continue
-    if (!def.elements) def.elements = {}
-    if (!def.elements.recipients) {
-      def.elements.recipients = { items: { type: 'cds.String' } }
-    }
-  }
-})
+if (cds.env.requires?.notifications?.enabled !== false) {
 
-cds.on('serving', service => {
-  if (service.name === 'notifications' || service instanceof cds.DatabaseService) return
-  service.on('*', async (req) => {
-    const def = service.events?.[req.event]
-    if (!def || def.kind !== 'event') return
-    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) return
-    const notifications = await cds.connect.to('notifications')
-    const notification = buildNotificationFromEvent(def, req.data)
-    try {
-      await notifications.notify(notification)
-    } catch (err) {
-      const LOG = cds.log('notifications')
-      LOG._error && LOG.error('Failed to send notification for event', def.name, err)
+  cds.on("loaded", m => {
+    for (const def of Object.values(m.definitions)) {
+      if (def.kind !== 'event') continue
+      if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) continue
+      if (!def.elements) def.elements = {}
+      if (!def.elements.recipients) {
+        def.elements.recipients = { items: { type: 'cds.String' } }
+      }
     }
   })
-})
 
-if (cds.cli.command === "build") {
-  // register build plugin
-  cds.build?.register?.('notifications', require("./lib/build"))
-}
+  cds.on('serving', service => {
+    if (service.name === 'notifications' || service instanceof cds.DatabaseService) return
+    service.on('*', async (req) => {
+      const def = service.events?.[req.event]
+      if (!def || def.kind !== 'event') return
+      if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) return
+      const notifications = await cds.connect.to('notifications')
+      const notification = buildNotificationFromEvent(def, req.data)
+      try {
+        await notifications.notify(notification)
+      } catch (err) {
+        const LOG = cds.log('notifications')
+        LOG._error && LOG.error('Failed to send notification for event', def.name, err)
+      }
+    })
+  })
 
-else cds.once("served", async () => {
-  const { validateNotificationTypes, readFile } = require("./lib/utils")
-  const { createNotificationTypesMap } = require("./lib/notificationTypes")
-  const { notificationTypesFromModel } = require("./lib/compile")
-  const production = cds.env.profiles?.includes("production")
-
-  const typesPath = cds.env.requires?.notifications?.types
-  const kind = cds.env.requires?.notifications?.kind
-  const needsProcessing = kind === 'notify-to-rest' || !production
-  if (!needsProcessing) return
-
-  const model = cds.context?.model ?? cds.model
-  const notificationTypes = [
-    ...notificationTypesFromModel(model),
-    ...( typesPath ? readFile(typesPath) : [] )
-  ]
-
-  if (validateNotificationTypes(notificationTypes)) {
-    if (kind === 'notify-to-rest') {
-      const { processNotificationTypes } = require('./lib/notificationTypes')
-      // deploy automatically on startup
-      await processNotificationTypes(notificationTypes)
-    } else if (!production) {
-      const notificationTypesMap = createNotificationTypesMap(notificationTypes, true)
-      cds.notifications = { local: { types: notificationTypesMap } }
-    }
+  if (cds.cli.command === "build") {
+    // register build plugin
+    cds.build?.register?.('notifications', require("./lib/build"))
   }
 
-  require("@sap-cloud-sdk/util").setGlobalLogLevel("error")
-})
+  else cds.once("served", async () => {
+    const { validateNotificationTypes, readFile } = require("./lib/utils")
+    const { createNotificationTypesMap } = require("./lib/notificationTypes")
+    const { notificationTypesFromModel } = require("./lib/compile")
+    const production = cds.env.profiles?.includes("production")
+
+    const typesPath = cds.env.requires?.notifications?.types
+    const kind = cds.env.requires?.notifications?.kind
+    const needsProcessing = kind === 'notify-to-rest' || !production
+    if (!needsProcessing) return
+
+    const model = cds.context?.model ?? cds.model
+    const notificationTypes = [
+      ...notificationTypesFromModel(model),
+      ...( typesPath ? readFile(typesPath) : [] )
+    ]
+
+    if (validateNotificationTypes(notificationTypes)) {
+      if (kind === 'notify-to-rest') {
+        const { processNotificationTypes } = require('./lib/notificationTypes')
+        // deploy automatically on startup
+        await processNotificationTypes(notificationTypes)
+      } else if (!production) {
+        const notificationTypesMap = createNotificationTypesMap(notificationTypes, true)
+        cds.notifications = { local: { types: notificationTypesMap } }
+      }
+    }
+
+    require("@sap-cloud-sdk/util").setGlobalLogLevel("error")
+  })
+
+}

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,4 +1,4 @@
-const cds = require("@sap/cds/lib")
+const cds = require('@sap/cds')
 if (!cds.env.requires?.notifications?.enabled) return 
 
 const { buildNotificationFromEvent } = require('./lib/utils')

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,10 +1,10 @@
 const cds = require("@sap/cds/lib")
-const { buildNotificationFromEvent } = require('./lib/utils')
+if (!cds.env.requires?.notifications?.enabled) return 
 
-const isEnabled = () => cds.env.requires?.notifications?.enabled !== false
+const { buildNotificationFromEvent } = require('./lib/utils')
+cds.build?.register?.('notifications', require("./lib/build"))
 
 cds.on("loaded", m => {
-  if (!isEnabled()) return
   for (const def of Object.values(m.definitions)) {
     if (def.kind !== 'event') continue
     if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) continue
@@ -16,7 +16,6 @@ cds.on("loaded", m => {
 })
 
 cds.on('serving', service => {
-  if (!isEnabled()) return
   if (service.name === 'notifications' || service instanceof cds.DatabaseService) return
   service.on('*', async (req, next) => {
     let def = req.target ?? service.events?.[req.event]
@@ -35,13 +34,7 @@ cds.on('serving', service => {
   })
 })
 
-if (cds.cli.command === "build") {
-  // register build plugin
-  cds.build?.register?.('notifications', require("./lib/build"))
-}
-
-else cds.once("served", async () => {
-  if (!isEnabled()) return
+cds.once("served", async () => {
   const { validateNotificationTypes, readFile } = require("./lib/utils")
   const { createNotificationTypesMap } = require("./lib/notificationTypes")
   const { notificationTypesFromModel } = require("./lib/compile")

--- a/lib/build.js
+++ b/lib/build.js
@@ -6,7 +6,7 @@ module.exports = class NotificationsBuildPlugin extends cds.build.Plugin {
   static taskDefaults = { src: cds.env.folders.srv }
 
   static hasTask() {
-    return !!cds.env.requires?.notifications
+    return (!!cds.env.requires?.notifications && cds.env.requires?.notifications?.enabled !== false)
   }
 
   async build() {

--- a/lib/build.js
+++ b/lib/build.js
@@ -6,7 +6,7 @@ module.exports = class NotificationsBuildPlugin extends cds.build.Plugin {
   static taskDefaults = { src: cds.env.folders.srv }
 
   static hasTask() {
-    return (!!cds.env.requires?.notifications && cds.env.requires?.notifications?.enabled !== false)
+    return (!!cds.env.requires?.notifications && cds.env.requires.notifications.enabled !== false)
   }
 
   async build() {

--- a/lib/build.js
+++ b/lib/build.js
@@ -6,7 +6,7 @@ module.exports = class NotificationsBuildPlugin extends cds.build.Plugin {
   static taskDefaults = { src: cds.env.folders.srv }
 
   static hasTask() {
-    return (!!cds.env.requires?.notifications && cds.env.requires.notifications.enabled !== false)
+    return (!!cds.env.requires?.notifications)
   }
 
   async build() {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       "notifications": {
         "prefix": "$app-name",
         "types": "srv/notification-types.json",
-        "outbox": true
+        "outbox": true,
+        "enabled": true
       },
       "kinds": {
         "notify-to-console": {

--- a/srv/notifyToConsole.js
+++ b/srv/notifyToConsole.js
@@ -17,7 +17,8 @@ module.exports = class NotifyToConsole extends NotificationService {
       )
 
       const { NotificationTypeKey, NotificationTypeVersion } = notification
-      const types = cds.notifications.local.types // REVISIT: what is this?
+      const types = cds.notifications?.local?.types
+      if (!types) return
 
       if (!(NotificationTypeKey in types)) {
         LOG._warn && LOG.warn(

--- a/tests/bookshop/db/schema.cds
+++ b/tests/bookshop/db/schema.cds
@@ -1,13 +1,13 @@
 using {
   Currency,
   managed,
-  cuid,
   sap
 } from '@sap/cds/common';
 
 namespace sap.capire.bookshop;
 
-entity Books : managed, cuid {
+entity Books : managed {
+  key ID   : Integer;
   title    : localized String(111)  @mandatory;
   descr    : localized String(1111);
   author   : Association to Authors @mandatory;
@@ -17,7 +17,8 @@ entity Books : managed, cuid {
   currency : Currency;
 }
 
-entity Authors : managed, cuid {
+entity Authors : managed {
+  key ID       : Integer;
   name         : String(111) @mandatory;
   dateOfBirth  : Date;
   dateOfDeath  : Date;

--- a/tests/integration/bookshop.test.js
+++ b/tests/integration/bookshop.test.js
@@ -1,5 +1,5 @@
 const cds = require("@sap/cds")
-const { join } = cds.utils.path
+const { join } = require("path")
 const { messages } = require("../../lib/utils")
 const { notificationTypesFromModel } = require("../../lib/compile")
 


### PR DESCRIPTION
Allows for toggle under cds.requres.notifications for enabled to be set to false (similar to other plugins). Addresses issue #124 