### PR TITLE
ci: add lint and prettier workflow

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -1,26 +1,26 @@
-name: "Integration tests"
-description: "Run tests with BTP services being bound"
+name: 'Integration tests'
+description: 'Run tests with BTP services being bound'
 inputs:
   CF_API:
-    description: "Cloud Foundry API endpoint"
+    description: 'Cloud Foundry API endpoint'
     required: true
   CF_USERNAME:
-    description: "Cloud Foundry username"
+    description: 'Cloud Foundry username'
     required: true
   CF_PASSWORD:
-    description: "Cloud Foundry password"
+    description: 'Cloud Foundry password'
     required: true
   CF_ORG:
-    description: "Cloud Foundry organization"
+    description: 'Cloud Foundry organization'
     required: true
   CF_SPACE:
-    description: "Cloud Foundry space"
+    description: 'Cloud Foundry space'
     required: true
   NODE_VERSION:
-    description: "Node.js version to use for tests"
+    description: 'Node.js version to use for tests'
     required: true
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Install dependencies and Cloud Foundry CLI (v8.9.0)
       shell: bash

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -1,26 +1,26 @@
-name: 'Integration tests'
-description: 'Run tests with BTP services being bound'
+name: "Integration tests"
+description: "Run tests with BTP services being bound"
 inputs:
   CF_API:
-    description: 'Cloud Foundry API endpoint'
+    description: "Cloud Foundry API endpoint"
     required: true
   CF_USERNAME:
-    description: 'Cloud Foundry username'
+    description: "Cloud Foundry username"
     required: true
   CF_PASSWORD:
-    description: 'Cloud Foundry password'
+    description: "Cloud Foundry password"
     required: true
   CF_ORG:
-    description: 'Cloud Foundry organization'
+    description: "Cloud Foundry organization"
     required: true
   CF_SPACE:
-    description: 'Cloud Foundry space'
+    description: "Cloud Foundry space"
     required: true
   NODE_VERSION:
-    description: 'Node.js version to use for tests'
+    description: "Node.js version to use for tests"
     required: true
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Install dependencies and Cloud Foundry CLI (v8.9.0)
       shell: bash

--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -1,0 +1,24 @@
+name: Lint & Prettier
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, auto_merge_enabled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v6
+      - run: npm i
+      - run: npm run lint
+      - run: npm run prettier:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       previous-tag:
-        description: 'Previous tag (optional)'
+        description: "Previous tag (optional)"
         required: false
         type: choice
-        default: 'latest'
+        default: "latest"
         options:
-          - 'latest'
-          - 'previous'
-          - 'beta'
+          - "latest"
+          - "previous"
+          - "beta"
 
 permissions:
   contents: write
@@ -41,10 +41,10 @@ jobs:
         id: parse-changelog
         uses: schwma/parse-changelog-action@v1.0.0
         with:
-          version: '${{ steps.package-version.outputs.current-version }}'
+          version: "${{ steps.package-version.outputs.current-version }}"
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:
-          tag: 'v${{ steps.package-version.outputs.current-version }}'
-          body: '${{ steps.parse-changelog.outputs.body }}'
+          tag: "v${{ steps.package-version.outputs.current-version }}"
+          body: "${{ steps.parse-changelog.outputs.body }}"
       - run: npm publish --access public --provenance --tag ${{ github.event.inputs.previous-tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       previous-tag:
-        description: "Previous tag (optional)"
+        description: 'Previous tag (optional)'
         required: false
         type: choice
-        default: "latest"
+        default: 'latest'
         options:
-          - "latest"
-          - "previous"
-          - "beta"
+          - 'latest'
+          - 'previous'
+          - 'beta'
 
 permissions:
   contents: write
@@ -41,10 +41,10 @@ jobs:
         id: parse-changelog
         uses: schwma/parse-changelog-action@v1.0.0
         with:
-          version: "${{ steps.package-version.outputs.current-version }}"
+          version: '${{ steps.package-version.outputs.current-version }}'
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:
-          tag: "v${{ steps.package-version.outputs.current-version }}"
-          body: "${{ steps.parse-changelog.outputs.body }}"
+          tag: 'v${{ steps.package-version.outputs.current-version }}'
+          body: '${{ steps.parse-changelog.outputs.body }}'
       - run: npm publish --access public --provenance --tag ${{ github.event.inputs.previous-tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Node.js CI
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
+    branches: ['main']
   pull_request_target:
-    branches: ["main"]
+    branches: ['main']
     types: [reopened, synchronize, opened]
 
 permissions:
@@ -14,7 +14,7 @@ permissions:
 jobs:
   requires-approval:
     runs-on: ubuntu-latest
-    name: "Waiting for PR approval as this workflow runs on pull_request_target"
+    name: 'Waiting for PR approval as this workflow runs on pull_request_target'
     if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.owner.login != 'cap-js'
     environment: pr-approval
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Node.js CI
 on:
   workflow_dispatch:
   push:
-    branches: ['main']
+    branches: ["main"]
   pull_request_target:
-    branches: ['main']
+    branches: ["main"]
     types: [reopened, synchronize, opened]
 
 permissions:
@@ -14,7 +14,7 @@ permissions:
 jobs:
   requires-approval:
     runs-on: ubuntu-latest
-    name: 'Waiting for PR approval as this workflow runs on pull_request_target'
+    name: "Waiting for PR approval as this workflow runs on pull_request_target"
     if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.owner.login != 'cap-js'
     environment: pr-approval
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Node.js CI
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request_target:
-    branches: [ "main" ]
+    branches: ["main"]
     types: [reopened, synchronize, opened]
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Integration tests (HANA + ANS)
-        uses: ./.github/actions/integration-tests@main
+        uses: ./.github/actions/integration-tests
         with:
           CF_API: ${{ secrets.CF_API }}
           CF_USERNAME: ${{ secrets.CF_USERNAME }}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,7 @@
 {
-    "tabWidth": 2,
-    "useTabs": false,
-    "printWidth": 200,
-    "trailingComma" : "none"
+	"tabWidth": 2,
+	"useTabs": true,
+	"printWidth": 120,
+	"semi": false,
+	"trailingComma": "none"
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,8 @@
 {
-	"tabWidth": 2,
-	"useTabs": true,
-	"printWidth": 120,
-	"semi": false,
-	"trailingComma": "none"
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 120,
+  "arrowParens": "avoid",
+  "semi": false,
+  "trailingComma": "none"
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,6 @@
 {
   "tabWidth": 2,
   "useTabs": false,
-  "singleQuote": true,
   "printWidth": 120,
   "arrowParens": "avoid",
   "semi": false,

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,7 @@
 {
   "tabWidth": 2,
   "useTabs": false,
+  "singleQuote": true,
   "printWidth": 120,
   "arrowParens": "avoid",
   "semi": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   the message is queued; the return value is only available when `outbox: false`.
 - Support for email delivery channels via `@notification.channels` in CDS annotations and `DeliveryChannels` in the JSON format.
 - Support for email templates via `@notification.email.subject` and `@notification.email.html` in CDS annotations, and `EmailSubject` / `EmailHtml` in JSON templates. The `email.html` annotation accepts an inline HTML string or a path to an `.html` file relative to the `.cds` source file.
-- i18n support for CDS annotation string values using `{i18n>key}` syntax. 
+- i18n support for CDS annotation string values using `{i18n>key}` syntax.
 - Notification types are automatically registered and kept in sync with the notification service on application startup when running in hybrid or production mode.
-- Allows to send notifications of `@notification`-annotated events  via `this.emit()` 
+- Allows to send notifications of `@notification`-annotated events via `this.emit()`
 - Batch notifications: `notify()` now accepts an array of notification objects. Each item is sent individually; partial failures are logged as warnings and the call only throws if all items fail.
 - Static and dynamic notification priority via `@notification.priority`. Accepts a fixed enum value (`#HIGH`, `#LOW`, etc.) or a CDS ternary expression evaluated against event data at runtime (e.g. `(quantity > 5 ? #HIGH : #LOW)`).
 - `cds.env.requires.notifications.channels` option to adjust the default delivery for all notification types globally
 - `cds build` integration: annotated events are compiled and written to `notification-types.json` in the build output, merged with any types from the JSON file.
 - Log full response body and headers when the `notifications` logger is enabled at debug level.
-- Return the full HTTP response from the REST notification handler when `outbox:false` 
+- Return the full HTTP response from the REST notification handler when `outbox:false`
 - Validation of ANS length constraints at emit time: `Properties` values exceeding 255 characters throw an error; `TargetParameters` values exceeding 250 characters are silently dropped. Event element names exceeding 128 characters are caught at `cds build` time.
 - Key elements (annotated with `key` in the event definition) are now included in `TargetParameters` only and excluded from `Properties`, matching ANS API expectations.
 - Support for disabling the plugin via `cds.requires.notifications.enabled: false`.
@@ -41,7 +41,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - New default `auto` for `cds.env.requires.notifications.authenticationIdentifier`. Each recipient is inspected: UUID values are published with `GlobalUserId`, everything else with `RecipientId`, with a warning when a value is neither a UUID nor an email. The previous values `UserUUID` and `RecipientId` are still supported for an explicit choice.
   In practice this means the plugin "just works" without configuration: applications can pass emails, UUIDs, or a mix of both, and the correct recipient key is chosen per value — no upfront configuration about Work Zone's authentication identifier required.
 - `buildNotificationFromEvent` now respects `authenticationIdentifier` config when resolving recipient keys, consistent with the rest of the API.
-
 
 ## Version 0.3.0 - 2026-01-09
 
@@ -65,13 +64,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Fix versions
 
-
 ## Version 0.2.3 - 2024-10-22
 
 ### Fixed
 
 - Fix cds build failure
-
 
 ## Version 0.2.2 - 2024-10-21
 
@@ -79,13 +76,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Build issues fixed
 
-
 ## Version 0.2.1 - 2024-09-16
 
 ### Fixed
 
 - Compatibility to `@sap/cds` 8
-
 
 ## Version 0.2.0 - 2024-03-29
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall
+- Focusing on what is best not just for us as individuals, but for the overall
   community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or advances of
+- The use of sexualized language or imagery, and sexual attention or advances of
   any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address,
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
   without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 We use GitHub to manage reviews of pull requests.
 
-* If you are a new contributor, see: [Steps to Contribute](#steps-to-contribute)
+- If you are a new contributor, see: [Steps to Contribute](#steps-to-contribute)
 
-* Before implementing your change, create an issue that describes the problem you would like to solve or the code that should be enhanced. Please note that you are willing to work on that issue.
+- Before implementing your change, create an issue that describes the problem you would like to solve or the code that should be enhanced. Please note that you are willing to work on that issue.
 
-* The team will review the issue and decide whether it should be implemented as a pull request. In that case, they will assign the issue to you. If the team decides against picking up the issue, the team will post a comment with an explanation.
+- The team will review the issue and decide whether it should be implemented as a pull request. In that case, they will assign the issue to you. If the team decides against picking up the issue, the team will post a comment with an explanation.
 
 ## Steps to Contribute
 
@@ -28,11 +28,11 @@ You are welcome to contribute code in order to fix a bug or to implement a new f
 
 The following rule governs code contributions:
 
-* Contributions must be licensed under the [Apache 2.0 License](./LICENSE)
-* Due to legal reasons, contributors will be asked to accept a Developer Certificate of Origin (DCO) when they create the first pull request to this project. This happens in an automated fashion during the submission process. SAP uses [the standard DCO text of the Linux Foundation](https://developercertificate.org/).
+- Contributions must be licensed under the [Apache 2.0 License](./LICENSE)
+- Due to legal reasons, contributors will be asked to accept a Developer Certificate of Origin (DCO) when they create the first pull request to this project. This happens in an automated fashion during the submission process. SAP uses [the standard DCO text of the Linux Foundation](https://developercertificate.org/).
 
 ## Issues and Planning
 
-* We use GitHub issues to track bugs and enhancement requests.
+- We use GitHub issues to track bugs and enhancement requests.
 
-* Please provide as much context as possible when you open an issue. The information you provide must be comprehensive enough to reproduce that issue for the assignee.
+- Please provide as much context as possible when you open an issue. The information you provide must be comprehensive enough to reproduce that issue for the assignee.

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ After installing the plugin, you can send notifications in two ways:
 Send a simple notification using `notify()`:
 
 ```js
-const alert = await cds.connect.to("notifications")
+const alert = await cds.connect.to('notifications')
 
 await alert.notify({
-  recipients: ["user@example.com"],
-  title: "Book Order Received",
+  recipients: ['user@example.com'],
+  title: 'Book Order Received',
   description: 'Your order for "Wuthering Heights" is being processed.'
 })
 ```
@@ -77,13 +77,13 @@ extend service CatalogService with {
 Emit the event from your service handler:
 
 ```js
-this.on("submitOrder", async req => {
+this.on('submitOrder', async req => {
   // ... process order ...
 
-  await this.emit("BookOrdered", {
+  await this.emit('BookOrdered', {
     title: book.title,
     buyer: req.user.id,
-    recipients: ["user@example.com"]
+    recipients: ['user@example.com']
   })
 })
 ```
@@ -355,13 +355,13 @@ There are two patterns for sending notifications.
 If you defined your notification type as a CDS event with a `@notification` annotation, the plugin hooks into your service automatically. Simply emit the event from your service handler.
 
 ```js
-this.on("submitOrder", async req => {
-  const book = await SELECT.one.from("Books").where({ ID: req.data.book })
+this.on('submitOrder', async req => {
+  const book = await SELECT.one.from('Books').where({ ID: req.data.book })
 
-  await this.emit("BookOrdered", {
+  await this.emit('BookOrdered', {
     title: book.title,
     buyer: req.user.id,
-    recipients: ["reader@bookshop.example"]
+    recipients: ['reader@bookshop.example']
   })
 })
 ```
@@ -375,12 +375,12 @@ You can also connect to the notification service and call `notify()` directly. T
 **Simple notification** (no pre-defined type needed):
 
 ```js
-const alert = await cds.connect.to("notifications")
+const alert = await cds.connect.to('notifications')
 
 await alert.notify({
   recipients: [...readers()],
-  priority: "HIGH",
-  title: "New book arrived!",
+  priority: 'HIGH',
+  title: 'New book arrived!',
   description: "Book 'Wuthering Heights' has been added to the catalog."
 })
 ```
@@ -391,7 +391,7 @@ await alert.notify({
 **Named notification type:**
 
 ```js
-await alert.notify("BookOrdered", {
+await alert.notify('BookOrdered', {
   recipients: [buyer.id],
   data: {
     title: book.title,
@@ -405,7 +405,7 @@ await alert.notify("BookOrdered", {
 It is possible to pass an array to `notify()` to send multiple notifications in a single call. This triggers only one outbox event, reducing the number of transactions when notifying many recipients. If some items fail, the successful ones are still delivered. Failures are logged as warnings, and the call only throws if **all** items fail.
 
 ```js
-alert.notify("BookOrdered", [
+alert.notify('BookOrdered', [
   { recipients: [buyer1.id], data: { title: book.title, buyer: buyer1.name } },
   { recipients: [buyer2.id], data: { title: book.title, buyer: buyer2.name } }
 ])
@@ -418,8 +418,8 @@ Alternatively, the default notification template can be used:
 
 ```js
 await alert.notify([
-  { type: "BookOrdered", recipients: [buyer1.id], data: { title: book1.title, buyer: buyer1.name } },
-  { type: "BookOrdered", recipients: [buyer2.id], data: { title: book2.title, buyer: buyer2.name } }
+  { type: 'BookOrdered', recipients: [buyer1.id], data: { title: book1.title, buyer: buyer1.name } },
+  { type: 'BookOrdered', recipients: [buyer2.id], data: { title: book2.title, buyer: buyer2.name } }
 ])
 ```
 
@@ -614,20 +614,20 @@ For full control, pass the complete notification object directly as described in
 ```js
 alert.notify({
   recipients: [...readers()],
-  type: "BookOrdered",
-  priority: "NEUTRAL",
+  type: 'BookOrdered',
+  priority: 'NEUTRAL',
   data: {
     title: book.title,
     buyer: buyer.name
   },
-  OriginId: "Example Origin Id",
-  NotificationTypeVersion: "1",
-  ProviderId: "/SAMPLEPROVIDER",
-  ActorId: "BACKENDACTORID",
-  ActorDisplayText: "ActorName",
-  ActorImageURL: "https://some-url",
-  NotificationTypeTimestamp: "2022-03-15T09:58:42.807Z",
-  TargetParameters: [{ Key: "string", Value: "string" }]
+  OriginId: 'Example Origin Id',
+  NotificationTypeVersion: '1',
+  ProviderId: '/SAMPLEPROVIDER',
+  ActorId: 'BACKENDACTORID',
+  ActorDisplayText: 'ActorName',
+  ActorImageURL: 'https://some-url',
+  NotificationTypeTimestamp: '2022-03-15T09:58:42.807Z',
+  TargetParameters: [{ Key: 'string', Value: 'string' }]
 })
 ```
 
@@ -635,14 +635,14 @@ alert.notify({
 
 ```js
 alert.notify({
-  NotificationTypeKey: "BookOrdered",
-  NotificationTypeVersion: "1",
-  Priority: "NEUTRAL",
+  NotificationTypeKey: 'BookOrdered',
+  NotificationTypeVersion: '1',
+  Priority: 'NEUTRAL',
   Properties: [
-    { Key: "title", IsSensitive: false, Language: "en", Value: "Wuthering Heights", Type: "String" },
-    { Key: "buyer", IsSensitive: false, Language: "en", Value: "reader@bookshop.com", Type: "String" }
+    { Key: 'title', IsSensitive: false, Language: 'en', Value: 'Wuthering Heights', Type: 'String' },
+    { Key: 'buyer', IsSensitive: false, Language: 'en', Value: 'reader@bookshop.com', Type: 'String' }
   ],
-  Recipients: [{ RecipientId: "reader1@bookshop.com" }, { RecipientId: "reader2@bookshop.com" }]
+  Recipients: [{ RecipientId: 'reader1@bookshop.com' }, { RecipientId: 'reader2@bookshop.com' }]
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ The `@cap-js/notifications` package is a [CDS plugin](https://cap.cloud.sap/docs
 - [Code of Conduct](#code-of-conduct)
 - [Licensing](#licensing)
 
-
 ## Setup
 
 **Requirements:** Node.js >= 20, `@sap/cds` >= 8.
@@ -38,7 +37,6 @@ To enable notifications, simply add this self-configuring plugin package to your
 npm add @cap-js/notifications
 ```
 
-
 ## Getting Started
 
 After installing the plugin, you can send notifications in two ways:
@@ -48,11 +46,11 @@ After installing the plugin, you can send notifications in two ways:
 Send a simple notification using `notify()`:
 
 ```js
-const alert = await cds.connect.to('notifications')
+const alert = await cds.connect.to("notifications")
 
 await alert.notify({
-  recipients: ['user@example.com'],
-  title: 'Book Order Received',
+  recipients: ["user@example.com"],
+  title: "Book Order Received",
   description: 'Your order for "Wuthering Heights" is being processed.'
 })
 ```
@@ -79,13 +77,13 @@ extend service CatalogService with {
 Emit the event from your service handler:
 
 ```js
-this.on('submitOrder', async req => {
+this.on("submitOrder", async req => {
   // ... process order ...
-  
-  await this.emit('BookOrdered', {
+
+  await this.emit("BookOrdered", {
     title: book.title,
     buyer: req.user.id,
-    recipients: ['user@example.com']
+    recipients: ["user@example.com"]
   })
 })
 ```
@@ -140,10 +138,9 @@ On startup the plugin registers your notification types automatically. Submittin
 > [!Note]
 > The bookshop sample uses in-app notifications by default. The Work Zone bell icon shows notifications for recipients identified by their SAP BTP Global User ID (UUID). To test email delivery as well, additional setup is required. For enabling, see [email delivery](#email-delivery) and [default email delivery](#default-email-delivery). For required BTP configuration see the [SMTP mail destination guide](https://help.sap.com/docs/build-work-zone-standard-edition/sap-build-work-zone-standard-edition/configuring-smtp-mail-destination).
 
-
 ## Define Notification Types
 
-Notifications are based on *notification types*: templates that define how a notification looks, including titles, subtitles, and email content. These types can be defined in two ways, both of which can be used together and are merged at startup.
+Notifications are based on _notification types_: templates that define how a notification looks, including titles, subtitles, and email content. These types can be defined in two ways, both of which can be used together and are merged at startup.
 
 ### Option A: CDS Annotations (recommended)
 
@@ -345,12 +342,9 @@ event BookOrdered { ... }
       "EmailHtml": "<p>Thanks for ordering <b>{{title}}</b>!</p>"
     }
   ],
-  "DeliveryChannels": [
-    { "Type": "MAIL", "Enabled": true, "DefaultPreference": true, "EditablePreference": true }
-  ]
+  "DeliveryChannels": [{ "Type": "MAIL", "Enabled": true, "DefaultPreference": true, "EditablePreference": true }]
 }
 ```
-
 
 ## Send Notifications
 
@@ -361,13 +355,13 @@ There are two patterns for sending notifications.
 If you defined your notification type as a CDS event with a `@notification` annotation, the plugin hooks into your service automatically. Simply emit the event from your service handler.
 
 ```js
-this.on('submitOrder', async req => {
-  const book = await SELECT.one.from('Books').where({ ID: req.data.book })
+this.on("submitOrder", async req => {
+  const book = await SELECT.one.from("Books").where({ ID: req.data.book })
 
-  await this.emit('BookOrdered', {
+  await this.emit("BookOrdered", {
     title: book.title,
     buyer: req.user.id,
-    recipients: ['reader@bookshop.example'],
+    recipients: ["reader@bookshop.example"]
   })
 })
 ```
@@ -381,10 +375,10 @@ You can also connect to the notification service and call `notify()` directly. T
 **Simple notification** (no pre-defined type needed):
 
 ```js
-const alert = await cds.connect.to('notifications')
+const alert = await cds.connect.to("notifications")
 
 await alert.notify({
-  recipients: [ ...readers() ],
+  recipients: [...readers()],
   priority: "HIGH",
   title: "New book arrived!",
   description: "Book 'Wuthering Heights' has been added to the catalog."
@@ -397,11 +391,11 @@ await alert.notify({
 **Named notification type:**
 
 ```js
-await alert.notify('BookOrdered', {
-  recipients: [ buyer.id ],
+await alert.notify("BookOrdered", {
+  recipients: [buyer.id],
   data: {
     title: book.title,
-    buyer: buyer.name,
+    buyer: buyer.name
   }
 })
 ```
@@ -411,21 +405,21 @@ await alert.notify('BookOrdered', {
 It is possible to pass an array to `notify()` to send multiple notifications in a single call. This triggers only one outbox event, reducing the number of transactions when notifying many recipients. If some items fail, the successful ones are still delivered. Failures are logged as warnings, and the call only throws if **all** items fail.
 
 ```js
-alert.notify('BookOrdered', [
-  { recipients: [ buyer1.id ], data: { title: book.title, buyer: buyer1.name } },
-  { recipients: [ buyer2.id ], data: { title: book.title, buyer: buyer2.name } },
+alert.notify("BookOrdered", [
+  { recipients: [buyer1.id], data: { title: book.title, buyer: buyer1.name } },
+  { recipients: [buyer2.id], data: { title: book.title, buyer: buyer2.name } }
 ])
 ```
 
 > [!Warning]
 > Batch sending is only available via `notify([...])`. CDS event emission dispatches one event per call.
 
-Alternatively, the default notification template can be used: 
+Alternatively, the default notification template can be used:
 
 ```js
 await alert.notify([
-  { type: 'BookOrdered', recipients: [buyer1.id], data: { title: book1.title, buyer: buyer1.name } },
-  { type: 'BookOrdered', recipients: [buyer2.id], data: { title: book2.title, buyer: buyer2.name } },
+  { type: "BookOrdered", recipients: [buyer1.id], data: { title: book1.title, buyer: buyer1.name } },
+  { type: "BookOrdered", recipients: [buyer2.id], data: { title: book2.title, buyer: buyer2.name } }
 ])
 ```
 
@@ -435,23 +429,23 @@ await alert.notify([
 
 For `notify({ recipients, title, ... })`, no pre-defined notification type is needed. The plugin uses a built-in `Default` template.
 
-| Parameter | Required | Description |
-|---|---|---|
-| `recipients` | yes | Array of recipient identifiers: email addresses or SAP BTP Global User IDs (UUIDs) |
-| `title` | yes | Notification title string |
-| `priority` | no | `LOW`, `NEUTRAL` (default), `MEDIUM`, or `HIGH` |
-| `description` | no | Subtitle text |
+| Parameter     | Required | Description                                                                        |
+| ------------- | -------- | ---------------------------------------------------------------------------------- |
+| `recipients`  | yes      | Array of recipient identifiers: email addresses or SAP BTP Global User IDs (UUIDs) |
+| `title`       | yes      | Notification title string                                                          |
+| `priority`    | no       | `LOW`, `NEUTRAL` (default), `MEDIUM`, or `HIGH`                                    |
+| `description` | no       | Subtitle text                                                                      |
 
 ### Named Notification Type
 
 For `notify('TypeKey', payload)` or `notify({ type: 'TypeKey', ... })`, a notification using a pre-defined notification type is sent.
 
-| Parameter | Required | Description |
-|---|---|---|
-| `recipients` | yes | Array of recipient identifiers: email addresses or SAP BTP Global User IDs (UUIDs) |
-| `type` | yes | Notification type key (e.g. `'BookOrdered'`) |
-| `data` | no | Key-value pairs used to fill mustache placeholders in the type template |
-| `priority` | no | `LOW`, `NEUTRAL` (default), `MEDIUM`, or `HIGH` |
+| Parameter    | Required | Description                                                                        |
+| ------------ | -------- | ---------------------------------------------------------------------------------- |
+| `recipients` | yes      | Array of recipient identifiers: email addresses or SAP BTP Global User IDs (UUIDs) |
+| `type`       | yes      | Notification type key (e.g. `'BookOrdered'`)                                       |
+| `data`       | no       | Key-value pairs used to fill mustache placeholders in the type template            |
+| `priority`   | no       | `LOW`, `NEUTRAL` (default), `MEDIUM`, or `HIGH`                                    |
 
 > **Note:** Recipients can be email addresses (e.g. `user@example.com`) or SAP BTP Global User IDs (UUID format, e.g. `a1b2c3d4-...`). In `auto` mode (default), the plugin detects the format per recipient and uses the correct key automatically. See [Authentication Identifier](#authentication-identifier) for details.
 
@@ -465,25 +459,24 @@ For `notify('TypeKey', payload)` or `notify({ type: 'TypeKey', ... })`, a notifi
 
 Complete mapping of CDS annotations to notification fields:
 
-| Annotation | ANS Field | Description |
-|---|---|---|
-| `@description` | `Description` | Notification type description |
-| `@notification.title` | `TemplateSensitive` | Main notification title (supports placeholders) |
-| `@notification.publicTitle` | `TemplatePublic` | Public fallback title |
-| `@notification.subtitle` | `Subtitle` | Subtitle text |
-| `@notification.groupedTitle` | `TemplateGrouped` | Group header for multiple notifications |
-| `@notification.email.subject` | `EmailSubject` | Email subject line |
-| `@notification.email.html` | `EmailHtml` | Inline HTML or path to `.html` file |
-| `@Common.SemanticObject` | `NavigationTargetObject` | Navigation target object |
-| `@Common.SemanticObjectAction` | `NavigationTargetAction` | Navigation action |
-| `@notification.priority` | `Priority` | `LOW`, `NEUTRAL`, `MEDIUM`, or `HIGH` |
+| Annotation                     | ANS Field                | Description                                     |
+| ------------------------------ | ------------------------ | ----------------------------------------------- |
+| `@description`                 | `Description`            | Notification type description                   |
+| `@notification.title`          | `TemplateSensitive`      | Main notification title (supports placeholders) |
+| `@notification.publicTitle`    | `TemplatePublic`         | Public fallback title                           |
+| `@notification.subtitle`       | `Subtitle`               | Subtitle text                                   |
+| `@notification.groupedTitle`   | `TemplateGrouped`        | Group header for multiple notifications         |
+| `@notification.email.subject`  | `EmailSubject`           | Email subject line                              |
+| `@notification.email.html`     | `EmailHtml`              | Inline HTML or path to `.html` file             |
+| `@Common.SemanticObject`       | `NavigationTargetObject` | Navigation target object                        |
+| `@Common.SemanticObjectAction` | `NavigationTargetAction` | Navigation action                               |
+| `@notification.priority`       | `Priority`               | `LOW`, `NEUTRAL`, `MEDIUM`, or `HIGH`           |
 
 ## Test-drive Locally
 
 During local development, notifications are mocked and printed to the console. No external service is required.
 
 <img width="700" alt="Notify to console" style="border-radius:0.5rem" src="_assets/notifyToConsole.png">
-
 
 ## Run in Production
 
@@ -500,7 +493,6 @@ Notification types are automatically registered and kept in sync with the notifi
 Once the application is deployed and integrated with SAP Build Work Zone, notifications appear under the Fiori notifications icon.
 
 <img width="1300" alt="Sample Application Demo" style="border-radius:0.5rem;" src="_assets/incidentsNotificationDemo.gif">
-
 
 ## Advanced Usage
 
@@ -623,10 +615,10 @@ For full control, pass the complete notification object directly as described in
 alert.notify({
   recipients: [...readers()],
   type: "BookOrdered",
-  priority: 'NEUTRAL',
+  priority: "NEUTRAL",
   data: {
     title: book.title,
-    buyer: buyer.name,
+    buyer: buyer.name
   },
   OriginId: "Example Origin Id",
   NotificationTypeVersion: "1",
@@ -635,9 +627,7 @@ alert.notify({
   ActorDisplayText: "ActorName",
   ActorImageURL: "https://some-url",
   NotificationTypeTimestamp: "2022-03-15T09:58:42.807Z",
-  TargetParameters: [
-    { "Key": "string", "Value": "string" }
-  ]
+  TargetParameters: [{ Key: "string", Value: "string" }]
 })
 ```
 
@@ -645,30 +635,24 @@ alert.notify({
 
 ```js
 alert.notify({
-  NotificationTypeKey: 'BookOrdered',
-  NotificationTypeVersion: '1',
-  Priority: 'NEUTRAL',
+  NotificationTypeKey: "BookOrdered",
+  NotificationTypeVersion: "1",
+  Priority: "NEUTRAL",
   Properties: [
-    { Key: 'title', IsSensitive: false, Language: 'en', Value: 'Wuthering Heights', Type: 'String' },
-    { Key: 'buyer', IsSensitive: false, Language: 'en', Value: 'reader@bookshop.com', Type: 'String' }
+    { Key: "title", IsSensitive: false, Language: "en", Value: "Wuthering Heights", Type: "String" },
+    { Key: "buyer", IsSensitive: false, Language: "en", Value: "reader@bookshop.com", Type: "String" }
   ],
-  Recipients: [
-    { RecipientId: "reader1@bookshop.com" },
-    { RecipientId: "reader2@bookshop.com" }
-  ]
+  Recipients: [{ RecipientId: "reader1@bookshop.com" }, { RecipientId: "reader2@bookshop.com" }]
 })
 ```
-
 
 ## Contributing
 
 This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/cap-js/notifications/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
 
-
 ## Code of Conduct
 
 We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. By participating in this project, you agree to abide by its [Code of Conduct](CODE_OF_CONDUCT.md) at all times.
-
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ After installing the plugin, you can send notifications in two ways:
 Send a simple notification using `notify()`:
 
 ```js
-const alert = await cds.connect.to('notifications')
+const alert = await cds.connect.to("notifications")
 
 await alert.notify({
-  recipients: ['user@example.com'],
-  title: 'Book Order Received',
+  recipients: ["user@example.com"],
+  title: "Book Order Received",
   description: 'Your order for "Wuthering Heights" is being processed.'
 })
 ```
@@ -77,13 +77,13 @@ extend service CatalogService with {
 Emit the event from your service handler:
 
 ```js
-this.on('submitOrder', async req => {
+this.on("submitOrder", async req => {
   // ... process order ...
 
-  await this.emit('BookOrdered', {
+  await this.emit("BookOrdered", {
     title: book.title,
     buyer: req.user.id,
-    recipients: ['user@example.com']
+    recipients: ["user@example.com"]
   })
 })
 ```
@@ -355,13 +355,13 @@ There are two patterns for sending notifications.
 If you defined your notification type as a CDS event with a `@notification` annotation, the plugin hooks into your service automatically. Simply emit the event from your service handler.
 
 ```js
-this.on('submitOrder', async req => {
-  const book = await SELECT.one.from('Books').where({ ID: req.data.book })
+this.on("submitOrder", async req => {
+  const book = await SELECT.one.from("Books").where({ ID: req.data.book })
 
-  await this.emit('BookOrdered', {
+  await this.emit("BookOrdered", {
     title: book.title,
     buyer: req.user.id,
-    recipients: ['reader@bookshop.example']
+    recipients: ["reader@bookshop.example"]
   })
 })
 ```
@@ -375,12 +375,12 @@ You can also connect to the notification service and call `notify()` directly. T
 **Simple notification** (no pre-defined type needed):
 
 ```js
-const alert = await cds.connect.to('notifications')
+const alert = await cds.connect.to("notifications")
 
 await alert.notify({
   recipients: [...readers()],
-  priority: 'HIGH',
-  title: 'New book arrived!',
+  priority: "HIGH",
+  title: "New book arrived!",
   description: "Book 'Wuthering Heights' has been added to the catalog."
 })
 ```
@@ -391,7 +391,7 @@ await alert.notify({
 **Named notification type:**
 
 ```js
-await alert.notify('BookOrdered', {
+await alert.notify("BookOrdered", {
   recipients: [buyer.id],
   data: {
     title: book.title,
@@ -405,7 +405,7 @@ await alert.notify('BookOrdered', {
 It is possible to pass an array to `notify()` to send multiple notifications in a single call. This triggers only one outbox event, reducing the number of transactions when notifying many recipients. If some items fail, the successful ones are still delivered. Failures are logged as warnings, and the call only throws if **all** items fail.
 
 ```js
-alert.notify('BookOrdered', [
+alert.notify("BookOrdered", [
   { recipients: [buyer1.id], data: { title: book.title, buyer: buyer1.name } },
   { recipients: [buyer2.id], data: { title: book.title, buyer: buyer2.name } }
 ])
@@ -418,8 +418,8 @@ Alternatively, the default notification template can be used:
 
 ```js
 await alert.notify([
-  { type: 'BookOrdered', recipients: [buyer1.id], data: { title: book1.title, buyer: buyer1.name } },
-  { type: 'BookOrdered', recipients: [buyer2.id], data: { title: book2.title, buyer: buyer2.name } }
+  { type: "BookOrdered", recipients: [buyer1.id], data: { title: book1.title, buyer: buyer1.name } },
+  { type: "BookOrdered", recipients: [buyer2.id], data: { title: book2.title, buyer: buyer2.name } }
 ])
 ```
 
@@ -614,20 +614,20 @@ For full control, pass the complete notification object directly as described in
 ```js
 alert.notify({
   recipients: [...readers()],
-  type: 'BookOrdered',
-  priority: 'NEUTRAL',
+  type: "BookOrdered",
+  priority: "NEUTRAL",
   data: {
     title: book.title,
     buyer: buyer.name
   },
-  OriginId: 'Example Origin Id',
-  NotificationTypeVersion: '1',
-  ProviderId: '/SAMPLEPROVIDER',
-  ActorId: 'BACKENDACTORID',
-  ActorDisplayText: 'ActorName',
-  ActorImageURL: 'https://some-url',
-  NotificationTypeTimestamp: '2022-03-15T09:58:42.807Z',
-  TargetParameters: [{ Key: 'string', Value: 'string' }]
+  OriginId: "Example Origin Id",
+  NotificationTypeVersion: "1",
+  ProviderId: "/SAMPLEPROVIDER",
+  ActorId: "BACKENDACTORID",
+  ActorDisplayText: "ActorName",
+  ActorImageURL: "https://some-url",
+  NotificationTypeTimestamp: "2022-03-15T09:58:42.807Z",
+  TargetParameters: [{ Key: "string", Value: "string" }]
 })
 ```
 
@@ -635,14 +635,14 @@ alert.notify({
 
 ```js
 alert.notify({
-  NotificationTypeKey: 'BookOrdered',
-  NotificationTypeVersion: '1',
-  Priority: 'NEUTRAL',
+  NotificationTypeKey: "BookOrdered",
+  NotificationTypeVersion: "1",
+  Priority: "NEUTRAL",
   Properties: [
-    { Key: 'title', IsSensitive: false, Language: 'en', Value: 'Wuthering Heights', Type: 'String' },
-    { Key: 'buyer', IsSensitive: false, Language: 'en', Value: 'reader@bookshop.com', Type: 'String' }
+    { Key: "title", IsSensitive: false, Language: "en", Value: "Wuthering Heights", Type: "String" },
+    { Key: "buyer", IsSensitive: false, Language: "en", Value: "reader@bookshop.com", Type: "String" }
   ],
-  Recipients: [{ RecipientId: 'reader1@bookshop.com' }, { RecipientId: 'reader2@bookshop.com' }]
+  Recipients: [{ RecipientId: "reader1@bookshop.com" }, { RecipientId: "reader2@bookshop.com" }]
 })
 ```
 

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,43 +1,43 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 if (!cds.env.requires?.notifications?.enabled) return
 
-const { buildNotificationFromEvent } = require('./lib/utils')
-cds.build?.register?.('notifications', require('./lib/build'))
+const { buildNotificationFromEvent } = require("./lib/utils")
+cds.build?.register?.("notifications", require("./lib/build"))
 
-cds.on('loaded', m => {
+cds.on("loaded", m => {
   for (const def of Object.values(m.definitions)) {
-    if (def.kind !== 'event') continue
-    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) continue
+    if (def.kind !== "event") continue
+    if (!Object.keys(def).some(k => k === "@notification" || k.startsWith("@notification."))) continue
     if (!def.elements) def.elements = {}
     if (!def.elements.recipients) {
-      def.elements.recipients = { items: { type: 'cds.String' } }
+      def.elements.recipients = { items: { type: "cds.String" } }
     }
   }
 })
 
-cds.on('serving', service => {
-  if (service.name === 'notifications' || service instanceof cds.DatabaseService) return
-  service.on('*', async (req, next) => {
+cds.on("serving", service => {
+  if (service.name === "notifications" || service instanceof cds.DatabaseService) return
+  service.on("*", async (req, next) => {
     let def = req.target ?? service.events?.[req.event]
-    if (!def || def.kind !== 'event') return next()
-    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) return next()
+    if (!def || def.kind !== "event") return next()
+    if (!Object.keys(def).some(k => k === "@notification" || k.startsWith("@notification."))) return next()
     if (!def.name) def = { ...def, name: req.event }
-    const notifications = await cds.connect.to('notifications')
+    const notifications = await cds.connect.to("notifications")
     const notification = await buildNotificationFromEvent(def, req.data)
     try {
       await notifications.notify(notification)
     } catch (err) {
-      const LOG = cds.log('notifications')
-      LOG._error && LOG.error('Failed to send notification for event', def.name, err)
+      const LOG = cds.log("notifications")
+      LOG._error && LOG.error("Failed to send notification for event", def.name, err)
     }
     return next()
   })
 })
 
-cds.once('served', async () => {
-  const { validateNotificationTypes, readFile } = require('./lib/utils')
-  const { createNotificationTypesMap } = require('./lib/notificationTypes')
-  const { notificationTypesFromModel } = require('./lib/compile')
+cds.once("served", async () => {
+  const { validateNotificationTypes, readFile } = require("./lib/utils")
+  const { createNotificationTypesMap } = require("./lib/notificationTypes")
+  const { notificationTypesFromModel } = require("./lib/compile")
   const typesPath = cds.env.requires?.notifications?.types
   const kind = cds.env.requires?.notifications?.kind
 
@@ -48,19 +48,19 @@ cds.once('served', async () => {
     const notificationTypesMap = createNotificationTypesMap(JSON.parse(JSON.stringify(notificationTypes)), true)
     cds.notifications = { local: { types: notificationTypesMap } }
 
-    if (kind === 'notify-to-rest') {
+    if (kind === "notify-to-rest") {
       const destination = cds.env.requires.notifications?.destination
-      if (destination && destination !== 'SAP_Notifications') {
-        const hasWorkzone = notificationTypes.some(t => t.DeliveryChannels?.some(ch => ch.Type === 'WEB'))
+      if (destination && destination !== "SAP_Notifications") {
+        const hasWorkzone = notificationTypes.some(t => t.DeliveryChannels?.some(ch => ch.Type === "WEB"))
         if (hasWorkzone)
           throw new Error(
             `Workzone channel requires the 'SAP_Notifications' destination but '${destination}' is configured.`
           )
       }
-      const { processNotificationTypes } = require('./lib/notificationTypes')
+      const { processNotificationTypes } = require("./lib/notificationTypes")
       await processNotificationTypes(notificationTypes)
     }
   }
 
-  require('@sap-cloud-sdk/util').setGlobalLogLevel('error')
+  require("@sap-cloud-sdk/util").setGlobalLogLevel("error")
 })

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,5 +1,5 @@
 const cds = require("@sap/cds")
-if (!cds.env.requires?.notifications?.enabled) return // eslint-disable-line no-undef
+if (!cds.env.requires?.notifications?.enabled) return
 
 const { buildNotificationFromEvent } = require("./lib/utils")
 cds.build?.register?.("notifications", require("./lib/build"))

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,34 +1,34 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 if (!cds.env.requires?.notifications?.enabled) return // eslint-disable-line no-undef
 
-const { buildNotificationFromEvent } = require('./lib/utils')
-cds.build?.register?.('notifications', require("./lib/build"))
+const { buildNotificationFromEvent } = require("./lib/utils")
+cds.build?.register?.("notifications", require("./lib/build"))
 
 cds.on("loaded", m => {
   for (const def of Object.values(m.definitions)) {
-    if (def.kind !== 'event') continue
-    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) continue
+    if (def.kind !== "event") continue
+    if (!Object.keys(def).some(k => k === "@notification" || k.startsWith("@notification."))) continue
     if (!def.elements) def.elements = {}
     if (!def.elements.recipients) {
-      def.elements.recipients = { items: { type: 'cds.String' } }
+      def.elements.recipients = { items: { type: "cds.String" } }
     }
   }
 })
 
-cds.on('serving', service => {
-  if (service.name === 'notifications' || service instanceof cds.DatabaseService) return
-  service.on('*', async (req, next) => {
+cds.on("serving", service => {
+  if (service.name === "notifications" || service instanceof cds.DatabaseService) return
+  service.on("*", async (req, next) => {
     let def = req.target ?? service.events?.[req.event]
-    if (!def || def.kind !== 'event') return next()
-    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) return next()
+    if (!def || def.kind !== "event") return next()
+    if (!Object.keys(def).some(k => k === "@notification" || k.startsWith("@notification."))) return next()
     if (!def.name) def = { ...def, name: req.event }
-    const notifications = await cds.connect.to('notifications')
+    const notifications = await cds.connect.to("notifications")
     const notification = await buildNotificationFromEvent(def, req.data)
     try {
       await notifications.notify(notification)
     } catch (err) {
-      const LOG = cds.log('notifications')
-      LOG._error && LOG.error('Failed to send notification for event', def.name, err)
+      const LOG = cds.log("notifications")
+      LOG._error && LOG.error("Failed to send notification for event", def.name, err)
     }
     return next()
   })
@@ -42,24 +42,22 @@ cds.once("served", async () => {
   const kind = cds.env.requires?.notifications?.kind
 
   const model = cds.context?.model ?? cds.model
-  const notificationTypes = [
-    ...notificationTypesFromModel(model),
-    ...( typesPath ? readFile(typesPath) : [] )
-  ]
+  const notificationTypes = [...notificationTypesFromModel(model), ...(typesPath ? readFile(typesPath) : [])]
 
   if (validateNotificationTypes(notificationTypes)) {
     const notificationTypesMap = createNotificationTypesMap(JSON.parse(JSON.stringify(notificationTypes)), true)
     cds.notifications = { local: { types: notificationTypesMap } }
 
-    if (kind === 'notify-to-rest') {
+    if (kind === "notify-to-rest") {
       const destination = cds.env.requires.notifications?.destination
-      if (destination && destination !== 'SAP_Notifications') {
-        const hasWorkzone = notificationTypes.some(t => t.DeliveryChannels?.some(ch => ch.Type === 'WEB'))
-        if (hasWorkzone) throw new Error(
-          `Workzone channel requires the 'SAP_Notifications' destination but '${destination}' is configured.`
-        )
+      if (destination && destination !== "SAP_Notifications") {
+        const hasWorkzone = notificationTypes.some(t => t.DeliveryChannels?.some(ch => ch.Type === "WEB"))
+        if (hasWorkzone)
+          throw new Error(
+            `Workzone channel requires the 'SAP_Notifications' destination but '${destination}' is configured.`
+          )
       }
-      const { processNotificationTypes } = require('./lib/notificationTypes')
+      const { processNotificationTypes } = require("./lib/notificationTypes")
       await processNotificationTypes(notificationTypes)
     }
   }

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,43 +1,43 @@
-const cds = require("@sap/cds")
+const cds = require('@sap/cds')
 if (!cds.env.requires?.notifications?.enabled) return
 
-const { buildNotificationFromEvent } = require("./lib/utils")
-cds.build?.register?.("notifications", require("./lib/build"))
+const { buildNotificationFromEvent } = require('./lib/utils')
+cds.build?.register?.('notifications', require('./lib/build'))
 
-cds.on("loaded", m => {
+cds.on('loaded', m => {
   for (const def of Object.values(m.definitions)) {
-    if (def.kind !== "event") continue
-    if (!Object.keys(def).some(k => k === "@notification" || k.startsWith("@notification."))) continue
+    if (def.kind !== 'event') continue
+    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) continue
     if (!def.elements) def.elements = {}
     if (!def.elements.recipients) {
-      def.elements.recipients = { items: { type: "cds.String" } }
+      def.elements.recipients = { items: { type: 'cds.String' } }
     }
   }
 })
 
-cds.on("serving", service => {
-  if (service.name === "notifications" || service instanceof cds.DatabaseService) return
-  service.on("*", async (req, next) => {
+cds.on('serving', service => {
+  if (service.name === 'notifications' || service instanceof cds.DatabaseService) return
+  service.on('*', async (req, next) => {
     let def = req.target ?? service.events?.[req.event]
-    if (!def || def.kind !== "event") return next()
-    if (!Object.keys(def).some(k => k === "@notification" || k.startsWith("@notification."))) return next()
+    if (!def || def.kind !== 'event') return next()
+    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) return next()
     if (!def.name) def = { ...def, name: req.event }
-    const notifications = await cds.connect.to("notifications")
+    const notifications = await cds.connect.to('notifications')
     const notification = await buildNotificationFromEvent(def, req.data)
     try {
       await notifications.notify(notification)
     } catch (err) {
-      const LOG = cds.log("notifications")
-      LOG._error && LOG.error("Failed to send notification for event", def.name, err)
+      const LOG = cds.log('notifications')
+      LOG._error && LOG.error('Failed to send notification for event', def.name, err)
     }
     return next()
   })
 })
 
-cds.once("served", async () => {
-  const { validateNotificationTypes, readFile } = require("./lib/utils")
-  const { createNotificationTypesMap } = require("./lib/notificationTypes")
-  const { notificationTypesFromModel } = require("./lib/compile")
+cds.once('served', async () => {
+  const { validateNotificationTypes, readFile } = require('./lib/utils')
+  const { createNotificationTypesMap } = require('./lib/notificationTypes')
+  const { notificationTypesFromModel } = require('./lib/compile')
   const typesPath = cds.env.requires?.notifications?.types
   const kind = cds.env.requires?.notifications?.kind
 
@@ -48,19 +48,19 @@ cds.once("served", async () => {
     const notificationTypesMap = createNotificationTypesMap(JSON.parse(JSON.stringify(notificationTypes)), true)
     cds.notifications = { local: { types: notificationTypesMap } }
 
-    if (kind === "notify-to-rest") {
+    if (kind === 'notify-to-rest') {
       const destination = cds.env.requires.notifications?.destination
-      if (destination && destination !== "SAP_Notifications") {
-        const hasWorkzone = notificationTypes.some(t => t.DeliveryChannels?.some(ch => ch.Type === "WEB"))
+      if (destination && destination !== 'SAP_Notifications') {
+        const hasWorkzone = notificationTypes.some(t => t.DeliveryChannels?.some(ch => ch.Type === 'WEB'))
         if (hasWorkzone)
           throw new Error(
             `Workzone channel requires the 'SAP_Notifications' destination but '${destination}' is configured.`
           )
       }
-      const { processNotificationTypes } = require("./lib/notificationTypes")
+      const { processNotificationTypes } = require('./lib/notificationTypes')
       await processNotificationTypes(notificationTypes)
     }
   }
 
-  require("@sap-cloud-sdk/util").setGlobalLogLevel("error")
+  require('@sap-cloud-sdk/util').setGlobalLogLevel('error')
 })

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,5 +1,5 @@
 const cds = require('@sap/cds')
-if (!cds.env.requires?.notifications?.enabled) return 
+if (!cds.env.requires?.notifications?.enabled) return // eslint-disable-line no-undef
 
 const { buildNotificationFromEvent } = require('./lib/utils')
 cds.build?.register?.('notifications', require("./lib/build"))

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,17 +1,17 @@
-import cds from '@sap/cds/eslint.config.mjs'
+import cds from "@sap/cds/eslint.config.mjs"
 export default [
   ...cds,
   {
-    files: ['**/*.js'],
+    files: ["**/*.js"],
     languageOptions: {
-      sourceType: 'commonjs'
+      sourceType: "commonjs"
     }
   },
   {
-    name: 'test-files-config',
-    files: ['tests/**/*'],
+    name: "test-files-config",
+    files: ["tests/**/*"],
     rules: {
-      'no-console': 'off'
+      "no-console": "off"
     }
   }
 ]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,17 +1,17 @@
-import cds from "@sap/cds/eslint.config.mjs"
+import cds from '@sap/cds/eslint.config.mjs'
 export default [
   ...cds,
   {
-    files: ["**/*.js"],
+    files: ['**/*.js'],
     languageOptions: {
-      sourceType: "commonjs"
+      sourceType: 'commonjs'
     }
   },
   {
-    name: "test-files-config",
-    files: ["tests/**/*"],
+    name: 'test-files-config',
+    files: ['tests/**/*'],
     rules: {
-      "no-console": "off"
+      'no-console': 'off'
     }
   }
 ]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,12 @@ import cds from "@sap/cds/eslint.config.mjs"
 export default [
   ...cds,
   {
+    files: ["**/*.js"],
+    languageOptions: {
+      sourceType: "commonjs"
+    }
+  },
+  {
     name: "test-files-config",
     files: ["tests/**/*"],
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,10 +2,10 @@ import cds from "@sap/cds/eslint.config.mjs"
 export default [
   ...cds,
   {
-    name: 'test-files-config',
+    name: "test-files-config",
     files: ["tests/**/*"],
     rules: {
-      'no-console': 'off',
+      "no-console": "off"
     }
-  },
+  }
 ]

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 
 const config = {
   testTimeout: 42222,
-  testMatch: ['**/*.test.js']
+  testMatch: ["**/*.test.js"]
 }
 
 module.exports = config

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 
 const config = {
   testTimeout: 42222,
-  testMatch: ["**/*.test.js"]
+  testMatch: ['**/*.test.js']
 }
 
 module.exports = config

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,4 +1,4 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 
 const { path } = cds.utils
 
@@ -13,15 +13,15 @@ module.exports = class NotificationsBuildPlugin extends cds.build.Plugin {
     const model = await this.model()
     if (!model) return
 
-    const { notificationTypesFromModel } = require('./compile')
-    const { readFile } = require('./utils')
+    const { notificationTypesFromModel } = require("./compile")
+    const { readFile } = require("./utils")
 
     const typesPath = cds.env.requires.notifications?.types
     const linkedCSN = cds.linked(model)
     const types = [...notificationTypesFromModel(linkedCSN), ...(typesPath ? readFile(typesPath) : [])]
 
     if (types.length) {
-      await this.write(JSON.stringify(types, null, 2)).to(path.join(this.task.dest, 'notification-types.json'))
+      await this.write(JSON.stringify(types, null, 2)).to(path.join(this.task.dest, "notification-types.json"))
     }
   }
 }

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,4 +1,4 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 
 const { path } = cds.utils
 
@@ -6,25 +6,22 @@ module.exports = class NotificationsBuildPlugin extends cds.build.Plugin {
   static taskDefaults = { src: cds.env.folders.srv }
 
   static hasTask() {
-    return (!!cds.env.requires?.notifications)
+    return !!cds.env.requires?.notifications
   }
 
   async build() {
     const model = await this.model()
     if (!model) return
 
-    const { notificationTypesFromModel } = require('./compile')
-    const { readFile } = require('./utils')
+    const { notificationTypesFromModel } = require("./compile")
+    const { readFile } = require("./utils")
 
     const typesPath = cds.env.requires.notifications?.types
     const linkedCSN = cds.linked(model)
-    const types = [
-      ...notificationTypesFromModel(linkedCSN),
-      ...(typesPath ? readFile(typesPath) : [])
-    ]
+    const types = [...notificationTypesFromModel(linkedCSN), ...(typesPath ? readFile(typesPath) : [])]
 
     if (types.length) {
-      await this.write(JSON.stringify(types, null, 2)).to(path.join(this.task.dest, 'notification-types.json'))
+      await this.write(JSON.stringify(types, null, 2)).to(path.join(this.task.dest, "notification-types.json"))
     }
   }
 }

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,4 +1,4 @@
-const cds = require("@sap/cds")
+const cds = require('@sap/cds')
 
 const { path } = cds.utils
 
@@ -13,15 +13,15 @@ module.exports = class NotificationsBuildPlugin extends cds.build.Plugin {
     const model = await this.model()
     if (!model) return
 
-    const { notificationTypesFromModel } = require("./compile")
-    const { readFile } = require("./utils")
+    const { notificationTypesFromModel } = require('./compile')
+    const { readFile } = require('./utils')
 
     const typesPath = cds.env.requires.notifications?.types
     const linkedCSN = cds.linked(model)
     const types = [...notificationTypesFromModel(linkedCSN), ...(typesPath ? readFile(typesPath) : [])]
 
     if (types.length) {
-      await this.write(JSON.stringify(types, null, 2)).to(path.join(this.task.dest, "notification-types.json"))
+      await this.write(JSON.stringify(types, null, 2)).to(path.join(this.task.dest, 'notification-types.json'))
     }
   }
 }

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,58 +1,58 @@
-const { existsSync, readFileSync } = require('fs')
-const { resolve, dirname } = require('path')
-const cds = require('@sap/cds')
-const LOG = cds.log('notifications')
+const { existsSync, readFileSync } = require("fs")
+const { resolve, dirname } = require("path")
+const cds = require("@sap/cds")
+const LOG = cds.log("notifications")
 
-const CHANNEL_MAP = { email: 'MAIL', workzone: 'WEB' }
+const CHANNEL_MAP = { email: "MAIL", workzone: "WEB" }
 
 function notificationTypesFromModel(model) {
   if (!model) return []
   const types = []
 
-  const defaultTexts = cds.env.i18n.default_language ?? 'en'
+  const defaultTexts = cds.env.i18n.default_language ?? "en"
 
   for (const def of model.definitions) {
-    if (def.kind !== 'event') continue
-    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) continue
+    if (def.kind !== "event") continue
+    if (!Object.keys(def).some(k => k === "@notification" || k.startsWith("@notification."))) continue
 
-    const eventName = def.name.split('.').pop()
+    const eventName = def.name.split(".").pop()
     const violations = Object.keys(def.elements ?? {}).filter(name => name.length > 128)
     if (violations.length) {
       throw new Error(
-        `Event '${eventName}' has elements exceeding the maximum key length of 128 characters: ${violations.map(n => `'${n}'`).join(', ')}`
+        `Event '${eventName}' has elements exceeding the maximum key length of 128 characters: ${violations.map(n => `'${n}'`).join(", ")}`
       )
     }
 
     const localeTexts = localesForKeys(def, defaultTexts)
 
     const templates = localeTexts.map(locale => {
-      const t = { Language: locale, TemplateLanguage: 'mustache' }
-      if (def['@description']) t.Description = resolveI18n(def['@description'], locale)
-      if (def['@notification.title']) t.TemplateSensitive = resolveI18n(def['@notification.title'], locale)
-      if (def['@notification.publicTitle']) t.TemplatePublic = resolveI18n(def['@notification.publicTitle'], locale)
-      if (def['@notification.subtitle']) t.Subtitle = resolveI18n(def['@notification.subtitle'], locale)
-      if (def['@notification.groupedTitle']) t.TemplateGrouped = resolveI18n(def['@notification.groupedTitle'], locale)
-      if (def['@notification.email.subject']) t.EmailSubject = resolveI18n(def['@notification.email.subject'], locale)
-      if (def['@notification.email.html'])
-        t.EmailHtml = resolveHtmlFile(def['@notification.email.html'], def.$location, locale)
+      const t = { Language: locale, TemplateLanguage: "mustache" }
+      if (def["@description"]) t.Description = resolveI18n(def["@description"], locale)
+      if (def["@notification.title"]) t.TemplateSensitive = resolveI18n(def["@notification.title"], locale)
+      if (def["@notification.publicTitle"]) t.TemplatePublic = resolveI18n(def["@notification.publicTitle"], locale)
+      if (def["@notification.subtitle"]) t.Subtitle = resolveI18n(def["@notification.subtitle"], locale)
+      if (def["@notification.groupedTitle"]) t.TemplateGrouped = resolveI18n(def["@notification.groupedTitle"], locale)
+      if (def["@notification.email.subject"]) t.EmailSubject = resolveI18n(def["@notification.email.subject"], locale)
+      if (def["@notification.email.html"])
+        t.EmailHtml = resolveHtmlFile(def["@notification.email.html"], def.$location, locale)
       return t
     })
 
     const type = {
       NotificationTypeKey: eventName,
-      NotificationTypeVersion: '1',
+      NotificationTypeVersion: "1",
       Templates: templates
     }
 
-    if (def['@Common.SemanticObject']) type.NavigationTargetObject = def['@Common.SemanticObject']
-    if (def['@Common.SemanticObjectAction']) type.NavigationTargetAction = def['@Common.SemanticObjectAction']
+    if (def["@Common.SemanticObject"]) type.NavigationTargetObject = def["@Common.SemanticObject"]
+    if (def["@Common.SemanticObjectAction"]) type.NavigationTargetAction = def["@Common.SemanticObjectAction"]
 
-    if (def['@notification.channels']?.length) {
-      type.DeliveryChannels = def['@notification.channels']
+    if (def["@notification.channels"]?.length) {
+      type.DeliveryChannels = def["@notification.channels"]
         .map(ch => {
-          const isObject = ch && typeof ch === 'object' && 'channel' in ch
+          const isObject = ch && typeof ch === "object" && "channel" in ch
           const name = isObject ? ch.channel : ch
-          if (typeof name !== 'string') return null
+          if (typeof name !== "string") return null
           const channelType = CHANNEL_MAP[name.toLowerCase()] ?? name.toUpperCase()
           return {
             Type: channelType,
@@ -65,7 +65,7 @@ function notificationTypesFromModel(model) {
     }
 
     if (!type.DeliveryChannels) {
-      const defaultChannels = cds.env.requires?.notifications?.channels ?? ['workzone']
+      const defaultChannels = cds.env.requires?.notifications?.channels ?? ["workzone"]
       type.DeliveryChannels = defaultChannels.map(ch => {
         const channelType = CHANNEL_MAP[ch.toLowerCase()] ?? ch.toUpperCase()
         return { Type: channelType, Enabled: true, DefaultPreference: true, EditablePreference: true }
@@ -89,7 +89,7 @@ function notificationTypesFromModel(model) {
 function localesForKeys(notifyEvent, defaultLang) {
   // Note: does not search for i18n keys within the email HTML file
   const i18nKeys = Object.values(notifyEvent)
-    .filter(v => typeof v === 'string')
+    .filter(v => typeof v === "string")
     .flatMap(v => [...v.matchAll(/\{i18n>([^}]+)\}/g)].map(m => m[1]))
     .filter(Boolean)
 
@@ -113,7 +113,7 @@ function localesForKeys(notifyEvent, defaultLang) {
  * @returns {string} The resolved translation, or the original value if not an i18n placeholder
  */
 function resolveI18n(value, locale) {
-  if (typeof value !== 'string') return value
+  if (typeof value !== "string") return value
   const match = value.match(/^\{i18n>([^}]+)\}$/)
   if (!match) return value
   return cds.i18n.labels.at(match[1], locale) ?? value
@@ -129,10 +129,10 @@ function resolveI18n(value, locale) {
  * @returns {string} The resolved HTML content, or the original value if the file was not found
  */
 function resolveHtmlFile(value, location, locale) {
-  if (typeof value !== 'string') return value
+  if (typeof value !== "string") return value
 
   let html = value
-  if (value.startsWith('./') || value.startsWith('../')) {
+  if (value.startsWith("./") || value.startsWith("../")) {
     if (!location?.file) {
       LOG._warn && LOG.warn(`Cannot resolve relative HTML path '${value}': no source location available`)
       return value
@@ -143,7 +143,7 @@ function resolveHtmlFile(value, location, locale) {
       LOG._warn && LOG.warn(`HTML file not found: ${htmlPath}`)
       return value
     }
-    html = readFileSync(htmlPath, 'utf8')
+    html = readFileSync(htmlPath, "utf8")
   }
 
   return html.replace(/\{i18n>([^}]+)\}/g, (match, key) => cds.i18n?.labels?.at(key, locale) ?? match)

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,58 +1,58 @@
-const { existsSync, readFileSync } = require("fs")
-const { resolve, dirname } = require("path")
-const cds = require("@sap/cds")
-const LOG = cds.log("notifications")
+const { existsSync, readFileSync } = require('fs')
+const { resolve, dirname } = require('path')
+const cds = require('@sap/cds')
+const LOG = cds.log('notifications')
 
-const CHANNEL_MAP = { email: "MAIL", workzone: "WEB" }
+const CHANNEL_MAP = { email: 'MAIL', workzone: 'WEB' }
 
 function notificationTypesFromModel(model) {
   if (!model) return []
   const types = []
 
-  const defaultTexts = cds.env.i18n.default_language ?? "en"
+  const defaultTexts = cds.env.i18n.default_language ?? 'en'
 
   for (const def of model.definitions) {
-    if (def.kind !== "event") continue
-    if (!Object.keys(def).some(k => k === "@notification" || k.startsWith("@notification."))) continue
+    if (def.kind !== 'event') continue
+    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) continue
 
-    const eventName = def.name.split(".").pop()
+    const eventName = def.name.split('.').pop()
     const violations = Object.keys(def.elements ?? {}).filter(name => name.length > 128)
     if (violations.length) {
       throw new Error(
-        `Event '${eventName}' has elements exceeding the maximum key length of 128 characters: ${violations.map(n => `'${n}'`).join(", ")}`
+        `Event '${eventName}' has elements exceeding the maximum key length of 128 characters: ${violations.map(n => `'${n}'`).join(', ')}`
       )
     }
 
     const localeTexts = localesForKeys(def, defaultTexts)
 
     const templates = localeTexts.map(locale => {
-      const t = { Language: locale, TemplateLanguage: "mustache" }
-      if (def["@description"]) t.Description = resolveI18n(def["@description"], locale)
-      if (def["@notification.title"]) t.TemplateSensitive = resolveI18n(def["@notification.title"], locale)
-      if (def["@notification.publicTitle"]) t.TemplatePublic = resolveI18n(def["@notification.publicTitle"], locale)
-      if (def["@notification.subtitle"]) t.Subtitle = resolveI18n(def["@notification.subtitle"], locale)
-      if (def["@notification.groupedTitle"]) t.TemplateGrouped = resolveI18n(def["@notification.groupedTitle"], locale)
-      if (def["@notification.email.subject"]) t.EmailSubject = resolveI18n(def["@notification.email.subject"], locale)
-      if (def["@notification.email.html"])
-        t.EmailHtml = resolveHtmlFile(def["@notification.email.html"], def.$location, locale)
+      const t = { Language: locale, TemplateLanguage: 'mustache' }
+      if (def['@description']) t.Description = resolveI18n(def['@description'], locale)
+      if (def['@notification.title']) t.TemplateSensitive = resolveI18n(def['@notification.title'], locale)
+      if (def['@notification.publicTitle']) t.TemplatePublic = resolveI18n(def['@notification.publicTitle'], locale)
+      if (def['@notification.subtitle']) t.Subtitle = resolveI18n(def['@notification.subtitle'], locale)
+      if (def['@notification.groupedTitle']) t.TemplateGrouped = resolveI18n(def['@notification.groupedTitle'], locale)
+      if (def['@notification.email.subject']) t.EmailSubject = resolveI18n(def['@notification.email.subject'], locale)
+      if (def['@notification.email.html'])
+        t.EmailHtml = resolveHtmlFile(def['@notification.email.html'], def.$location, locale)
       return t
     })
 
     const type = {
       NotificationTypeKey: eventName,
-      NotificationTypeVersion: "1",
+      NotificationTypeVersion: '1',
       Templates: templates
     }
 
-    if (def["@Common.SemanticObject"]) type.NavigationTargetObject = def["@Common.SemanticObject"]
-    if (def["@Common.SemanticObjectAction"]) type.NavigationTargetAction = def["@Common.SemanticObjectAction"]
+    if (def['@Common.SemanticObject']) type.NavigationTargetObject = def['@Common.SemanticObject']
+    if (def['@Common.SemanticObjectAction']) type.NavigationTargetAction = def['@Common.SemanticObjectAction']
 
-    if (def["@notification.channels"]?.length) {
-      type.DeliveryChannels = def["@notification.channels"]
+    if (def['@notification.channels']?.length) {
+      type.DeliveryChannels = def['@notification.channels']
         .map(ch => {
-          const isObject = ch && typeof ch === "object" && "channel" in ch
+          const isObject = ch && typeof ch === 'object' && 'channel' in ch
           const name = isObject ? ch.channel : ch
-          if (typeof name !== "string") return null
+          if (typeof name !== 'string') return null
           const channelType = CHANNEL_MAP[name.toLowerCase()] ?? name.toUpperCase()
           return {
             Type: channelType,
@@ -65,7 +65,7 @@ function notificationTypesFromModel(model) {
     }
 
     if (!type.DeliveryChannels) {
-      const defaultChannels = cds.env.requires?.notifications?.channels ?? ["workzone"]
+      const defaultChannels = cds.env.requires?.notifications?.channels ?? ['workzone']
       type.DeliveryChannels = defaultChannels.map(ch => {
         const channelType = CHANNEL_MAP[ch.toLowerCase()] ?? ch.toUpperCase()
         return { Type: channelType, Enabled: true, DefaultPreference: true, EditablePreference: true }
@@ -89,7 +89,7 @@ function notificationTypesFromModel(model) {
 function localesForKeys(notifyEvent, defaultLang) {
   // Note: does not search for i18n keys within the email HTML file
   const i18nKeys = Object.values(notifyEvent)
-    .filter(v => typeof v === "string")
+    .filter(v => typeof v === 'string')
     .flatMap(v => [...v.matchAll(/\{i18n>([^}]+)\}/g)].map(m => m[1]))
     .filter(Boolean)
 
@@ -113,7 +113,7 @@ function localesForKeys(notifyEvent, defaultLang) {
  * @returns {string} The resolved translation, or the original value if not an i18n placeholder
  */
 function resolveI18n(value, locale) {
-  if (typeof value !== "string") return value
+  if (typeof value !== 'string') return value
   const match = value.match(/^\{i18n>([^}]+)\}$/)
   if (!match) return value
   return cds.i18n.labels.at(match[1], locale) ?? value
@@ -129,10 +129,10 @@ function resolveI18n(value, locale) {
  * @returns {string} The resolved HTML content, or the original value if the file was not found
  */
 function resolveHtmlFile(value, location, locale) {
-  if (typeof value !== "string") return value
+  if (typeof value !== 'string') return value
 
   let html = value
-  if (value.startsWith("./") || value.startsWith("../")) {
+  if (value.startsWith('./') || value.startsWith('../')) {
     if (!location?.file) {
       LOG._warn && LOG.warn(`Cannot resolve relative HTML path '${value}': no source location available`)
       return value
@@ -143,7 +143,7 @@ function resolveHtmlFile(value, location, locale) {
       LOG._warn && LOG.warn(`HTML file not found: ${htmlPath}`)
       return value
     }
-    html = readFileSync(htmlPath, "utf8")
+    html = readFileSync(htmlPath, 'utf8')
   }
 
   return html.replace(/\{i18n>([^}]+)\}/g, (match, key) => cds.i18n?.labels?.at(key, locale) ?? match)

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,68 +1,71 @@
-const { existsSync, readFileSync } = require('fs')
-const { resolve, dirname } = require('path')
-const cds = require('@sap/cds')
-const LOG = cds.log('notifications')
+const { existsSync, readFileSync } = require("fs")
+const { resolve, dirname } = require("path")
+const cds = require("@sap/cds")
+const LOG = cds.log("notifications")
 
-const CHANNEL_MAP = { email: 'MAIL', workzone: 'WEB' }
+const CHANNEL_MAP = { email: "MAIL", workzone: "WEB" }
 
 function notificationTypesFromModel(model) {
   if (!model) return []
   const types = []
 
-  const defaultTexts = cds.env.i18n.default_language ?? 'en'
+  const defaultTexts = cds.env.i18n.default_language ?? "en"
 
   for (const def of model.definitions) {
-    if (def.kind !== 'event') continue
-    if (!Object.keys(def).some(k => k === '@notification' || k.startsWith('@notification.'))) continue
+    if (def.kind !== "event") continue
+    if (!Object.keys(def).some(k => k === "@notification" || k.startsWith("@notification."))) continue
 
-    const eventName = def.name.split('.').pop()
+    const eventName = def.name.split(".").pop()
     const violations = Object.keys(def.elements ?? {}).filter(name => name.length > 128)
     if (violations.length) {
       throw new Error(
-        `Event '${eventName}' has elements exceeding the maximum key length of 128 characters: ${violations.map(n => `'${n}'`).join(', ')}`
+        `Event '${eventName}' has elements exceeding the maximum key length of 128 characters: ${violations.map(n => `'${n}'`).join(", ")}`
       )
     }
-    
+
     const localeTexts = localesForKeys(def, defaultTexts)
 
     const templates = localeTexts.map(locale => {
-      const t = { Language: locale, TemplateLanguage: 'mustache' }
-      if (def['@description'])                   t.Description       = resolveI18n(def['@description'], locale)
-      if (def['@notification.title'])            t.TemplateSensitive = resolveI18n(def['@notification.title'], locale)
-      if (def['@notification.publicTitle'])      t.TemplatePublic    = resolveI18n(def['@notification.publicTitle'], locale)
-      if (def['@notification.subtitle'])         t.Subtitle          = resolveI18n(def['@notification.subtitle'], locale)
-      if (def['@notification.groupedTitle'])     t.TemplateGrouped   = resolveI18n(def['@notification.groupedTitle'], locale)
-      if (def['@notification.email.subject'])    t.EmailSubject      = resolveI18n(def['@notification.email.subject'], locale)
-      if (def['@notification.email.html'])       t.EmailHtml         = resolveHtmlFile(def['@notification.email.html'], def.$location, locale)
+      const t = { Language: locale, TemplateLanguage: "mustache" }
+      if (def["@description"]) t.Description = resolveI18n(def["@description"], locale)
+      if (def["@notification.title"]) t.TemplateSensitive = resolveI18n(def["@notification.title"], locale)
+      if (def["@notification.publicTitle"]) t.TemplatePublic = resolveI18n(def["@notification.publicTitle"], locale)
+      if (def["@notification.subtitle"]) t.Subtitle = resolveI18n(def["@notification.subtitle"], locale)
+      if (def["@notification.groupedTitle"]) t.TemplateGrouped = resolveI18n(def["@notification.groupedTitle"], locale)
+      if (def["@notification.email.subject"]) t.EmailSubject = resolveI18n(def["@notification.email.subject"], locale)
+      if (def["@notification.email.html"])
+        t.EmailHtml = resolveHtmlFile(def["@notification.email.html"], def.$location, locale)
       return t
     })
 
     const type = {
       NotificationTypeKey: eventName,
-      NotificationTypeVersion: '1',
-      Templates: templates,
+      NotificationTypeVersion: "1",
+      Templates: templates
     }
 
-    if (def['@Common.SemanticObject'])       type.NavigationTargetObject = def['@Common.SemanticObject']
-    if (def['@Common.SemanticObjectAction']) type.NavigationTargetAction = def['@Common.SemanticObjectAction']
+    if (def["@Common.SemanticObject"]) type.NavigationTargetObject = def["@Common.SemanticObject"]
+    if (def["@Common.SemanticObjectAction"]) type.NavigationTargetAction = def["@Common.SemanticObjectAction"]
 
-    if (def['@notification.channels']?.length) {
-      type.DeliveryChannels = def['@notification.channels'].map(ch => {
-        const isObject = ch && typeof ch === 'object' && 'channel' in ch
-        const name = isObject ? ch.channel : ch
-        if (typeof name !== 'string') return null
-        const channelType = CHANNEL_MAP[name.toLowerCase()] ?? name.toUpperCase()
-        return {
-          Type:               channelType,
-          Enabled:            true,
-          DefaultPreference:  true,
-          EditablePreference: true,
-        }
-      }).filter(Boolean)
+    if (def["@notification.channels"]?.length) {
+      type.DeliveryChannels = def["@notification.channels"]
+        .map(ch => {
+          const isObject = ch && typeof ch === "object" && "channel" in ch
+          const name = isObject ? ch.channel : ch
+          if (typeof name !== "string") return null
+          const channelType = CHANNEL_MAP[name.toLowerCase()] ?? name.toUpperCase()
+          return {
+            Type: channelType,
+            Enabled: true,
+            DefaultPreference: true,
+            EditablePreference: true
+          }
+        })
+        .filter(Boolean)
     }
 
     if (!type.DeliveryChannels) {
-      const defaultChannels = cds.env.requires?.notifications?.channels ?? ['workzone']
+      const defaultChannels = cds.env.requires?.notifications?.channels ?? ["workzone"]
       type.DeliveryChannels = defaultChannels.map(ch => {
         const channelType = CHANNEL_MAP[ch.toLowerCase()] ?? ch.toUpperCase()
         return { Type: channelType, Enabled: true, DefaultPreference: true, EditablePreference: true }
@@ -86,16 +89,19 @@ function notificationTypesFromModel(model) {
 function localesForKeys(notifyEvent, defaultLang) {
   // Note: does not search for i18n keys within the email HTML file
   const i18nKeys = Object.values(notifyEvent)
-    .filter(v => typeof v === 'string')
+    .filter(v => typeof v === "string")
     .flatMap(v => [...v.matchAll(/\{i18n>([^}]+)\}/g)].map(m => m[1]))
     .filter(Boolean)
 
   return [
     defaultLang,
-    ...new Set(i18nKeys.flatMap(key =>
-      Object.keys(cds.i18n.labels.all(key))
-        .filter(locale => locale !== defaultLang && cds.i18n.labels.all(key)[locale] !== cds.i18n.labels.at(key, defaultLang))
-    ))
+    ...new Set(
+      i18nKeys.flatMap(key =>
+        Object.keys(cds.i18n.labels.all(key)).filter(
+          locale => locale !== defaultLang && cds.i18n.labels.all(key)[locale] !== cds.i18n.labels.at(key, defaultLang)
+        )
+      )
+    )
   ]
 }
 
@@ -107,7 +113,7 @@ function localesForKeys(notifyEvent, defaultLang) {
  * @returns {string} The resolved translation, or the original value if not an i18n placeholder
  */
 function resolveI18n(value, locale) {
-  if (typeof value !== 'string') return value
+  if (typeof value !== "string") return value
   const match = value.match(/^\{i18n>([^}]+)\}$/)
   if (!match) return value
   return cds.i18n.labels.at(match[1], locale) ?? value
@@ -123,10 +129,10 @@ function resolveI18n(value, locale) {
  * @returns {string} The resolved HTML content, or the original value if the file was not found
  */
 function resolveHtmlFile(value, location, locale) {
-  if (typeof value !== 'string') return value
+  if (typeof value !== "string") return value
 
   let html = value
-  if (value.startsWith('./') || value.startsWith('../')) {
+  if (value.startsWith("./") || value.startsWith("../")) {
     if (!location?.file) {
       LOG._warn && LOG.warn(`Cannot resolve relative HTML path '${value}': no source location available`)
       return value
@@ -137,12 +143,10 @@ function resolveHtmlFile(value, location, locale) {
       LOG._warn && LOG.warn(`HTML file not found: ${htmlPath}`)
       return value
     }
-    html = readFileSync(htmlPath, 'utf8')
+    html = readFileSync(htmlPath, "utf8")
   }
 
-  return html.replace(/\{i18n>([^}]+)\}/g, (match, key) =>
-    cds.i18n?.labels?.at(key, locale) ?? match
-  )
+  return html.replace(/\{i18n>([^}]+)\}/g, (match, key) => cds.i18n?.labels?.at(key, locale) ?? match)
 }
 
 module.exports = { notificationTypesFromModel }

--- a/lib/notificationTypes.js
+++ b/lib/notificationTypes.js
@@ -3,7 +3,7 @@ const { buildHeadersForDestination } = require("@sap-cloud-sdk/connectivity")
 const { getNotificationDestination, getPrefix, getNotificationTypesKeyWithPrefix } = require("./utils")
 const NOTIFICATION_TYPES_API_ENDPOINT = "v2/NotificationType.svc"
 const cds = require("@sap/cds")
-const LOG = cds.log('notifications')
+const LOG = cds.log("notifications")
 
 const defaultTemplate = {
   NotificationTypeKey: "Default",
@@ -23,9 +23,9 @@ const defaultTemplate = {
 
 function fromOdataArrayFormat(objectInArray) {
   if (objectInArray === undefined || objectInArray === null || Array.isArray(objectInArray)) {
-    return (objectInArray === undefined || objectInArray === null) ? [] : objectInArray
+    return objectInArray === undefined || objectInArray === null ? [] : objectInArray
   } else {
-    return (objectInArray.results === undefined || objectInArray.results === null) ? [] : objectInArray.results
+    return objectInArray.results === undefined || objectInArray.results === null ? [] : objectInArray.results
   }
 }
 
@@ -33,11 +33,11 @@ function createNotificationTypesMap(notificationTypesJSON, isLocal = false) {
   const types = {}
 
   if (isLocal) {
-    types["Default"] = { "1": defaultTemplate }
+    types["Default"] = { 1: defaultTemplate }
   }
 
   // add user provided templates
-  notificationTypesJSON.forEach((notificationType) => {
+  notificationTypesJSON.forEach(notificationType => {
     // set default NotificationTypeVersion if required
     if (notificationType.NotificationTypeVersion === undefined) {
       notificationType.NotificationTypeVersion = "1"
@@ -73,9 +73,10 @@ async function createNotificationType(notificationType) {
     url: NOTIFICATION_TYPES_API_ENDPOINT
   })
 
-  LOG._warn && LOG.warn(
-    `Notification Type of key ${notificationType.NotificationTypeKey} and version ${notificationType.NotificationTypeVersion} was not found. Creating it...`
-  )
+  LOG._warn &&
+    LOG.warn(
+      `Notification Type of key ${notificationType.NotificationTypeKey} and version ${notificationType.NotificationTypeVersion} was not found. Creating it...`
+    )
 
   let response
   try {
@@ -87,7 +88,9 @@ async function createNotificationType(notificationType) {
     })
   } catch (err) {
     const message = err.response?.data?.error?.message?.value ?? err.message
-    throw new Error(`Failed to create notification type ${notificationType.NotificationTypeKey}: ${message}`)
+    throw new Error(`Failed to create notification type ${notificationType.NotificationTypeKey}: ${message}`, {
+      cause: err
+    })
   }
   return response.data?.d ?? response
 }
@@ -98,9 +101,10 @@ async function updateNotificationType(id, notificationType) {
     url: NOTIFICATION_TYPES_API_ENDPOINT
   })
 
-  LOG._info && LOG.info(
-    `Detected change in notification type of key ${notificationType.NotificationTypeKey} and version ${notificationType.NotificationTypeVersion}. Updating it...`
-  )
+  LOG._info &&
+    LOG.info(
+      `Detected change in notification type of key ${notificationType.NotificationTypeKey} and version ${notificationType.NotificationTypeVersion}. Updating it...`
+    )
 
   const response = await executeHttpRequest(notificationDestination, {
     url: `${NOTIFICATION_TYPES_API_ENDPOINT}/NotificationTypes(guid'${id}')`,
@@ -117,9 +121,10 @@ async function deleteNotificationType(notificationType) {
     url: NOTIFICATION_TYPES_API_ENDPOINT
   })
 
-  LOG._info && LOG.info(
-    `Notification Type of key ${notificationType.NotificationTypeKey} and version ${notificationType.NotificationTypeVersion} not present in the types file. Deleting it...`
-  )
+  LOG._info &&
+    LOG.info(
+      `Notification Type of key ${notificationType.NotificationTypeKey} and version ${notificationType.NotificationTypeVersion} not present in the types file. Deleting it...`
+    )
 
   const response = await executeHttpRequest(notificationDestination, {
     url: `${NOTIFICATION_TYPES_API_ENDPOINT}/NotificationTypes(guid'${notificationType.NotificationTypeId}')`,
@@ -132,7 +137,7 @@ async function deleteNotificationType(notificationType) {
 function _createChannelsMap(channels) {
   const channelMap = {}
 
-  channels.forEach((channel) => {
+  channels.forEach(channel => {
     channelMap[channel.Type] = channel
   })
 
@@ -241,9 +246,18 @@ function isNotificationTypeEqual(oldNotificationType, newNotificationType) {
 
   return (
     oldNotificationType.IsGroupable == newNotificationType.IsGroupable &&
-    areTemplatesEqual(fromOdataArrayFormat(oldNotificationType.Templates), fromOdataArrayFormat(newNotificationType.Templates)) &&
-    areActionsEqual(fromOdataArrayFormat(oldNotificationType.Actions), fromOdataArrayFormat(newNotificationType.Actions)) &&
-    areDeliveryChannelsEqual(fromOdataArrayFormat(oldNotificationType.DeliveryChannels), fromOdataArrayFormat(newNotificationType.DeliveryChannels))
+    areTemplatesEqual(
+      fromOdataArrayFormat(oldNotificationType.Templates),
+      fromOdataArrayFormat(newNotificationType.Templates)
+    ) &&
+    areActionsEqual(
+      fromOdataArrayFormat(oldNotificationType.Actions),
+      fromOdataArrayFormat(newNotificationType.Actions)
+    ) &&
+    areDeliveryChannelsEqual(
+      fromOdataArrayFormat(oldNotificationType.DeliveryChannels),
+      fromOdataArrayFormat(newNotificationType.DeliveryChannels)
+    )
   )
 }
 
@@ -276,15 +290,21 @@ async function processNotificationTypes(notificationTypesJSON) {
       continue
     }
 
-    const newType = structuredClone(notificationTypes[existingType.NotificationTypeKey][existingType.NotificationTypeVersion])
+    const newType = structuredClone(
+      notificationTypes[existingType.NotificationTypeKey][existingType.NotificationTypeVersion]
+    )
 
     // if the type is there then verify if everything is same or not
     if (!isNotificationTypeEqual(existingType, newType)) {
-      await updateNotificationType(existingType.NotificationTypeId, notificationTypes[existingType.NotificationTypeKey][existingType.NotificationTypeVersion])
-    } else {
-      LOG._info && LOG.info(
-        `Notification Type of key ${existingType.NotificationTypeKey} and version ${existingType.NotificationTypeVersion} unchanged.`
+      await updateNotificationType(
+        existingType.NotificationTypeId,
+        notificationTypes[existingType.NotificationTypeKey][existingType.NotificationTypeVersion]
       )
+    } else {
+      LOG._info &&
+        LOG.info(
+          `Notification Type of key ${existingType.NotificationTypeKey} and version ${existingType.NotificationTypeVersion} unchanged.`
+        )
     }
 
     delete notificationTypes[existingType.NotificationTypeKey][existingType.NotificationTypeVersion]

--- a/lib/notificationTypes.js
+++ b/lib/notificationTypes.js
@@ -1,22 +1,22 @@
-const { executeHttpRequest } = require("@sap-cloud-sdk/http-client")
-const { buildHeadersForDestination } = require("@sap-cloud-sdk/connectivity")
-const { getNotificationDestination, getPrefix, getNotificationTypesKeyWithPrefix } = require("./utils")
-const NOTIFICATION_TYPES_API_ENDPOINT = "v2/NotificationType.svc"
-const cds = require("@sap/cds")
-const LOG = cds.log("notifications")
+const { executeHttpRequest } = require('@sap-cloud-sdk/http-client')
+const { buildHeadersForDestination } = require('@sap-cloud-sdk/connectivity')
+const { getNotificationDestination, getPrefix, getNotificationTypesKeyWithPrefix } = require('./utils')
+const NOTIFICATION_TYPES_API_ENDPOINT = 'v2/NotificationType.svc'
+const cds = require('@sap/cds')
+const LOG = cds.log('notifications')
 
 const defaultTemplate = {
-  NotificationTypeKey: "Default",
-  NotificationTypeVersion: "1",
+  NotificationTypeKey: 'Default',
+  NotificationTypeVersion: '1',
   Templates: [
     {
-      Language: "en",
-      Description: "Other Notifications",
-      TemplatePublic: "{{title}}",
-      TemplateSensitive: "{{title}}",
-      TemplateGrouped: "Other Notifications",
-      TemplateLanguage: "mustache",
-      Subtitle: "{{description}}"
+      Language: 'en',
+      Description: 'Other Notifications',
+      TemplatePublic: '{{title}}',
+      TemplateSensitive: '{{title}}',
+      TemplateGrouped: 'Other Notifications',
+      TemplateLanguage: 'mustache',
+      Subtitle: '{{description}}'
     }
   ]
 }
@@ -33,14 +33,14 @@ function createNotificationTypesMap(notificationTypesJSON, isLocal = false) {
   const types = {}
 
   if (isLocal) {
-    types["Default"] = { 1: defaultTemplate }
+    types['Default'] = { 1: defaultTemplate }
   }
 
   // add user provided templates
   notificationTypesJSON.forEach(notificationType => {
     // set default NotificationTypeVersion if required
     if (notificationType.NotificationTypeVersion === undefined) {
-      notificationType.NotificationTypeVersion = "1"
+      notificationType.NotificationTypeVersion = '1'
     }
 
     const notificationTypeKeyWithPrefix = getNotificationTypesKeyWithPrefix(notificationType.NotificationTypeKey)
@@ -62,7 +62,7 @@ async function getNotificationTypes() {
   const notificationDestination = await getNotificationDestination()
   const response = await executeHttpRequest(notificationDestination, {
     url: `${NOTIFICATION_TYPES_API_ENDPOINT}/NotificationTypes?$format=json&$expand=Templates,Actions,DeliveryChannels`,
-    method: "get"
+    method: 'get'
   })
   return response.data.d.results
 }
@@ -82,7 +82,7 @@ async function createNotificationType(notificationType) {
   try {
     response = await executeHttpRequest(notificationDestination, {
       url: `${NOTIFICATION_TYPES_API_ENDPOINT}/NotificationTypes`,
-      method: "post",
+      method: 'post',
       data: notificationType,
       headers: csrfHeaders
     })
@@ -108,7 +108,7 @@ async function updateNotificationType(id, notificationType) {
 
   const response = await executeHttpRequest(notificationDestination, {
     url: `${NOTIFICATION_TYPES_API_ENDPOINT}/NotificationTypes(guid'${id}')`,
-    method: "patch",
+    method: 'patch',
     data: notificationType,
     headers: csrfHeaders
   })
@@ -128,7 +128,7 @@ async function deleteNotificationType(notificationType) {
 
   const response = await executeHttpRequest(notificationDestination, {
     url: `${NOTIFICATION_TYPES_API_ENDPOINT}/NotificationTypes(guid'${notificationType.NotificationTypeId}')`,
-    method: "delete",
+    method: 'delete',
     headers: csrfHeaders
   })
   return response.status
@@ -271,7 +271,7 @@ async function processNotificationTypes(notificationTypesJSON) {
 
   // iterate through notification types
   for (const existingType of existingTypes) {
-    if (existingType.NotificationTypeKey == "Default") {
+    if (existingType.NotificationTypeKey == 'Default') {
       defaultTemplateExists = true
       continue
     }

--- a/lib/notificationTypes.js
+++ b/lib/notificationTypes.js
@@ -1,22 +1,22 @@
-const { executeHttpRequest } = require('@sap-cloud-sdk/http-client')
-const { buildHeadersForDestination } = require('@sap-cloud-sdk/connectivity')
-const { getNotificationDestination, getPrefix, getNotificationTypesKeyWithPrefix } = require('./utils')
-const NOTIFICATION_TYPES_API_ENDPOINT = 'v2/NotificationType.svc'
-const cds = require('@sap/cds')
-const LOG = cds.log('notifications')
+const { executeHttpRequest } = require("@sap-cloud-sdk/http-client")
+const { buildHeadersForDestination } = require("@sap-cloud-sdk/connectivity")
+const { getNotificationDestination, getPrefix, getNotificationTypesKeyWithPrefix } = require("./utils")
+const NOTIFICATION_TYPES_API_ENDPOINT = "v2/NotificationType.svc"
+const cds = require("@sap/cds")
+const LOG = cds.log("notifications")
 
 const defaultTemplate = {
-  NotificationTypeKey: 'Default',
-  NotificationTypeVersion: '1',
+  NotificationTypeKey: "Default",
+  NotificationTypeVersion: "1",
   Templates: [
     {
-      Language: 'en',
-      Description: 'Other Notifications',
-      TemplatePublic: '{{title}}',
-      TemplateSensitive: '{{title}}',
-      TemplateGrouped: 'Other Notifications',
-      TemplateLanguage: 'mustache',
-      Subtitle: '{{description}}'
+      Language: "en",
+      Description: "Other Notifications",
+      TemplatePublic: "{{title}}",
+      TemplateSensitive: "{{title}}",
+      TemplateGrouped: "Other Notifications",
+      TemplateLanguage: "mustache",
+      Subtitle: "{{description}}"
     }
   ]
 }
@@ -33,14 +33,14 @@ function createNotificationTypesMap(notificationTypesJSON, isLocal = false) {
   const types = {}
 
   if (isLocal) {
-    types['Default'] = { 1: defaultTemplate }
+    types["Default"] = { 1: defaultTemplate }
   }
 
   // add user provided templates
   notificationTypesJSON.forEach(notificationType => {
     // set default NotificationTypeVersion if required
     if (notificationType.NotificationTypeVersion === undefined) {
-      notificationType.NotificationTypeVersion = '1'
+      notificationType.NotificationTypeVersion = "1"
     }
 
     const notificationTypeKeyWithPrefix = getNotificationTypesKeyWithPrefix(notificationType.NotificationTypeKey)
@@ -62,7 +62,7 @@ async function getNotificationTypes() {
   const notificationDestination = await getNotificationDestination()
   const response = await executeHttpRequest(notificationDestination, {
     url: `${NOTIFICATION_TYPES_API_ENDPOINT}/NotificationTypes?$format=json&$expand=Templates,Actions,DeliveryChannels`,
-    method: 'get'
+    method: "get"
   })
   return response.data.d.results
 }
@@ -82,7 +82,7 @@ async function createNotificationType(notificationType) {
   try {
     response = await executeHttpRequest(notificationDestination, {
       url: `${NOTIFICATION_TYPES_API_ENDPOINT}/NotificationTypes`,
-      method: 'post',
+      method: "post",
       data: notificationType,
       headers: csrfHeaders
     })
@@ -108,7 +108,7 @@ async function updateNotificationType(id, notificationType) {
 
   const response = await executeHttpRequest(notificationDestination, {
     url: `${NOTIFICATION_TYPES_API_ENDPOINT}/NotificationTypes(guid'${id}')`,
-    method: 'patch',
+    method: "patch",
     data: notificationType,
     headers: csrfHeaders
   })
@@ -128,7 +128,7 @@ async function deleteNotificationType(notificationType) {
 
   const response = await executeHttpRequest(notificationDestination, {
     url: `${NOTIFICATION_TYPES_API_ENDPOINT}/NotificationTypes(guid'${notificationType.NotificationTypeId}')`,
-    method: 'delete',
+    method: "delete",
     headers: csrfHeaders
   })
   return response.status
@@ -271,7 +271,7 @@ async function processNotificationTypes(notificationTypesJSON) {
 
   // iterate through notification types
   for (const existingType of existingTypes) {
-    if (existingType.NotificationTypeKey == 'Default') {
+    if (existingType.NotificationTypeKey == "Default") {
       defaultTemplateExists = true
       continue
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
-const { existsSync, readFileSync } = require('fs')
-const { basename } = require('path')
+const { existsSync, readFileSync } = require("fs")
+const { basename } = require("path")
 const cds = require("@sap/cds")
-const LOG = cds.log('notifications')
+const LOG = cds.log("notifications")
 const { getDestination } = require("@sap-cloud-sdk/connectivity")
 const PRIORITIES = ["LOW", "NEUTRAL", "MEDIUM", "HIGH"]
 const MAX_PROPERTY_VALUE_LENGTH = 255
@@ -22,11 +22,11 @@ const messages = {
   PAYLOAD_IS_NOT_OBJECT: "Payload is not an object.",
   EMPTY_OBJECT_FOR_NOTIFY: "Empty object is passed a single parameter to notify function.",
   NO_OBJECT_FOR_NOTIFY: "An object must be passed to notify function.",
-  PROPERTY_VALUE_TOO_LONG: `Property value exceeds the maximum length of ${MAX_PROPERTY_VALUE_LENGTH} characters.`,
+  PROPERTY_VALUE_TOO_LONG: `Property value exceeds the maximum length of ${MAX_PROPERTY_VALUE_LENGTH} characters.`
 }
 
 function validateNotificationTypes(notificationTypes) {
-  for(let notificationType of notificationTypes){
+  for (let notificationType of notificationTypes) {
     if (!("NotificationTypeKey" in notificationType)) {
       LOG._warn && LOG.warn(messages.INVALID_NOTIFICATION_TYPES)
       return false
@@ -99,7 +99,6 @@ function validateCustomNotifyParameters(type, recipients, properties, navigation
   return true
 }
 
-
 function readFile(filePath) {
   const resolvedPath = cds.utils.path.resolve(cds.root, filePath)
   if (!existsSync(resolvedPath)) return []
@@ -117,24 +116,28 @@ async function getNotificationDestination() {
 }
 
 function getRecipientKey(recipient) {
-  const authenticationIdentifier = cds.env.requires.notifications?.authenticationIdentifier ?? 'auto'
-  if (authenticationIdentifier === 'UserUUID') return 'GlobalUserId'
-  if (authenticationIdentifier === 'RecipientId') return 'RecipientId'
+  const authenticationIdentifier = cds.env.requires.notifications?.authenticationIdentifier ?? "auto"
+  if (authenticationIdentifier === "UserUUID") return "GlobalUserId"
+  if (authenticationIdentifier === "RecipientId") return "RecipientId"
   // 'auto' (and any unrecognized value): detect format per recipient
-  if (typeof recipient === 'string' && UUID_REGEX.test(recipient)) return 'GlobalUserId'
-  if (typeof recipient === 'string' && !EMAIL_REGEX.test(recipient)) {
-    LOG._warn && LOG.warn(`Recipient '${recipient}' is neither a UUID nor an email format. Falling back to RecipientId.`)
+  if (typeof recipient === "string" && UUID_REGEX.test(recipient)) return "GlobalUserId"
+  if (typeof recipient === "string" && !EMAIL_REGEX.test(recipient)) {
+    LOG._warn &&
+      LOG.warn(`Recipient '${recipient}' is neither a UUID nor an email format. Falling back to RecipientId.`)
   }
-  return 'RecipientId'
+  return "RecipientId"
 }
 
 let prefix
 function getPrefix() {
   if (!prefix) {
     prefix = cds.env.requires.notifications?.prefix
-    if (prefix === "$app-name") try {
-      prefix = require(cds.root + '/package.json').name
-    } catch { prefix = null }
+    if (prefix === "$app-name")
+      try {
+        prefix = require(cds.root + "/package.json").name
+      } catch {
+        prefix = null
+      }
     if (!prefix) prefix = basename(cds.root)
   }
   return prefix
@@ -145,28 +148,23 @@ function getNotificationTypesKeyWithPrefix(notificationTypeKey) {
   return `${prefix}/${notificationTypeKey}`
 }
 
-function buildDefaultNotification(
-  recipients,
-  priority = "NEUTRAL",
-  title,
-  description = ""
-) {
-  const locale = cds.context?.locale ?? 'en'
+function buildDefaultNotification(recipients, priority = "NEUTRAL", title, description = "") {
+  const locale = cds.context?.locale ?? "en"
   const properties = [
     {
       Key: "title",
       Language: locale,
       Value: title,
       Type: "String",
-      IsSensitive: true,
+      IsSensitive: true
     },
     {
       Key: "description",
       Language: locale,
       Value: description,
       Type: "String",
-      IsSensitive: true,
-    },
+      IsSensitive: true
+    }
   ]
 
   return {
@@ -174,20 +172,25 @@ function buildDefaultNotification(
     NotificationTypeVersion: "1",
     Priority: priority,
     Properties: properties,
-    Recipients: recipients.map((recipient) => ({ [getRecipientKey(recipient)]: recipient }))
+    Recipients: recipients.map(recipient => ({ [getRecipientKey(recipient)]: recipient }))
   }
 }
 
 function buildCustomNotification(_) {
   let notification = {
-
     // Properties with simple API variants
     NotificationTypeKey: getNotificationTypesKeyWithPrefix(_.NotificationTypeKey || _.type),
     Recipients: _.Recipients || _.recipients?.map(id => ({ [getRecipientKey(id)]: id })),
     Priority: _.Priority || _.priority || "NEUTRAL",
-    Properties: _.Properties || Object.entries(_.data).map(([k,v]) => ({
-      Key:k, Value:v, Language: cds.context?.locale ?? 'en', Type: typeof v, IsSensitive: true,
-    })),
+    Properties:
+      _.Properties ||
+      Object.entries(_.data).map(([k, v]) => ({
+        Key: k,
+        Value: v,
+        Language: cds.context?.locale ?? "en",
+        Type: typeof v,
+        IsSensitive: true
+      })),
 
     // Low-level API properties
     OriginId: _.OriginId,
@@ -200,72 +203,79 @@ function buildCustomNotification(_) {
     ActorDisplayText: _.ActorDisplayText,
     ActorImageURL: _.ActorImageURL,
     TargetParameters: _.TargetParameters,
-    NotificationTypeTimestamp: _.NotificationTypeTimestamp,
+    NotificationTypeTimestamp: _.NotificationTypeTimestamp
   }
   return notification
 }
 
 const CDS_TO_ANS_TYPE = {
-  'cds.Integer':   'Integer',
-  'cds.Integer64': 'Integer',
-  'cds.Int16':     'Integer',
-  'cds.Int32':     'Integer',
-  'cds.Int64':     'Integer',
-  'cds.UInt8':     'Integer',
-  'cds.Date':      'Date',
-  'cds.DateTime':  'Date',
-  'cds.Timestamp': 'Date',
-  'cds.Time':      'Date',
+  "cds.Integer"   : "Integer",
+  "cds.Integer64" : "Integer",
+  "cds.Int16"     : "Integer",
+  "cds.Int32"     : "Integer",
+  "cds.Int64"     : "Integer",
+  "cds.UInt8"     : "Integer",
+  "cds.Date"      : "Date",
+  "cds.DateTime"  : "Date",
+  "cds.Timestamp" : "Date",
+  "cds.Time"      : "Date"
 }
 
 function mapCdsTypeToANSType(cdsType) {
-  return CDS_TO_ANS_TYPE[cdsType] ?? 'String'
+  return CDS_TO_ANS_TYPE[cdsType] ?? "String"
 }
 
 function validatePriority(priority) {
   if (!PRIORITIES.includes(priority)) {
-    LOG._warn && LOG.warn(`Invalid priority '${priority}'. Allowed priorities are ${PRIORITIES.join(', ')}. Falling back to NEUTRAL.`)
+    LOG._warn &&
+      LOG.warn(
+        `Invalid priority '${priority}'. Allowed priorities are ${PRIORITIES.join(", ")}. Falling back to NEUTRAL.`
+      )
     return false
   }
   return true
 }
 
 function resolveEnumValue(val) {
-  if (val && typeof val === 'object') {
-    if ('#' in val) return val['#']
-    if ('=' in val) return val.val
+  if (val && typeof val === "object") {
+    if ("#" in val) return val["#"]
+    if ("=" in val) return val.val
   }
   return val
 }
 
 function replaceRefsInExpr(expr, data) {
   if (Array.isArray(expr)) return expr.map(item => replaceRefsInExpr(item, data))
-  if (!expr || typeof expr !== 'object') return expr
-  if ('#' in expr) return { val: expr['#'], param: false }
-  if ('ref' in expr && !expr.param) {
+  if (!expr || typeof expr !== "object") return expr
+  if ("#" in expr) return { val: expr["#"], param: false }
+  if ("ref" in expr && !expr.param) {
     if (expr.ref.length === 1) {
       const key = expr.ref[0]
       return { val: key in data ? data[key] : null, param: false }
     }
     return expr
   }
-  if ('xpr' in expr) return { xpr: replaceRefsInExpr(expr.xpr, data) }
-  if ('func' in expr) {
+  if ("xpr" in expr) return { xpr: replaceRefsInExpr(expr.xpr, data) }
+  if ("func" in expr) {
     const args = Array.isArray(expr.args)
       ? replaceRefsInExpr(expr.args, data)
       : expr.args && Object.fromEntries(Object.entries(expr.args).map(([k, v]) => [k, replaceRefsInExpr(v, data)]))
     return { ...expr, args }
   }
-  if ('list' in expr) return { list: replaceRefsInExpr(expr.list, data) }
+  if ("list" in expr) return { list: replaceRefsInExpr(expr.list, data) }
   return expr
 }
 
 async function evaluateDynamicPriority(xpr, data) {
   const resolvedXpr = replaceRefsInExpr(xpr, data)
-  const col = { ...resolvedXpr, as: 'result' }
-  const from = cds.db?.kind === 'hana' ? { ref: ['DUMMY'] } : undefined
+  const col = { ...resolvedXpr, as: "result" }
+  const from = cds.db?.kind === "hana" ? { ref: ["DUMMY"] } : undefined
   let row
-  try { row = await cds.db?.run({ SELECT: { one: true, columns: [col], from } }) } catch { return undefined }
+  try {
+    row = await cds.db?.run({ SELECT: { one: true, columns: [col], from } })
+  } catch {
+    return undefined
+  }
   const result = row?.result ?? row?.RESULT
   if (result == null) return undefined
   const priority = String(result).toUpperCase()
@@ -279,45 +289,47 @@ async function buildNotificationFromEvent(eventDef, data = {}) {
   const Recipients = recipients.map(id => ({ [getRecipientKey(id)]: id }))
 
   const keyElementNames = new Set(
-    Object.entries(eventDef.elements ?? {}).filter(([, elem]) => elem.key).map(([key]) => key)
+    Object.entries(eventDef.elements ?? {})
+      .filter(([, elem]) => elem.key)
+      .map(([key]) => key)
   )
   const Properties = Object.entries(eventData)
     .filter(([key]) => !keyElementNames.has(key))
     .map(([key, value]) => ({
       Key: key,
-      Language: cds.env.i18n?.default_language ?? 'en',
-      Value: String(value ?? ''),
+      Language: cds.env.i18n?.default_language ?? "en",
+      Value: String(value ?? ""),
       Type: mapCdsTypeToANSType(eventDef.elements?.[key]?.type),
-      IsSensitive: true,
+      IsSensitive: true
     }))
 
   const TargetParameters = [...keyElementNames].map(key => ({
     Key: key,
-    Value: String(data[key] ?? ''),
+    Value: String(data[key] ?? "")
   }))
 
-  const priorityAnnotation = eventDef['@notification.priority']
-  let Priority = 'NEUTRAL'
+  const priorityAnnotation = eventDef["@notification.priority"]
+  let Priority = "NEUTRAL"
   if (priorityAnnotation) {
     if (priorityAnnotation.xpr) {
-      Priority = await evaluateDynamicPriority({ xpr: priorityAnnotation.xpr }, data) ?? 'NEUTRAL'
+      Priority = (await evaluateDynamicPriority({ xpr: priorityAnnotation.xpr }, data)) ?? "NEUTRAL"
     } else {
       const raw = resolveEnumValue(priorityAnnotation)
       if (raw) {
         const priority = String(raw).toUpperCase()
-        Priority = validatePriority(priority) ? priority : 'NEUTRAL'
+        Priority = validatePriority(priority) ? priority : "NEUTRAL"
       }
     }
   }
 
   const notification = {
-    NotificationTypeKey: eventDef.name.split('.').pop(),
-    NotificationTypeVersion: '1',
-    NavigationTargetObject: eventDef['@Common.SemanticObject'],
-    NavigationTargetAction: eventDef['@Common.SemanticObjectAction'],
+    NotificationTypeKey: eventDef.name.split(".").pop(),
+    NotificationTypeVersion: "1",
+    NavigationTargetObject: eventDef["@Common.SemanticObject"],
+    NavigationTargetAction: eventDef["@Common.SemanticObjectAction"],
     Priority,
     Properties,
-    Recipients,
+    Recipients
   }
 
   if (TargetParameters.length) notification.TargetParameters = TargetParameters
@@ -330,16 +342,19 @@ function applyValueLengthConstraints(notification) {
 
   if (notification.Properties) {
     for (const prop of notification.Properties) {
-      if (String(prop.Value ?? '').length > MAX_PROPERTY_VALUE_LENGTH) {
+      if (String(prop.Value ?? "").length > MAX_PROPERTY_VALUE_LENGTH) {
         throw new Error(messages.PROPERTY_VALUE_TOO_LONG)
       }
     }
   }
 
   if (notification.TargetParameters) {
-    notification = { ...notification, TargetParameters: notification.TargetParameters.filter(
-      param => String(param.Value ?? '').length <= MAX_TARGET_PARAM_VALUE_LENGTH
-    ) }
+    notification = {
+      ...notification,
+      TargetParameters: notification.TargetParameters.filter(
+        param => String(param.Value ?? "").length <= MAX_TARGET_PARAM_VALUE_LENGTH
+      )
+    }
   }
 
   return notification
@@ -354,13 +369,15 @@ function buildNotification(notificationData) {
   }
 
   if (notificationData.type) {
-    if (!validateCustomNotifyParameters(
-      notificationData.type,
-      notificationData.recipients,
-      notificationData.properties,
-      notificationData.navigation,
-      notificationData.priority,
-      notificationData.payload)
+    if (
+      !validateCustomNotifyParameters(
+        notificationData.type,
+        notificationData.recipients,
+        notificationData.properties,
+        notificationData.navigation,
+        notificationData.priority,
+        notificationData.payload
+      )
     ) {
       return
     }
@@ -370,11 +387,13 @@ function buildNotification(notificationData) {
     notificationData.NotificationTypeKey = getNotificationTypesKeyWithPrefix(notificationData.NotificationTypeKey)
     notification = notificationData
   } else {
-    if (!validateDefaultNotifyParameters(
-      notificationData.recipients,
-      notificationData.priority,
-      notificationData.title,
-      notificationData.description)
+    if (
+      !validateDefaultNotifyParameters(
+        notificationData.recipients,
+        notificationData.priority,
+        notificationData.title,
+        notificationData.description
+      )
     ) {
       return
     }
@@ -403,5 +422,5 @@ module.exports = {
   replaceRefsInExpr,
   applyValueLengthConstraints,
   MAX_PROPERTY_VALUE_LENGTH,
-  MAX_TARGET_PARAM_VALUE_LENGTH,
+  MAX_TARGET_PARAM_VALUE_LENGTH
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -209,16 +209,16 @@ function buildCustomNotification(_) {
 }
 
 const CDS_TO_ANS_TYPE = {
-  "cds.Integer"   : "Integer",
-  "cds.Integer64" : "Integer",
-  "cds.Int16"     : "Integer",
-  "cds.Int32"     : "Integer",
-  "cds.Int64"     : "Integer",
-  "cds.UInt8"     : "Integer",
-  "cds.Date"      : "Date",
-  "cds.DateTime"  : "Date",
-  "cds.Timestamp" : "Date",
-  "cds.Time"      : "Date"
+  "cds.Integer": "Integer",
+  "cds.Integer64": "Integer",
+  "cds.Int16": "Integer",
+  "cds.Int32": "Integer",
+  "cds.Int64": "Integer",
+  "cds.UInt8": "Integer",
+  "cds.Date": "Date",
+  "cds.DateTime": "Date",
+  "cds.Timestamp": "Date",
+  "cds.Time": "Date"
 }
 
 function mapCdsTypeToANSType(cdsType) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,9 @@
-const { existsSync, readFileSync } = require("fs")
-const { basename } = require("path")
-const cds = require("@sap/cds")
-const LOG = cds.log("notifications")
-const { getDestination } = require("@sap-cloud-sdk/connectivity")
-const PRIORITIES = ["LOW", "NEUTRAL", "MEDIUM", "HIGH"]
+const { existsSync, readFileSync } = require('fs')
+const { basename } = require('path')
+const cds = require('@sap/cds')
+const LOG = cds.log('notifications')
+const { getDestination } = require('@sap-cloud-sdk/connectivity')
+const PRIORITIES = ['LOW', 'NEUTRAL', 'MEDIUM', 'HIGH']
 const MAX_PROPERTY_VALUE_LENGTH = 255
 const MAX_TARGET_PARAM_VALUE_LENGTH = 250
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -11,23 +11,23 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const messages = {
   INVALID_NOTIFICATION_TYPES: "Notification Types must contain the following key: 'NotificationTypeKey'.",
-  DESTINATION_NOT_FOUND: "Failed to get destination: ",
-  MANDATORY_PARAMETER_NOT_PASSED_FOR_DEFAULT_NOTIFICATION: "Recipients and title are mandatory parameters.",
-  MANDATORY_PARAMETER_NOT_PASSED_FOR_CUSTOM_NOTIFICATION: "Recipients are mandatory parameters.",
-  RECIPIENTS_IS_NOT_ARRAY: "Recipients is not an array or it is empty.",
-  TITLE_IS_NOT_STRING: "Title is not a string.",
-  DESCRIPTION_IS_NOT_STRING: "Description is not a string.",
-  PROPERTIES_IS_NOT_OBJECT: "Properties is not an object.",
-  NAVIGATION_IS_NOT_OBJECT: "Navigation is not an object.",
-  PAYLOAD_IS_NOT_OBJECT: "Payload is not an object.",
-  EMPTY_OBJECT_FOR_NOTIFY: "Empty object is passed a single parameter to notify function.",
-  NO_OBJECT_FOR_NOTIFY: "An object must be passed to notify function.",
+  DESTINATION_NOT_FOUND: 'Failed to get destination: ',
+  MANDATORY_PARAMETER_NOT_PASSED_FOR_DEFAULT_NOTIFICATION: 'Recipients and title are mandatory parameters.',
+  MANDATORY_PARAMETER_NOT_PASSED_FOR_CUSTOM_NOTIFICATION: 'Recipients are mandatory parameters.',
+  RECIPIENTS_IS_NOT_ARRAY: 'Recipients is not an array or it is empty.',
+  TITLE_IS_NOT_STRING: 'Title is not a string.',
+  DESCRIPTION_IS_NOT_STRING: 'Description is not a string.',
+  PROPERTIES_IS_NOT_OBJECT: 'Properties is not an object.',
+  NAVIGATION_IS_NOT_OBJECT: 'Navigation is not an object.',
+  PAYLOAD_IS_NOT_OBJECT: 'Payload is not an object.',
+  EMPTY_OBJECT_FOR_NOTIFY: 'Empty object is passed a single parameter to notify function.',
+  NO_OBJECT_FOR_NOTIFY: 'An object must be passed to notify function.',
   PROPERTY_VALUE_TOO_LONG: `Property value exceeds the maximum length of ${MAX_PROPERTY_VALUE_LENGTH} characters.`
 }
 
 function validateNotificationTypes(notificationTypes) {
   for (let notificationType of notificationTypes) {
-    if (!("NotificationTypeKey" in notificationType)) {
+    if (!('NotificationTypeKey' in notificationType)) {
       LOG._warn && LOG.warn(messages.INVALID_NOTIFICATION_TYPES)
       return false
     }
@@ -47,7 +47,7 @@ function validateDefaultNotifyParameters(recipients, priority, title, descriptio
     return false
   }
 
-  if (typeof title !== "string") {
+  if (typeof title !== 'string') {
     LOG._warn && LOG.warn(messages.TITLE_IS_NOT_STRING)
     return false
   }
@@ -57,7 +57,7 @@ function validateDefaultNotifyParameters(recipients, priority, title, descriptio
     return false
   }
 
-  if (description && typeof description !== "string") {
+  if (description && typeof description !== 'string') {
     LOG._warn && LOG.warn(messages.DESCRIPTION_IS_NOT_STRING)
     return false
   }
@@ -86,12 +86,12 @@ function validateCustomNotifyParameters(type, recipients, properties, navigation
     return false
   }
 
-  if (navigation && typeof navigation !== "object") {
+  if (navigation && typeof navigation !== 'object') {
     LOG._warn && LOG.warn(messages.NAVIGATION_IS_NOT_OBJECT)
     return false
   }
 
-  if (payload && typeof payload !== "object") {
+  if (payload && typeof payload !== 'object') {
     LOG._warn && LOG.warn(messages.PAYLOAD_IS_NOT_OBJECT)
     return false
   }
@@ -107,7 +107,7 @@ function readFile(filePath) {
 }
 
 async function getNotificationDestination() {
-  const destinationName = cds.env.requires.notifications?.destination ?? "SAP_Notifications"
+  const destinationName = cds.env.requires.notifications?.destination ?? 'SAP_Notifications'
   const notificationDestination = await getDestination({ destinationName, useCache: true })
   if (!notificationDestination) {
     throw new Error(messages.DESTINATION_NOT_FOUND + destinationName)
@@ -116,25 +116,25 @@ async function getNotificationDestination() {
 }
 
 function getRecipientKey(recipient) {
-  const authenticationIdentifier = cds.env.requires.notifications?.authenticationIdentifier ?? "auto"
-  if (authenticationIdentifier === "UserUUID") return "GlobalUserId"
-  if (authenticationIdentifier === "RecipientId") return "RecipientId"
+  const authenticationIdentifier = cds.env.requires.notifications?.authenticationIdentifier ?? 'auto'
+  if (authenticationIdentifier === 'UserUUID') return 'GlobalUserId'
+  if (authenticationIdentifier === 'RecipientId') return 'RecipientId'
   // 'auto' (and any unrecognized value): detect format per recipient
-  if (typeof recipient === "string" && UUID_REGEX.test(recipient)) return "GlobalUserId"
-  if (typeof recipient === "string" && !EMAIL_REGEX.test(recipient)) {
+  if (typeof recipient === 'string' && UUID_REGEX.test(recipient)) return 'GlobalUserId'
+  if (typeof recipient === 'string' && !EMAIL_REGEX.test(recipient)) {
     LOG._warn &&
       LOG.warn(`Recipient '${recipient}' is neither a UUID nor an email format. Falling back to RecipientId.`)
   }
-  return "RecipientId"
+  return 'RecipientId'
 }
 
 let prefix
 function getPrefix() {
   if (!prefix) {
     prefix = cds.env.requires.notifications?.prefix
-    if (prefix === "$app-name")
+    if (prefix === '$app-name')
       try {
-        prefix = require(cds.root + "/package.json").name
+        prefix = require(cds.root + '/package.json').name
       } catch {
         prefix = null
       }
@@ -148,28 +148,28 @@ function getNotificationTypesKeyWithPrefix(notificationTypeKey) {
   return `${prefix}/${notificationTypeKey}`
 }
 
-function buildDefaultNotification(recipients, priority = "NEUTRAL", title, description = "") {
-  const locale = cds.context?.locale ?? "en"
+function buildDefaultNotification(recipients, priority = 'NEUTRAL', title, description = '') {
+  const locale = cds.context?.locale ?? 'en'
   const properties = [
     {
-      Key: "title",
+      Key: 'title',
       Language: locale,
       Value: title,
-      Type: "String",
+      Type: 'String',
       IsSensitive: true
     },
     {
-      Key: "description",
+      Key: 'description',
       Language: locale,
       Value: description,
-      Type: "String",
+      Type: 'String',
       IsSensitive: true
     }
   ]
 
   return {
-    NotificationTypeKey: "Default",
-    NotificationTypeVersion: "1",
+    NotificationTypeKey: 'Default',
+    NotificationTypeVersion: '1',
     Priority: priority,
     Properties: properties,
     Recipients: recipients.map(recipient => ({ [getRecipientKey(recipient)]: recipient }))
@@ -181,13 +181,13 @@ function buildCustomNotification(_) {
     // Properties with simple API variants
     NotificationTypeKey: getNotificationTypesKeyWithPrefix(_.NotificationTypeKey || _.type),
     Recipients: _.Recipients || _.recipients?.map(id => ({ [getRecipientKey(id)]: id })),
-    Priority: _.Priority || _.priority || "NEUTRAL",
+    Priority: _.Priority || _.priority || 'NEUTRAL',
     Properties:
       _.Properties ||
       Object.entries(_.data).map(([k, v]) => ({
         Key: k,
         Value: v,
-        Language: cds.context?.locale ?? "en",
+        Language: cds.context?.locale ?? 'en',
         Type: typeof v,
         IsSensitive: true
       })),
@@ -195,7 +195,7 @@ function buildCustomNotification(_) {
     // Low-level API properties
     OriginId: _.OriginId,
     NotificationTypeId: _.NotificationTypeId,
-    NotificationTypeVersion: _.NotificationTypeVersion || "1",
+    NotificationTypeVersion: _.NotificationTypeVersion || '1',
     NavigationTargetAction: _.NavigationTargetAction,
     NavigationTargetObject: _.NavigationTargetObject,
     ProviderId: _.ProviderId,
@@ -209,27 +209,27 @@ function buildCustomNotification(_) {
 }
 
 const CDS_TO_ANS_TYPE = {
-  "cds.Integer": "Integer",
-  "cds.Integer64": "Integer",
-  "cds.Int16": "Integer",
-  "cds.Int32": "Integer",
-  "cds.Int64": "Integer",
-  "cds.UInt8": "Integer",
-  "cds.Date": "Date",
-  "cds.DateTime": "Date",
-  "cds.Timestamp": "Date",
-  "cds.Time": "Date"
+  'cds.Integer': 'Integer',
+  'cds.Integer64': 'Integer',
+  'cds.Int16': 'Integer',
+  'cds.Int32': 'Integer',
+  'cds.Int64': 'Integer',
+  'cds.UInt8': 'Integer',
+  'cds.Date': 'Date',
+  'cds.DateTime': 'Date',
+  'cds.Timestamp': 'Date',
+  'cds.Time': 'Date'
 }
 
 function mapCdsTypeToANSType(cdsType) {
-  return CDS_TO_ANS_TYPE[cdsType] ?? "String"
+  return CDS_TO_ANS_TYPE[cdsType] ?? 'String'
 }
 
 function validatePriority(priority) {
   if (!PRIORITIES.includes(priority)) {
     LOG._warn &&
       LOG.warn(
-        `Invalid priority '${priority}'. Allowed priorities are ${PRIORITIES.join(", ")}. Falling back to NEUTRAL.`
+        `Invalid priority '${priority}'. Allowed priorities are ${PRIORITIES.join(', ')}. Falling back to NEUTRAL.`
       )
     return false
   }
@@ -237,39 +237,39 @@ function validatePriority(priority) {
 }
 
 function resolveEnumValue(val) {
-  if (val && typeof val === "object") {
-    if ("#" in val) return val["#"]
-    if ("=" in val) return val.val
+  if (val && typeof val === 'object') {
+    if ('#' in val) return val['#']
+    if ('=' in val) return val.val
   }
   return val
 }
 
 function replaceRefsInExpr(expr, data) {
   if (Array.isArray(expr)) return expr.map(item => replaceRefsInExpr(item, data))
-  if (!expr || typeof expr !== "object") return expr
-  if ("#" in expr) return { val: expr["#"], param: false }
-  if ("ref" in expr && !expr.param) {
+  if (!expr || typeof expr !== 'object') return expr
+  if ('#' in expr) return { val: expr['#'], param: false }
+  if ('ref' in expr && !expr.param) {
     if (expr.ref.length === 1) {
       const key = expr.ref[0]
       return { val: key in data ? data[key] : null, param: false }
     }
     return expr
   }
-  if ("xpr" in expr) return { xpr: replaceRefsInExpr(expr.xpr, data) }
-  if ("func" in expr) {
+  if ('xpr' in expr) return { xpr: replaceRefsInExpr(expr.xpr, data) }
+  if ('func' in expr) {
     const args = Array.isArray(expr.args)
       ? replaceRefsInExpr(expr.args, data)
       : expr.args && Object.fromEntries(Object.entries(expr.args).map(([k, v]) => [k, replaceRefsInExpr(v, data)]))
     return { ...expr, args }
   }
-  if ("list" in expr) return { list: replaceRefsInExpr(expr.list, data) }
+  if ('list' in expr) return { list: replaceRefsInExpr(expr.list, data) }
   return expr
 }
 
 async function evaluateDynamicPriority(xpr, data) {
   const resolvedXpr = replaceRefsInExpr(xpr, data)
-  const col = { ...resolvedXpr, as: "result" }
-  const from = cds.db?.kind === "hana" ? { ref: ["DUMMY"] } : undefined
+  const col = { ...resolvedXpr, as: 'result' }
+  const from = cds.db?.kind === 'hana' ? { ref: ['DUMMY'] } : undefined
   let row
   try {
     row = await cds.db?.run({ SELECT: { one: true, columns: [col], from } })
@@ -297,36 +297,36 @@ async function buildNotificationFromEvent(eventDef, data = {}) {
     .filter(([key]) => !keyElementNames.has(key))
     .map(([key, value]) => ({
       Key: key,
-      Language: cds.env.i18n?.default_language ?? "en",
-      Value: String(value ?? ""),
+      Language: cds.env.i18n?.default_language ?? 'en',
+      Value: String(value ?? ''),
       Type: mapCdsTypeToANSType(eventDef.elements?.[key]?.type),
       IsSensitive: true
     }))
 
   const TargetParameters = [...keyElementNames].map(key => ({
     Key: key,
-    Value: String(data[key] ?? "")
+    Value: String(data[key] ?? '')
   }))
 
-  const priorityAnnotation = eventDef["@notification.priority"]
-  let Priority = "NEUTRAL"
+  const priorityAnnotation = eventDef['@notification.priority']
+  let Priority = 'NEUTRAL'
   if (priorityAnnotation) {
     if (priorityAnnotation.xpr) {
-      Priority = (await evaluateDynamicPriority({ xpr: priorityAnnotation.xpr }, data)) ?? "NEUTRAL"
+      Priority = (await evaluateDynamicPriority({ xpr: priorityAnnotation.xpr }, data)) ?? 'NEUTRAL'
     } else {
       const raw = resolveEnumValue(priorityAnnotation)
       if (raw) {
         const priority = String(raw).toUpperCase()
-        Priority = validatePriority(priority) ? priority : "NEUTRAL"
+        Priority = validatePriority(priority) ? priority : 'NEUTRAL'
       }
     }
   }
 
   const notification = {
-    NotificationTypeKey: eventDef.name.split(".").pop(),
-    NotificationTypeVersion: "1",
-    NavigationTargetObject: eventDef["@Common.SemanticObject"],
-    NavigationTargetAction: eventDef["@Common.SemanticObjectAction"],
+    NotificationTypeKey: eventDef.name.split('.').pop(),
+    NotificationTypeVersion: '1',
+    NavigationTargetObject: eventDef['@Common.SemanticObject'],
+    NavigationTargetAction: eventDef['@Common.SemanticObjectAction'],
     Priority,
     Properties,
     Recipients
@@ -342,7 +342,7 @@ function applyValueLengthConstraints(notification) {
 
   if (notification.Properties) {
     for (const prop of notification.Properties) {
-      if (String(prop.Value ?? "").length > MAX_PROPERTY_VALUE_LENGTH) {
+      if (String(prop.Value ?? '').length > MAX_PROPERTY_VALUE_LENGTH) {
         throw new Error(messages.PROPERTY_VALUE_TOO_LONG)
       }
     }
@@ -352,7 +352,7 @@ function applyValueLengthConstraints(notification) {
     notification = {
       ...notification,
       TargetParameters: notification.TargetParameters.filter(
-        param => String(param.Value ?? "").length <= MAX_TARGET_PARAM_VALUE_LENGTH
+        param => String(param.Value ?? '').length <= MAX_TARGET_PARAM_VALUE_LENGTH
       )
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,9 @@
-const { existsSync, readFileSync } = require('fs')
-const { basename } = require('path')
-const cds = require('@sap/cds')
-const LOG = cds.log('notifications')
-const { getDestination } = require('@sap-cloud-sdk/connectivity')
-const PRIORITIES = ['LOW', 'NEUTRAL', 'MEDIUM', 'HIGH']
+const { existsSync, readFileSync } = require("fs")
+const { basename } = require("path")
+const cds = require("@sap/cds")
+const LOG = cds.log("notifications")
+const { getDestination } = require("@sap-cloud-sdk/connectivity")
+const PRIORITIES = ["LOW", "NEUTRAL", "MEDIUM", "HIGH"]
 const MAX_PROPERTY_VALUE_LENGTH = 255
 const MAX_TARGET_PARAM_VALUE_LENGTH = 250
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -11,23 +11,23 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const messages = {
   INVALID_NOTIFICATION_TYPES: "Notification Types must contain the following key: 'NotificationTypeKey'.",
-  DESTINATION_NOT_FOUND: 'Failed to get destination: ',
-  MANDATORY_PARAMETER_NOT_PASSED_FOR_DEFAULT_NOTIFICATION: 'Recipients and title are mandatory parameters.',
-  MANDATORY_PARAMETER_NOT_PASSED_FOR_CUSTOM_NOTIFICATION: 'Recipients are mandatory parameters.',
-  RECIPIENTS_IS_NOT_ARRAY: 'Recipients is not an array or it is empty.',
-  TITLE_IS_NOT_STRING: 'Title is not a string.',
-  DESCRIPTION_IS_NOT_STRING: 'Description is not a string.',
-  PROPERTIES_IS_NOT_OBJECT: 'Properties is not an object.',
-  NAVIGATION_IS_NOT_OBJECT: 'Navigation is not an object.',
-  PAYLOAD_IS_NOT_OBJECT: 'Payload is not an object.',
-  EMPTY_OBJECT_FOR_NOTIFY: 'Empty object is passed a single parameter to notify function.',
-  NO_OBJECT_FOR_NOTIFY: 'An object must be passed to notify function.',
+  DESTINATION_NOT_FOUND: "Failed to get destination: ",
+  MANDATORY_PARAMETER_NOT_PASSED_FOR_DEFAULT_NOTIFICATION: "Recipients and title are mandatory parameters.",
+  MANDATORY_PARAMETER_NOT_PASSED_FOR_CUSTOM_NOTIFICATION: "Recipients are mandatory parameters.",
+  RECIPIENTS_IS_NOT_ARRAY: "Recipients is not an array or it is empty.",
+  TITLE_IS_NOT_STRING: "Title is not a string.",
+  DESCRIPTION_IS_NOT_STRING: "Description is not a string.",
+  PROPERTIES_IS_NOT_OBJECT: "Properties is not an object.",
+  NAVIGATION_IS_NOT_OBJECT: "Navigation is not an object.",
+  PAYLOAD_IS_NOT_OBJECT: "Payload is not an object.",
+  EMPTY_OBJECT_FOR_NOTIFY: "Empty object is passed a single parameter to notify function.",
+  NO_OBJECT_FOR_NOTIFY: "An object must be passed to notify function.",
   PROPERTY_VALUE_TOO_LONG: `Property value exceeds the maximum length of ${MAX_PROPERTY_VALUE_LENGTH} characters.`
 }
 
 function validateNotificationTypes(notificationTypes) {
   for (let notificationType of notificationTypes) {
-    if (!('NotificationTypeKey' in notificationType)) {
+    if (!("NotificationTypeKey" in notificationType)) {
       LOG._warn && LOG.warn(messages.INVALID_NOTIFICATION_TYPES)
       return false
     }
@@ -47,7 +47,7 @@ function validateDefaultNotifyParameters(recipients, priority, title, descriptio
     return false
   }
 
-  if (typeof title !== 'string') {
+  if (typeof title !== "string") {
     LOG._warn && LOG.warn(messages.TITLE_IS_NOT_STRING)
     return false
   }
@@ -57,7 +57,7 @@ function validateDefaultNotifyParameters(recipients, priority, title, descriptio
     return false
   }
 
-  if (description && typeof description !== 'string') {
+  if (description && typeof description !== "string") {
     LOG._warn && LOG.warn(messages.DESCRIPTION_IS_NOT_STRING)
     return false
   }
@@ -86,12 +86,12 @@ function validateCustomNotifyParameters(type, recipients, properties, navigation
     return false
   }
 
-  if (navigation && typeof navigation !== 'object') {
+  if (navigation && typeof navigation !== "object") {
     LOG._warn && LOG.warn(messages.NAVIGATION_IS_NOT_OBJECT)
     return false
   }
 
-  if (payload && typeof payload !== 'object') {
+  if (payload && typeof payload !== "object") {
     LOG._warn && LOG.warn(messages.PAYLOAD_IS_NOT_OBJECT)
     return false
   }
@@ -107,7 +107,7 @@ function readFile(filePath) {
 }
 
 async function getNotificationDestination() {
-  const destinationName = cds.env.requires.notifications?.destination ?? 'SAP_Notifications'
+  const destinationName = cds.env.requires.notifications?.destination ?? "SAP_Notifications"
   const notificationDestination = await getDestination({ destinationName, useCache: true })
   if (!notificationDestination) {
     throw new Error(messages.DESTINATION_NOT_FOUND + destinationName)
@@ -116,25 +116,25 @@ async function getNotificationDestination() {
 }
 
 function getRecipientKey(recipient) {
-  const authenticationIdentifier = cds.env.requires.notifications?.authenticationIdentifier ?? 'auto'
-  if (authenticationIdentifier === 'UserUUID') return 'GlobalUserId'
-  if (authenticationIdentifier === 'RecipientId') return 'RecipientId'
+  const authenticationIdentifier = cds.env.requires.notifications?.authenticationIdentifier ?? "auto"
+  if (authenticationIdentifier === "UserUUID") return "GlobalUserId"
+  if (authenticationIdentifier === "RecipientId") return "RecipientId"
   // 'auto' (and any unrecognized value): detect format per recipient
-  if (typeof recipient === 'string' && UUID_REGEX.test(recipient)) return 'GlobalUserId'
-  if (typeof recipient === 'string' && !EMAIL_REGEX.test(recipient)) {
+  if (typeof recipient === "string" && UUID_REGEX.test(recipient)) return "GlobalUserId"
+  if (typeof recipient === "string" && !EMAIL_REGEX.test(recipient)) {
     LOG._warn &&
       LOG.warn(`Recipient '${recipient}' is neither a UUID nor an email format. Falling back to RecipientId.`)
   }
-  return 'RecipientId'
+  return "RecipientId"
 }
 
 let prefix
 function getPrefix() {
   if (!prefix) {
     prefix = cds.env.requires.notifications?.prefix
-    if (prefix === '$app-name')
+    if (prefix === "$app-name")
       try {
-        prefix = require(cds.root + '/package.json').name
+        prefix = require(cds.root + "/package.json").name
       } catch {
         prefix = null
       }
@@ -148,28 +148,28 @@ function getNotificationTypesKeyWithPrefix(notificationTypeKey) {
   return `${prefix}/${notificationTypeKey}`
 }
 
-function buildDefaultNotification(recipients, priority = 'NEUTRAL', title, description = '') {
-  const locale = cds.context?.locale ?? 'en'
+function buildDefaultNotification(recipients, priority = "NEUTRAL", title, description = "") {
+  const locale = cds.context?.locale ?? "en"
   const properties = [
     {
-      Key: 'title',
+      Key: "title",
       Language: locale,
       Value: title,
-      Type: 'String',
+      Type: "String",
       IsSensitive: true
     },
     {
-      Key: 'description',
+      Key: "description",
       Language: locale,
       Value: description,
-      Type: 'String',
+      Type: "String",
       IsSensitive: true
     }
   ]
 
   return {
-    NotificationTypeKey: 'Default',
-    NotificationTypeVersion: '1',
+    NotificationTypeKey: "Default",
+    NotificationTypeVersion: "1",
     Priority: priority,
     Properties: properties,
     Recipients: recipients.map(recipient => ({ [getRecipientKey(recipient)]: recipient }))
@@ -181,13 +181,13 @@ function buildCustomNotification(_) {
     // Properties with simple API variants
     NotificationTypeKey: getNotificationTypesKeyWithPrefix(_.NotificationTypeKey || _.type),
     Recipients: _.Recipients || _.recipients?.map(id => ({ [getRecipientKey(id)]: id })),
-    Priority: _.Priority || _.priority || 'NEUTRAL',
+    Priority: _.Priority || _.priority || "NEUTRAL",
     Properties:
       _.Properties ||
       Object.entries(_.data).map(([k, v]) => ({
         Key: k,
         Value: v,
-        Language: cds.context?.locale ?? 'en',
+        Language: cds.context?.locale ?? "en",
         Type: typeof v,
         IsSensitive: true
       })),
@@ -195,7 +195,7 @@ function buildCustomNotification(_) {
     // Low-level API properties
     OriginId: _.OriginId,
     NotificationTypeId: _.NotificationTypeId,
-    NotificationTypeVersion: _.NotificationTypeVersion || '1',
+    NotificationTypeVersion: _.NotificationTypeVersion || "1",
     NavigationTargetAction: _.NavigationTargetAction,
     NavigationTargetObject: _.NavigationTargetObject,
     ProviderId: _.ProviderId,
@@ -209,27 +209,27 @@ function buildCustomNotification(_) {
 }
 
 const CDS_TO_ANS_TYPE = {
-  'cds.Integer': 'Integer',
-  'cds.Integer64': 'Integer',
-  'cds.Int16': 'Integer',
-  'cds.Int32': 'Integer',
-  'cds.Int64': 'Integer',
-  'cds.UInt8': 'Integer',
-  'cds.Date': 'Date',
-  'cds.DateTime': 'Date',
-  'cds.Timestamp': 'Date',
-  'cds.Time': 'Date'
+  "cds.Integer": "Integer",
+  "cds.Integer64": "Integer",
+  "cds.Int16": "Integer",
+  "cds.Int32": "Integer",
+  "cds.Int64": "Integer",
+  "cds.UInt8": "Integer",
+  "cds.Date": "Date",
+  "cds.DateTime": "Date",
+  "cds.Timestamp": "Date",
+  "cds.Time": "Date"
 }
 
 function mapCdsTypeToANSType(cdsType) {
-  return CDS_TO_ANS_TYPE[cdsType] ?? 'String'
+  return CDS_TO_ANS_TYPE[cdsType] ?? "String"
 }
 
 function validatePriority(priority) {
   if (!PRIORITIES.includes(priority)) {
     LOG._warn &&
       LOG.warn(
-        `Invalid priority '${priority}'. Allowed priorities are ${PRIORITIES.join(', ')}. Falling back to NEUTRAL.`
+        `Invalid priority '${priority}'. Allowed priorities are ${PRIORITIES.join(", ")}. Falling back to NEUTRAL.`
       )
     return false
   }
@@ -237,39 +237,39 @@ function validatePriority(priority) {
 }
 
 function resolveEnumValue(val) {
-  if (val && typeof val === 'object') {
-    if ('#' in val) return val['#']
-    if ('=' in val) return val.val
+  if (val && typeof val === "object") {
+    if ("#" in val) return val["#"]
+    if ("=" in val) return val.val
   }
   return val
 }
 
 function replaceRefsInExpr(expr, data) {
   if (Array.isArray(expr)) return expr.map(item => replaceRefsInExpr(item, data))
-  if (!expr || typeof expr !== 'object') return expr
-  if ('#' in expr) return { val: expr['#'], param: false }
-  if ('ref' in expr && !expr.param) {
+  if (!expr || typeof expr !== "object") return expr
+  if ("#" in expr) return { val: expr["#"], param: false }
+  if ("ref" in expr && !expr.param) {
     if (expr.ref.length === 1) {
       const key = expr.ref[0]
       return { val: key in data ? data[key] : null, param: false }
     }
     return expr
   }
-  if ('xpr' in expr) return { xpr: replaceRefsInExpr(expr.xpr, data) }
-  if ('func' in expr) {
+  if ("xpr" in expr) return { xpr: replaceRefsInExpr(expr.xpr, data) }
+  if ("func" in expr) {
     const args = Array.isArray(expr.args)
       ? replaceRefsInExpr(expr.args, data)
       : expr.args && Object.fromEntries(Object.entries(expr.args).map(([k, v]) => [k, replaceRefsInExpr(v, data)]))
     return { ...expr, args }
   }
-  if ('list' in expr) return { list: replaceRefsInExpr(expr.list, data) }
+  if ("list" in expr) return { list: replaceRefsInExpr(expr.list, data) }
   return expr
 }
 
 async function evaluateDynamicPriority(xpr, data) {
   const resolvedXpr = replaceRefsInExpr(xpr, data)
-  const col = { ...resolvedXpr, as: 'result' }
-  const from = cds.db?.kind === 'hana' ? { ref: ['DUMMY'] } : undefined
+  const col = { ...resolvedXpr, as: "result" }
+  const from = cds.db?.kind === "hana" ? { ref: ["DUMMY"] } : undefined
   let row
   try {
     row = await cds.db?.run({ SELECT: { one: true, columns: [col], from } })
@@ -297,36 +297,36 @@ async function buildNotificationFromEvent(eventDef, data = {}) {
     .filter(([key]) => !keyElementNames.has(key))
     .map(([key, value]) => ({
       Key: key,
-      Language: cds.env.i18n?.default_language ?? 'en',
-      Value: String(value ?? ''),
+      Language: cds.env.i18n?.default_language ?? "en",
+      Value: String(value ?? ""),
       Type: mapCdsTypeToANSType(eventDef.elements?.[key]?.type),
       IsSensitive: true
     }))
 
   const TargetParameters = [...keyElementNames].map(key => ({
     Key: key,
-    Value: String(data[key] ?? '')
+    Value: String(data[key] ?? "")
   }))
 
-  const priorityAnnotation = eventDef['@notification.priority']
-  let Priority = 'NEUTRAL'
+  const priorityAnnotation = eventDef["@notification.priority"]
+  let Priority = "NEUTRAL"
   if (priorityAnnotation) {
     if (priorityAnnotation.xpr) {
-      Priority = (await evaluateDynamicPriority({ xpr: priorityAnnotation.xpr }, data)) ?? 'NEUTRAL'
+      Priority = (await evaluateDynamicPriority({ xpr: priorityAnnotation.xpr }, data)) ?? "NEUTRAL"
     } else {
       const raw = resolveEnumValue(priorityAnnotation)
       if (raw) {
         const priority = String(raw).toUpperCase()
-        Priority = validatePriority(priority) ? priority : 'NEUTRAL'
+        Priority = validatePriority(priority) ? priority : "NEUTRAL"
       }
     }
   }
 
   const notification = {
-    NotificationTypeKey: eventDef.name.split('.').pop(),
-    NotificationTypeVersion: '1',
-    NavigationTargetObject: eventDef['@Common.SemanticObject'],
-    NavigationTargetAction: eventDef['@Common.SemanticObjectAction'],
+    NotificationTypeKey: eventDef.name.split(".").pop(),
+    NotificationTypeVersion: "1",
+    NavigationTargetObject: eventDef["@Common.SemanticObject"],
+    NavigationTargetAction: eventDef["@Common.SemanticObjectAction"],
     Priority,
     Properties,
     Recipients
@@ -342,7 +342,7 @@ function applyValueLengthConstraints(notification) {
 
   if (notification.Properties) {
     for (const prop of notification.Properties) {
-      if (String(prop.Value ?? '').length > MAX_PROPERTY_VALUE_LENGTH) {
+      if (String(prop.Value ?? "").length > MAX_PROPERTY_VALUE_LENGTH) {
         throw new Error(messages.PROPERTY_VALUE_TOO_LONG)
       }
     }
@@ -352,7 +352,7 @@ function applyValueLengthConstraints(notification) {
     notification = {
       ...notification,
       TargetParameters: notification.TargetParameters.filter(
-        param => String(param.Value ?? '').length <= MAX_TARGET_PARAM_VALUE_LENGTH
+        param => String(param.Value ?? "").length <= MAX_TARGET_PARAM_VALUE_LENGTH
       )
     }
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "scripts": {
     "lint": "npx eslint .",
+    "prettier": "npx -y prettier@3 --write .",
+    "prettier:check": "npx -y prettier@3 --check .",
     "test": "npx jest --silent",
     "test:hybrid": "cds bind --exec -- npx jest --silent",
     "test-with-coverage": "npx jest --silent --coverage"

--- a/srv/notifyToConsole.js
+++ b/srv/notifyToConsole.js
@@ -1,22 +1,21 @@
-const NotificationService = require('./service')
+const NotificationService = require("./service")
 const cds = require("@sap/cds")
-const LOG = cds.log('notifications')
+const LOG = cds.log("notifications")
 
 module.exports = class NotifyToConsole extends NotificationService {
   async init() {
-
     this.on("*", req => {
-      LOG._debug && LOG.debug('Handling notification event:', req.event)
+      LOG._debug && LOG.debug("Handling notification event:", req.event)
       const notification = req.data
       if (!notification) return
 
       const notifications = Array.isArray(notification) ? notification : [notification]
       for (const n of notifications) {
-        LOG.info (
-          '\n---------------------------------------------------------------\n' +
-          'Notification:', req.event,
-           n,
-          '\n---------------------------------------------------------------\n',
+        LOG.info(
+          "\n---------------------------------------------------------------\n" + "Notification:",
+          req.event,
+          n,
+          "\n---------------------------------------------------------------\n"
         )
 
         const { NotificationTypeKey, NotificationTypeVersion } = n
@@ -24,16 +23,15 @@ module.exports = class NotifyToConsole extends NotificationService {
         if (!types) return
 
         if (!(NotificationTypeKey in types)) {
-          LOG._warn && LOG.warn(
-            `Notification Type ${NotificationTypeKey} is not in the notification types file`
-          )
+          LOG._warn && LOG.warn(`Notification Type ${NotificationTypeKey} is not in the notification types file`)
           continue
         }
 
         if (!(NotificationTypeVersion in types[NotificationTypeKey])) {
-          LOG._warn && LOG.warn(
-            `Notification Type Version ${NotificationTypeVersion} for type ${NotificationTypeKey} is not in the notification types file`
-          )
+          LOG._warn &&
+            LOG.warn(
+              `Notification Type Version ${NotificationTypeVersion} for type ${NotificationTypeKey} is not in the notification types file`
+            )
         }
       }
     })

--- a/srv/notifyToConsole.js
+++ b/srv/notifyToConsole.js
@@ -1,21 +1,21 @@
-const NotificationService = require("./service")
-const cds = require("@sap/cds")
-const LOG = cds.log("notifications")
+const NotificationService = require('./service')
+const cds = require('@sap/cds')
+const LOG = cds.log('notifications')
 
 module.exports = class NotifyToConsole extends NotificationService {
   async init() {
-    this.on("*", req => {
-      LOG._debug && LOG.debug("Handling notification event:", req.event)
+    this.on('*', req => {
+      LOG._debug && LOG.debug('Handling notification event:', req.event)
       const notification = req.data
       if (!notification) return
 
       const notifications = Array.isArray(notification) ? notification : [notification]
       for (const n of notifications) {
         LOG.info(
-          "\n---------------------------------------------------------------\n" + "Notification:",
+          '\n---------------------------------------------------------------\n' + 'Notification:',
           req.event,
           n,
-          "\n---------------------------------------------------------------\n"
+          '\n---------------------------------------------------------------\n'
         )
 
         const { NotificationTypeKey, NotificationTypeVersion } = n

--- a/srv/notifyToConsole.js
+++ b/srv/notifyToConsole.js
@@ -1,21 +1,21 @@
-const NotificationService = require('./service')
-const cds = require('@sap/cds')
-const LOG = cds.log('notifications')
+const NotificationService = require("./service")
+const cds = require("@sap/cds")
+const LOG = cds.log("notifications")
 
 module.exports = class NotifyToConsole extends NotificationService {
   async init() {
-    this.on('*', req => {
-      LOG._debug && LOG.debug('Handling notification event:', req.event)
+    this.on("*", req => {
+      LOG._debug && LOG.debug("Handling notification event:", req.event)
       const notification = req.data
       if (!notification) return
 
       const notifications = Array.isArray(notification) ? notification : [notification]
       for (const n of notifications) {
         LOG.info(
-          '\n---------------------------------------------------------------\n' + 'Notification:',
+          "\n---------------------------------------------------------------\n" + "Notification:",
           req.event,
           n,
-          '\n---------------------------------------------------------------\n'
+          "\n---------------------------------------------------------------\n"
         )
 
         const { NotificationTypeKey, NotificationTypeVersion } = n

--- a/srv/notifyToRest.js
+++ b/srv/notifyToRest.js
@@ -1,15 +1,15 @@
-const NotificationService = require('./service')
+const NotificationService = require("./service")
 
-const { buildHeadersForDestination } = require('@sap-cloud-sdk/connectivity')
-const httpClient = require('@sap-cloud-sdk/http-client')
-const { getNotificationDestination } = require('../lib/utils')
-const cds = require('@sap/cds')
-const LOG = cds.log('notifications')
-const NOTIFICATIONS_API_ENDPOINT = 'v2/Notification.svc'
+const { buildHeadersForDestination } = require("@sap-cloud-sdk/connectivity")
+const httpClient = require("@sap-cloud-sdk/http-client")
+const { getNotificationDestination } = require("../lib/utils")
+const cds = require("@sap/cds")
+const LOG = cds.log("notifications")
+const NOTIFICATIONS_API_ENDPOINT = "v2/Notification.svc"
 
 module.exports = exports = class NotifyToRest extends NotificationService {
   async init() {
-    this.on('*', req => this.postNotification(req.data))
+    this.on("*", req => this.postNotification(req.data))
     return super.init()
   }
 
@@ -18,8 +18,8 @@ module.exports = exports = class NotifyToRest extends NotificationService {
 
     if (Array.isArray(notificationData)) {
       const results = await Promise.allSettled(notificationData.map(n => this._postOne(n, notificationDestination)))
-      const failures = results.filter(r => r.status === 'rejected')
-      for (const f of failures) LOG._warn && LOG.warn('Batch notification failed:', f.reason?.message ?? f.reason)
+      const failures = results.filter(r => r.status === "rejected")
+      for (const f of failures) LOG._warn && LOG.warn("Batch notification failed:", f.reason?.message ?? f.reason)
       if (results.length === 0) return results
       if (failures.length === results.length) throw failures[0].reason
       return results
@@ -38,12 +38,12 @@ module.exports = exports = class NotifyToRest extends NotificationService {
         )
       const response = await httpClient.executeHttpRequest(notificationDestination, {
         url: `${NOTIFICATIONS_API_ENDPOINT}/Notifications`,
-        method: 'post',
+        method: "post",
         data: notificationData,
-        headers: { ...csrfHeaders, Accept: 'application/json' }
+        headers: { ...csrfHeaders, Accept: "application/json" }
       })
       if (LOG._debug) {
-        LOG.debug('Notification sent', {
+        LOG.debug("Notification sent", {
           body: response?.data,
           headers: response?.headers
         })

--- a/srv/notifyToRest.js
+++ b/srv/notifyToRest.js
@@ -1,15 +1,15 @@
-const NotificationService = require("./service")
+const NotificationService = require('./service')
 
-const { buildHeadersForDestination } = require("@sap-cloud-sdk/connectivity")
-const httpClient = require("@sap-cloud-sdk/http-client")
-const { getNotificationDestination } = require("../lib/utils")
-const cds = require("@sap/cds")
-const LOG = cds.log("notifications")
-const NOTIFICATIONS_API_ENDPOINT = "v2/Notification.svc"
+const { buildHeadersForDestination } = require('@sap-cloud-sdk/connectivity')
+const httpClient = require('@sap-cloud-sdk/http-client')
+const { getNotificationDestination } = require('../lib/utils')
+const cds = require('@sap/cds')
+const LOG = cds.log('notifications')
+const NOTIFICATIONS_API_ENDPOINT = 'v2/Notification.svc'
 
 module.exports = exports = class NotifyToRest extends NotificationService {
   async init() {
-    this.on("*", req => this.postNotification(req.data))
+    this.on('*', req => this.postNotification(req.data))
     return super.init()
   }
 
@@ -18,8 +18,8 @@ module.exports = exports = class NotifyToRest extends NotificationService {
 
     if (Array.isArray(notificationData)) {
       const results = await Promise.allSettled(notificationData.map(n => this._postOne(n, notificationDestination)))
-      const failures = results.filter(r => r.status === "rejected")
-      for (const f of failures) LOG._warn && LOG.warn("Batch notification failed:", f.reason?.message ?? f.reason)
+      const failures = results.filter(r => r.status === 'rejected')
+      for (const f of failures) LOG._warn && LOG.warn('Batch notification failed:', f.reason?.message ?? f.reason)
       if (results.length === 0) return results
       if (failures.length === results.length) throw failures[0].reason
       return results
@@ -38,12 +38,12 @@ module.exports = exports = class NotifyToRest extends NotificationService {
         )
       const response = await httpClient.executeHttpRequest(notificationDestination, {
         url: `${NOTIFICATIONS_API_ENDPOINT}/Notifications`,
-        method: "post",
+        method: 'post',
         data: notificationData,
-        headers: { ...csrfHeaders, Accept: "application/json" }
+        headers: { ...csrfHeaders, Accept: 'application/json' }
       })
       if (LOG._debug) {
-        LOG.debug("Notification sent", {
+        LOG.debug('Notification sent', {
           body: response?.data,
           headers: response?.headers
         })

--- a/srv/notifyToRest.js
+++ b/srv/notifyToRest.js
@@ -4,9 +4,8 @@ const { buildHeadersForDestination } = require("@sap-cloud-sdk/connectivity")
 const httpClient = require("@sap-cloud-sdk/http-client")
 const { getNotificationDestination } = require("../lib/utils")
 const cds = require("@sap/cds")
-const LOG = cds.log('notifications')
+const LOG = cds.log("notifications")
 const NOTIFICATIONS_API_ENDPOINT = "v2/Notification.svc"
-
 
 module.exports = exports = class NotifyToRest extends NotificationService {
   async init() {
@@ -19,8 +18,8 @@ module.exports = exports = class NotifyToRest extends NotificationService {
 
     if (Array.isArray(notificationData)) {
       const results = await Promise.allSettled(notificationData.map(n => this._postOne(n, notificationDestination)))
-      const failures = results.filter(r => r.status === 'rejected')
-      for (const f of failures) LOG._warn && LOG.warn('Batch notification failed:', f.reason?.message ?? f.reason)
+      const failures = results.filter(r => r.status === "rejected")
+      for (const f of failures) LOG._warn && LOG.warn("Batch notification failed:", f.reason?.message ?? f.reason)
       if (results.length === 0) return results
       if (failures.length === results.length) throw failures[0].reason
       return results
@@ -30,22 +29,23 @@ module.exports = exports = class NotifyToRest extends NotificationService {
 
   async _postOne(notificationData, notificationDestination) {
     const csrfHeaders = await buildHeadersForDestination(notificationDestination, {
-      url: NOTIFICATIONS_API_ENDPOINT,
+      url: NOTIFICATIONS_API_ENDPOINT
     })
     try {
-      LOG._info && LOG.info(
-        `Sending notification of key: ${notificationData.NotificationTypeKey} and version: ${notificationData.NotificationTypeVersion}`
-      )
+      LOG._info &&
+        LOG.info(
+          `Sending notification of key: ${notificationData.NotificationTypeKey} and version: ${notificationData.NotificationTypeVersion}`
+        )
       const response = await httpClient.executeHttpRequest(notificationDestination, {
         url: `${NOTIFICATIONS_API_ENDPOINT}/Notifications`,
         method: "post",
         data: notificationData,
-        headers: { ...csrfHeaders, Accept: "application/json" },
+        headers: { ...csrfHeaders, Accept: "application/json" }
       })
       if (LOG._debug) {
         LOG.debug("Notification sent", {
           body: response?.data,
-          headers: response?.headers,
+          headers: response?.headers
         })
       }
       return response

--- a/srv/service.js
+++ b/srv/service.js
@@ -1,47 +1,47 @@
 const { buildNotification, applyValueLengthConstraints, messages } = require("./../lib/utils")
-const cds = require('@sap/cds')
-const LOG = cds.log('notifications')
+const cds = require("@sap/cds")
+const LOG = cds.log("notifications")
 
 class NotificationService extends cds.Service {
-
   /**
    * Emits a notification. Method notify can be used alternatively.
    * @param {string} [event] - The notification type.
    * @param {object|object[]} message - The message object or array of message objects for batch
    */
-  emit (event, message) {
+  emit(event, message) {
     if (!event) {
       LOG._warn && LOG.warn(messages.NO_OBJECT_FOR_NOTIFY)
       return
     }
     // Outbox calls us with a req object, e.g. { event, data, headers }
-    if (event.event) return super.emit (event)
+    if (event.event) return super.emit(event)
     // First argument is optional for convenience
-    if (!message) [ message, event ] = [ event ]
+    if (!message) [message, event] = [event]
     // Batch: array of messages emitted as a single event
     if (Array.isArray(message)) {
-      const type = event || 'Default'
-      const notifications = message.map(m => {
-        const n = event ? { ...m, type: event } : m
-        return buildNotification(n)
-      }).filter(Boolean)
+      const type = event || "Default"
+      const notifications = message
+        .map(m => {
+          const n = event ? { ...m, type: event } : m
+          return buildNotification(n)
+        })
+        .filter(Boolean)
       return super.emit(type, notifications)
     }
     // CAP events translate to notification types and vice versa
     if (event) message.type = event
-    else event = message.type || message.NotificationTypeKey || 'Default'
+    else event = message.type || message.NotificationTypeKey || "Default"
     // Prepare and emit the notification
     message = buildNotification(message)
     message = applyValueLengthConstraints(message)
-    return super.emit (event, message)
+    return super.emit(event, message)
   }
 
   /**
    * That's just a semantic alias for emit.
    */
-  notify (type, message) {
-    return this.emit (type,message)
+  notify(type, message) {
+    return this.emit(type, message)
   }
-
 }
 module.exports = NotificationService

--- a/srv/service.js
+++ b/srv/service.js
@@ -1,6 +1,6 @@
-const { buildNotification, applyValueLengthConstraints, messages } = require('./../lib/utils')
-const cds = require('@sap/cds')
-const LOG = cds.log('notifications')
+const { buildNotification, applyValueLengthConstraints, messages } = require("./../lib/utils")
+const cds = require("@sap/cds")
+const LOG = cds.log("notifications")
 
 class NotificationService extends cds.Service {
   /**
@@ -19,7 +19,7 @@ class NotificationService extends cds.Service {
     if (!message) [message, event] = [event]
     // Batch: array of messages emitted as a single event
     if (Array.isArray(message)) {
-      const type = event || 'Default'
+      const type = event || "Default"
       const notifications = message
         .map(m => {
           const n = event ? { ...m, type: event } : m
@@ -30,7 +30,7 @@ class NotificationService extends cds.Service {
     }
     // CAP events translate to notification types and vice versa
     if (event) message.type = event
-    else event = message.type || message.NotificationTypeKey || 'Default'
+    else event = message.type || message.NotificationTypeKey || "Default"
     // Prepare and emit the notification
     message = buildNotification(message)
     message = applyValueLengthConstraints(message)

--- a/srv/service.js
+++ b/srv/service.js
@@ -1,6 +1,6 @@
-const { buildNotification, applyValueLengthConstraints, messages } = require("./../lib/utils")
-const cds = require("@sap/cds")
-const LOG = cds.log("notifications")
+const { buildNotification, applyValueLengthConstraints, messages } = require('./../lib/utils')
+const cds = require('@sap/cds')
+const LOG = cds.log('notifications')
 
 class NotificationService extends cds.Service {
   /**
@@ -19,7 +19,7 @@ class NotificationService extends cds.Service {
     if (!message) [message, event] = [event]
     // Batch: array of messages emitted as a single event
     if (Array.isArray(message)) {
-      const type = event || "Default"
+      const type = event || 'Default'
       const notifications = message
         .map(m => {
           const n = event ? { ...m, type: event } : m
@@ -30,7 +30,7 @@ class NotificationService extends cds.Service {
     }
     // CAP events translate to notification types and vice versa
     if (event) message.type = event
-    else event = message.type || message.NotificationTypeKey || "Default"
+    else event = message.type || message.NotificationTypeKey || 'Default'
     // Prepare and emit the notification
     message = buildNotification(message)
     message = applyValueLengthConstraints(message)

--- a/tests/bookshop/README.md
+++ b/tests/bookshop/README.md
@@ -4,21 +4,19 @@ Welcome to your new project.
 
 It contains these folders and files, following our recommended project layout:
 
-File or Folder | Purpose
----------|----------
-`app/` | content for UI frontends goes here
-`db/` | your domain models and data go here
-`srv/` | your service models and code go here
-`package.json` | project metadata and configuration
-`readme.md` | this getting started guide
-
+| File or Folder | Purpose                              |
+| -------------- | ------------------------------------ |
+| `app/`         | content for UI frontends goes here   |
+| `db/`          | your domain models and data go here  |
+| `srv/`         | your service models and code go here |
+| `package.json` | project metadata and configuration   |
+| `readme.md`    | this getting started guide           |
 
 ## Next Steps
 
 - Open a new terminal and run `cds watch`
 - (in VS Code simply choose _**Terminal** > Run Task > cds watch_)
 - Start adding content, for example, a [db/schema.cds](db/schema.cds).
-
 
 ## Learn More
 

--- a/tests/bookshop/app/admin-books/webapp/Component.js
+++ b/tests/bookshop/app/admin-books/webapp/Component.js
@@ -1,7 +1,7 @@
-sap.ui.define(['sap/fe/core/AppComponent'], function (AppComponent) {
-  'use strict'
-  return AppComponent.extend('books.Component', {
-    metadata: { manifest: 'json' }
+sap.ui.define(["sap/fe/core/AppComponent"], function (AppComponent) {
+  "use strict"
+  return AppComponent.extend("books.Component", {
+    metadata: { manifest: "json" }
   })
 })
 

--- a/tests/bookshop/app/admin-books/webapp/Component.js
+++ b/tests/bookshop/app/admin-books/webapp/Component.js
@@ -1,7 +1,7 @@
-sap.ui.define(["sap/fe/core/AppComponent"], function (AppComponent) {
-  "use strict"
-  return AppComponent.extend("books.Component", {
-    metadata: { manifest: "json" }
+sap.ui.define(['sap/fe/core/AppComponent'], function (AppComponent) {
+  'use strict'
+  return AppComponent.extend('books.Component', {
+    metadata: { manifest: 'json' }
   })
 })
 

--- a/tests/bookshop/app/browse/webapp/Component.js
+++ b/tests/bookshop/app/browse/webapp/Component.js
@@ -1,7 +1,7 @@
-sap.ui.define(['sap/fe/core/AppComponent'], function (AppComponent) {
-  'use strict'
-  return AppComponent.extend('bookshop.Component', {
-    metadata: { manifest: 'json' }
+sap.ui.define(["sap/fe/core/AppComponent"], function (AppComponent) {
+  "use strict"
+  return AppComponent.extend("bookshop.Component", {
+    metadata: { manifest: "json" }
   })
 })
 /* eslint no-undef:0 */

--- a/tests/bookshop/app/browse/webapp/Component.js
+++ b/tests/bookshop/app/browse/webapp/Component.js
@@ -1,7 +1,7 @@
-sap.ui.define(["sap/fe/core/AppComponent"], function (AppComponent) {
-  "use strict"
-  return AppComponent.extend("bookshop.Component", {
-    metadata: { manifest: "json" }
+sap.ui.define(['sap/fe/core/AppComponent'], function (AppComponent) {
+  'use strict'
+  return AppComponent.extend('bookshop.Component', {
+    metadata: { manifest: 'json' }
   })
 })
 /* eslint no-undef:0 */

--- a/tests/bookshop/app/browse/webapp/Component.js
+++ b/tests/bookshop/app/browse/webapp/Component.js
@@ -1,7 +1,7 @@
-sap.ui.define(["sap/fe/core/AppComponent"], function(AppComponent) {
-	"use strict"
-	return AppComponent.extend("bookshop.Component", {
-		metadata: { manifest: "json" }
-	})
+sap.ui.define(["sap/fe/core/AppComponent"], function (AppComponent) {
+  "use strict"
+  return AppComponent.extend("bookshop.Component", {
+    metadata: { manifest: "json" }
+  })
 })
 /* eslint no-undef:0 */

--- a/tests/bookshop/app/index.html
+++ b/tests/bookshop/app/index.html
@@ -7,8 +7,8 @@
     <title>Bookshop</title>
 
     <script>
-      window['sap-ushell-config'] = {
-        defaultRenderer: 'fiori2',
+      window["sap-ushell-config"] = {
+        defaultRenderer: "fiori2",
         applications: {}
       }
     </script>
@@ -28,7 +28,7 @@
       data-sap-ui-frameOptions="allow"
     ></script>
     <script>
-      sap.ui.getCore().attachInit(() => sap.ushell.Container.createRenderer().placeAt('content'))
+      sap.ui.getCore().attachInit(() => sap.ushell.Container.createRenderer().placeAt("content"))
     </script>
   </head>
   <body class="sapUiBody" id="content"></body>

--- a/tests/bookshop/app/index.html
+++ b/tests/bookshop/app/index.html
@@ -7,8 +7,8 @@
     <title>Bookshop</title>
 
     <script>
-      window["sap-ushell-config"] = {
-        defaultRenderer: "fiori2",
+      window['sap-ushell-config'] = {
+        defaultRenderer: 'fiori2',
         applications: {}
       }
     </script>
@@ -28,7 +28,7 @@
       data-sap-ui-frameOptions="allow"
     ></script>
     <script>
-      sap.ui.getCore().attachInit(() => sap.ushell.Container.createRenderer().placeAt("content"))
+      sap.ui.getCore().attachInit(() => sap.ushell.Container.createRenderer().placeAt('content'))
     </script>
   </head>
   <body class="sapUiBody" id="content"></body>

--- a/tests/bookshop/app/index.html
+++ b/tests/bookshop/app/index.html
@@ -1,21 +1,25 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bookshop</title>
 
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<title>Bookshop</title>
+    <script>
+      window["sap-ushell-config"] = {
+        defaultRenderer: "fiori2",
+        applications: {}
+      }
+    </script>
 
-	<script>
-		window["sap-ushell-config"] = {
-			defaultRenderer: "fiori2",
-			applications: {}
-		};
-	</script>
-
-	<script id="sap-ushell-bootstrap" src="https://sapui5.hana.ondemand.com/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
-    <script id="sap-ui-bootstrap" src="https://sapui5.hana.ondemand.com/resources/sap-ui-core.js"
+    <script
+      id="sap-ushell-bootstrap"
+      src="https://sapui5.hana.ondemand.com/test-resources/sap/ushell/bootstrap/sandbox.js"
+    ></script>
+    <script
+      id="sap-ui-bootstrap"
+      src="https://sapui5.hana.ondemand.com/resources/sap-ui-core.js"
       data-sap-ui-libs="sap.m, sap.ushell, sap.collaboration, sap.ui.layout"
       data-sap-ui-compatVersion="edge"
       data-sap-ui-async="true"
@@ -23,10 +27,9 @@
       data-sap-ui-theme="sap_horizon"
       data-sap-ui-frameOptions="allow"
     ></script>
-	<script>
-		sap.ui.getCore().attachInit(() => sap.ushell.Container.createRenderer().placeAt("content"))
-	</script>
-
-</head>
-<body class="sapUiBody" id="content"></body>
+    <script>
+      sap.ui.getCore().attachInit(() => sap.ushell.Container.createRenderer().placeAt("content"))
+    </script>
+  </head>
+  <body class="sapUiBody" id="content"></body>
 </html>

--- a/tests/bookshop/eslint.config.mjs
+++ b/tests/bookshop/eslint.config.mjs
@@ -1,2 +1,2 @@
-import cds from '@sap/cds/eslint.config.mjs'
+import cds from "@sap/cds/eslint.config.mjs"
 export default [...cds.recommended]

--- a/tests/bookshop/eslint.config.mjs
+++ b/tests/bookshop/eslint.config.mjs
@@ -1,2 +1,2 @@
-import cds from '@sap/cds/eslint.config.mjs'
-export default [ ...cds.recommended ]
+import cds from "@sap/cds/eslint.config.mjs"
+export default [...cds.recommended]

--- a/tests/bookshop/eslint.config.mjs
+++ b/tests/bookshop/eslint.config.mjs
@@ -1,2 +1,2 @@
-import cds from "@sap/cds/eslint.config.mjs"
+import cds from '@sap/cds/eslint.config.mjs'
 export default [...cds.recommended]

--- a/tests/bookshop/mta.yaml
+++ b/tests/bookshop/mta.yaml
@@ -1,7 +1,7 @@
 _schema-version: 3.3.0
 ID: bookshop-notify
 version: 1.0.0
-description: 'A simple CAP project.'
+description: "A simple CAP project."
 parameters:
   enable-parallel-deployments: true
 build-parameters:
@@ -49,7 +49,7 @@ modules:
       disk-quota: 1GB
       tasks:
         - name: notification-content-deployment
-          command: 'node node_modules/@cap-js/notifications/lib/content-deployment.js'
+          command: "node node_modules/@cap-js/notifications/lib/content-deployment.js"
           memory: 256MB
           disk-quota: 1GB
     requires:
@@ -70,13 +70,13 @@ resources:
         tenant-mode: dedicated
         oauth2-configuration:
           credential-types:
-            - 'binding-secret'
-            - 'x509'
+            - "binding-secret"
+            - "x509"
         role-collections:
-          - name: 'admin (bookshop-notify ${org}-${space})'
-            description: 'generated'
+          - name: "admin (bookshop-notify ${org}-${space})"
+            description: "generated"
             role-template-references:
-              - '$XSAPPNAME.admin'
+              - "$XSAPPNAME.admin"
   - name: bookshop-notify-db
     type: com.sap.xs.hdi-container
     parameters:

--- a/tests/bookshop/mta.yaml
+++ b/tests/bookshop/mta.yaml
@@ -73,10 +73,10 @@ resources:
             - "binding-secret"
             - "x509"
         role-collections:
-          - name: 'admin (bookshop-notify ${org}-${space})'
-            description: 'generated'
+          - name: "admin (bookshop-notify ${org}-${space})"
+            description: "generated"
             role-template-references:
-              - '$XSAPPNAME.admin'
+              - "$XSAPPNAME.admin"
   - name: bookshop-notify-db
     type: com.sap.xs.hdi-container
     parameters:

--- a/tests/bookshop/mta.yaml
+++ b/tests/bookshop/mta.yaml
@@ -1,7 +1,7 @@
 _schema-version: 3.3.0
 ID: bookshop-notify
 version: 1.0.0
-description: "A simple CAP project."
+description: 'A simple CAP project.'
 parameters:
   enable-parallel-deployments: true
 build-parameters:
@@ -49,7 +49,7 @@ modules:
       disk-quota: 1GB
       tasks:
         - name: notification-content-deployment
-          command: "node node_modules/@cap-js/notifications/lib/content-deployment.js"
+          command: 'node node_modules/@cap-js/notifications/lib/content-deployment.js'
           memory: 256MB
           disk-quota: 1GB
     requires:
@@ -70,13 +70,13 @@ resources:
         tenant-mode: dedicated
         oauth2-configuration:
           credential-types:
-            - "binding-secret"
-            - "x509"
+            - 'binding-secret'
+            - 'x509'
         role-collections:
-          - name: "admin (bookshop-notify ${org}-${space})"
-            description: "generated"
+          - name: 'admin (bookshop-notify ${org}-${space})'
+            description: 'generated'
             role-template-references:
-              - "$XSAPPNAME.admin"
+              - '$XSAPPNAME.admin'
   - name: bookshop-notify-db
     type: com.sap.xs.hdi-container
     parameters:

--- a/tests/bookshop/srv/admin-service.js
+++ b/tests/bookshop/srv/admin-service.js
@@ -1,11 +1,17 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 module.exports = cds.service.impl(async function () {
-  this.on('resetStock', async () => {
-    const db = await cds.connect.to('db')
-    const SEED_STOCK = [[201, 12], [207, 11], [251, 333], [252, 555], [271, 22]]
+  this.on("resetStock", async () => {
+    const db = await cds.connect.to("db")
+    const SEED_STOCK = [
+      [201, 12],
+      [207, 11],
+      [251, 333],
+      [252, 555],
+      [271, 22]
+    ]
     for (const [id, stock] of SEED_STOCK) {
       await db.run(`UPDATE SAP_CAPIRE_BOOKSHOP_BOOKS SET STOCK = ${stock} WHERE ID = ${id}`)
     }
-    return { message: 'Stock reset' }
+    return { message: "Stock reset" }
   })
 })

--- a/tests/bookshop/srv/admin-service.js
+++ b/tests/bookshop/srv/admin-service.js
@@ -1,7 +1,7 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 module.exports = cds.service.impl(async function () {
-  this.on('resetStock', async () => {
-    const db = await cds.connect.to('db')
+  this.on("resetStock", async () => {
+    const db = await cds.connect.to("db")
     const SEED_STOCK = [
       [201, 12],
       [207, 11],
@@ -12,6 +12,6 @@ module.exports = cds.service.impl(async function () {
     for (const [id, stock] of SEED_STOCK) {
       await db.run(`UPDATE SAP_CAPIRE_BOOKSHOP_BOOKS SET STOCK = ${stock} WHERE ID = ${id}`)
     }
-    return { message: 'Stock reset' }
+    return { message: "Stock reset" }
   })
 })

--- a/tests/bookshop/srv/admin-service.js
+++ b/tests/bookshop/srv/admin-service.js
@@ -1,7 +1,7 @@
-const cds = require("@sap/cds")
+const cds = require('@sap/cds')
 module.exports = cds.service.impl(async function () {
-  this.on("resetStock", async () => {
-    const db = await cds.connect.to("db")
+  this.on('resetStock', async () => {
+    const db = await cds.connect.to('db')
     const SEED_STOCK = [
       [201, 12],
       [207, 11],
@@ -12,6 +12,6 @@ module.exports = cds.service.impl(async function () {
     for (const [id, stock] of SEED_STOCK) {
       await db.run(`UPDATE SAP_CAPIRE_BOOKSHOP_BOOKS SET STOCK = ${stock} WHERE ID = ${id}`)
     }
-    return { message: "Stock reset" }
+    return { message: 'Stock reset' }
   })
 })

--- a/tests/bookshop/srv/cat-service.js
+++ b/tests/bookshop/srv/cat-service.js
@@ -22,7 +22,7 @@ module.exports = cds.service.impl(async function () {
       title: book.title,
       buyer: req.user.id,
       quantity: quantity,
-      recipients: ["0c62ccd5-96a8-43dd-8a12-7202ea2d1fb9"]
+      recipients: ["reader@bookshop.example"]
     })
 
     return { stock: book.stock - quantity }

--- a/tests/bookshop/srv/cat-service.js
+++ b/tests/bookshop/srv/cat-service.js
@@ -1,26 +1,28 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 module.exports = cds.service.impl(async function () {
-  const alert = await cds.connect.to('notifications')
+  const alert = await cds.connect.to("notifications")
 
-  this.on('submitOrder', async req => {
+  this.on("submitOrder", async req => {
     const { book: bookId, quantity } = req.data
 
-    const book = await SELECT.one.from('sap.capire.bookshop.Books').where({ ID: bookId })
+    const book = await SELECT.one.from("sap.capire.bookshop.Books").where({ ID: bookId })
     if (!book) return req.error(404, `Book ${bookId} not found`)
     if (book.stock < quantity) return req.error(400, `Not enough stock for book ${bookId}`)
 
-    await UPDATE('sap.capire.bookshop.Books').set({ stock: book.stock - quantity }).where({ ID: bookId })
+    await UPDATE("sap.capire.bookshop.Books")
+      .set({ stock: book.stock - quantity })
+      .where({ ID: bookId })
 
-    await alert.notify('BookOrderedNotify', {
-      recipients: ['reader@bookshop.example'],
+    await alert.notify("BookOrderedNotify", {
+      recipients: ["reader@bookshop.example"],
       data: { title: book.title, buyer: req.user.id }
     })
 
-    await this.emit('BookOrderedNotify', {
+    await this.emit("BookOrderedNotify", {
       title: book.title,
       buyer: req.user.id,
       quantity: quantity,
-      recipients: ['reader@bookshop.example'],
+      recipients: ["0c62ccd5-96a8-43dd-8a12-7202ea2d1fb9"]
     })
 
     return { stock: book.stock - quantity }

--- a/tests/bookshop/srv/cat-service.js
+++ b/tests/bookshop/srv/cat-service.js
@@ -1,28 +1,28 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 module.exports = cds.service.impl(async function () {
-  const alert = await cds.connect.to('notifications')
+  const alert = await cds.connect.to("notifications")
 
-  this.on('submitOrder', async req => {
+  this.on("submitOrder", async req => {
     const { book: bookId, quantity } = req.data
 
-    const book = await SELECT.one.from('sap.capire.bookshop.Books').where({ ID: bookId })
+    const book = await SELECT.one.from("sap.capire.bookshop.Books").where({ ID: bookId })
     if (!book) return req.error(404, `Book ${bookId} not found`)
     if (book.stock < quantity) return req.error(400, `Not enough stock for book ${bookId}`)
 
-    await UPDATE('sap.capire.bookshop.Books')
+    await UPDATE("sap.capire.bookshop.Books")
       .set({ stock: book.stock - quantity })
       .where({ ID: bookId })
 
-    await alert.notify('BookOrderedNotify', {
-      recipients: ['reader@bookshop.example'],
+    await alert.notify("BookOrderedNotify", {
+      recipients: ["reader@bookshop.example"],
       data: { title: book.title, buyer: req.user.id }
     })
 
-    await this.emit('BookOrderedNotify', {
+    await this.emit("BookOrderedNotify", {
       title: book.title,
       buyer: req.user.id,
       quantity: quantity,
-      recipients: ['reader@bookshop.example']
+      recipients: ["reader@bookshop.example"]
     })
 
     return { stock: book.stock - quantity }

--- a/tests/bookshop/srv/cat-service.js
+++ b/tests/bookshop/srv/cat-service.js
@@ -1,28 +1,28 @@
-const cds = require("@sap/cds")
+const cds = require('@sap/cds')
 module.exports = cds.service.impl(async function () {
-  const alert = await cds.connect.to("notifications")
+  const alert = await cds.connect.to('notifications')
 
-  this.on("submitOrder", async req => {
+  this.on('submitOrder', async req => {
     const { book: bookId, quantity } = req.data
 
-    const book = await SELECT.one.from("sap.capire.bookshop.Books").where({ ID: bookId })
+    const book = await SELECT.one.from('sap.capire.bookshop.Books').where({ ID: bookId })
     if (!book) return req.error(404, `Book ${bookId} not found`)
     if (book.stock < quantity) return req.error(400, `Not enough stock for book ${bookId}`)
 
-    await UPDATE("sap.capire.bookshop.Books")
+    await UPDATE('sap.capire.bookshop.Books')
       .set({ stock: book.stock - quantity })
       .where({ ID: bookId })
 
-    await alert.notify("BookOrderedNotify", {
-      recipients: ["reader@bookshop.example"],
+    await alert.notify('BookOrderedNotify', {
+      recipients: ['reader@bookshop.example'],
       data: { title: book.title, buyer: req.user.id }
     })
 
-    await this.emit("BookOrderedNotify", {
+    await this.emit('BookOrderedNotify', {
       title: book.title,
       buyer: req.user.id,
       quantity: quantity,
-      recipients: ["reader@bookshop.example"]
+      recipients: ['reader@bookshop.example']
     })
 
     return { stock: book.stock - quantity }

--- a/tests/bookshop/xs-security.json
+++ b/tests/bookshop/xs-security.json
@@ -10,9 +10,7 @@
     {
       "name": "admin",
       "description": "generated",
-      "scope-references": [
-        "$XSAPPNAME.admin"
-      ],
+      "scope-references": ["$XSAPPNAME.admin"],
       "attribute-references": []
     }
   ]

--- a/tests/integration/bookshop.test.js
+++ b/tests/integration/bookshop.test.js
@@ -1,254 +1,254 @@
-const cds = require('@sap/cds')
-const { join } = require('path')
-const { messages } = require('../../lib/utils')
-const { notificationTypesFromModel } = require('../../lib/compile')
+const cds = require("@sap/cds")
+const { join } = require("path")
+const { messages } = require("../../lib/utils")
+const { notificationTypesFromModel } = require("../../lib/compile")
 
-const usesRestService = ['hybrid', 'production'].includes(process.env.CDS_ENV)
+const usesRestService = ["hybrid", "production"].includes(process.env.CDS_ENV)
 
-cds.test(join(__dirname, '../bookshop'))
+cds.test(join(__dirname, "../bookshop"))
 
-describe('Notifications Integration', () => {
+describe("Notifications Integration", () => {
   let log = cds.test.log()
   let alert
 
   beforeAll(async () => {
-    alert = await cds.connect.to('notifications')
+    alert = await cds.connect.to("notifications")
   })
 
-  describe('Service implementation', () => {
-    test('Resolves to correct implementation', () => {
+  describe("Service implementation", () => {
+    test("Resolves to correct implementation", () => {
       if (!usesRestService) {
-        expect(alert.constructor.name).toBe('NotifyToConsole')
+        expect(alert.constructor.name).toBe("NotifyToConsole")
       } else {
-        expect(alert.constructor.name).toBe('NotifyToRest')
+        expect(alert.constructor.name).toBe("NotifyToRest")
       }
     })
   })
 
-  describe('Startup', () => {
-    test('Notification types are loaded into cds.notifications on startup', () => {
+  describe("Startup", () => {
+    test("Notification types are loaded into cds.notifications on startup", () => {
       expect(cds.notifications?.local?.types).toBeDefined()
-      expect(cds.notifications.local.types).toHaveProperty('bookshop/BookOrderedNotify')
+      expect(cds.notifications.local.types).toHaveProperty("bookshop/BookOrderedNotify")
     })
 
-    test('Notification types from CDS and JSON are merged', () => {
-      expect(cds.notifications.local.types).toHaveProperty('bookshop/BookOrderedNotify')
-      expect(cds.notifications.local.types).toHaveProperty('bookshop/BookReturned')
+    test("Notification types from CDS and JSON are merged", () => {
+      expect(cds.notifications.local.types).toHaveProperty("bookshop/BookOrderedNotify")
+      expect(cds.notifications.local.types).toHaveProperty("bookshop/BookReturned")
     })
   })
 
-  test('Sending a default notification logs to console', async () => {
+  test("Sending a default notification logs to console", async () => {
     await alert.notify({
-      recipients: ['reader@bookshop.com'],
-      title: 'New book arrived',
-      description: 'A new book has been added to the catalog.'
+      recipients: ["reader@bookshop.com"],
+      title: "New book arrived",
+      description: "A new book has been added to the catalog."
     })
   })
 
-  describe('i18n', () => {
-    test('Notification type templates have resolved i18n values', () => {
-      const type = cds.notifications.local.types['bookshop/BookOrderedNotify']['1']
-      const en = type.Templates.find(t => t.Language === 'en')
-      expect(en.TemplateSensitive).toBe('Book Ordered')
-      expect(en.Subtitle).toBe('{{buyer}} ordered {{title}}')
+  describe("i18n", () => {
+    test("Notification type templates have resolved i18n values", () => {
+      const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
+      const en = type.Templates.find(t => t.Language === "en")
+      expect(en.TemplateSensitive).toBe("Book Ordered")
+      expect(en.Subtitle).toBe("{{buyer}} ordered {{title}}")
     })
 
-    test('Notification type for BookOrderedNotify has templates for all available languages', () => {
-      const type = cds.notifications.local.types['bookshop/BookOrderedNotify']['1']
+    test("Notification type for BookOrderedNotify has templates for all available languages", () => {
+      const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
       expect(type.Templates).toHaveLength(2)
-      expect(type.Templates.map(t => t.Language)).toContain('en')
-      expect(type.Templates.map(t => t.Language)).toContain('de')
+      expect(type.Templates.map(t => t.Language)).toContain("en")
+      expect(type.Templates.map(t => t.Language)).toContain("de")
     })
 
-    test('German template for BookOrderedNotify has German translation', () => {
-      const type = cds.notifications.local.types['bookshop/BookOrderedNotify']['1']
-      const de = type.Templates.find(t => t.Language === 'de')
-      expect(de.TemplateSensitive).toBe('Buch bestellt')
-      expect(de.Subtitle).toBe('{{buyer}} hat {{title}} bestellt')
+    test("German template for BookOrderedNotify has German translation", () => {
+      const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
+      const de = type.Templates.find(t => t.Language === "de")
+      expect(de.TemplateSensitive).toBe("Buch bestellt")
+      expect(de.Subtitle).toBe("{{buyer}} hat {{title}} bestellt")
     })
 
-    test('Email html is loaded from file with i18n resolved per locale', () => {
-      const type = cds.notifications.local.types['bookshop/BookOrderedNotify']['1']
-      const en = type.Templates.find(t => t.Language === 'en')
-      const de = type.Templates.find(t => t.Language === 'de')
+    test("Email html is loaded from file with i18n resolved per locale", () => {
+      const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
+      const en = type.Templates.find(t => t.Language === "en")
+      const de = type.Templates.find(t => t.Language === "de")
       expect(en.EmailHtml).toBe(
-        '<h1>Book Ordered</h1>\n<p>Hi {{buyer}}, your order for <b>{{title}}</b> has been placed.</p>\n'
+        "<h1>Book Ordered</h1>\n<p>Hi {{buyer}}, your order for <b>{{title}}</b> has been placed.</p>\n"
       )
       expect(de.EmailHtml).toBe(
-        '<h1>Buch bestellt</h1>\n<p>Hallo {{buyer}}, deine Bestellung für <b>{{title}}</b> wurde aufgegeben.</p>\n'
+        "<h1>Buch bestellt</h1>\n<p>Hallo {{buyer}}, deine Bestellung für <b>{{title}}</b> wurde aufgegeben.</p>\n"
       )
     })
   })
 
-  describe('Sending notifications', () => {
-    test('Sending a notification with no arguments warns and does nothing', async () => {
+  describe("Sending notifications", () => {
+    test("Sending a notification with no arguments warns and does nothing", async () => {
       await alert.notify()
       expect(log.output).toContain(messages.NO_OBJECT_FOR_NOTIFY)
     })
 
-    test('Sending a default notification reaches the service without error', async () => {
+    test("Sending a default notification reaches the service without error", async () => {
       await expect(
         alert.notify({
-          recipients: ['reader@bookshop.com'],
-          title: 'New book arrived',
-          description: 'A new book has been added to the catalogue'
+          recipients: ["reader@bookshop.com"],
+          title: "New book arrived",
+          description: "A new book has been added to the catalogue"
         })
       ).resolves.not.toThrow()
 
       if (!usesRestService) {
-        expect(log.output).toContain('Notification:')
+        expect(log.output).toContain("Notification:")
         expect(log.output).toContain("NotificationTypeKey: 'Default'")
         expect(log.output).toContain("RecipientId: 'reader@bookshop.com'")
         expect(log.output).toContain("Value: 'New book arrived'")
       }
     })
 
-    test('Custom typed notification uses prefixed type key', async () => {
+    test("Custom typed notification uses prefixed type key", async () => {
       await expect(
-        alert.notify('BookOrderedNotify', {
-          recipients: ['reader@bookshop.com'],
-          data: { title: 'Moby Dick', buyer: 'reader@bookshop.com' }
+        alert.notify("BookOrderedNotify", {
+          recipients: ["reader@bookshop.com"],
+          data: { title: "Moby Dick", buyer: "reader@bookshop.com" }
         })
       ).resolves.not.toThrow()
 
       if (!usesRestService) {
-        expect(log.output).toContain('bookshop/BookOrderedNotify')
-        expect(log.output).not.toContain('is not in the notification types file')
+        expect(log.output).toContain("bookshop/BookOrderedNotify")
+        expect(log.output).not.toContain("is not in the notification types file")
       }
     })
 
-    test('Sending a notification with unknown type key gives a warning (dev only)', async () => {
+    test("Sending a notification with unknown type key gives a warning (dev only)", async () => {
       if (usesRestService) return
 
-      await alert.notify('UnknownType', {
-        recipients: ['reader@bookshop.com'],
-        data: { title: 'test' }
+      await alert.notify("UnknownType", {
+        recipients: ["reader@bookshop.com"],
+        data: { title: "test" }
       })
 
-      expect(log.output).toContain('UnknownType is not in the notification types file')
+      expect(log.output).toContain("UnknownType is not in the notification types file")
     })
   })
 
-  describe('Event emission', () => {
-    test('Emitting a @notification event directly triggers a notification', async () => {
-      const catalog = await cds.connect.to('CatalogService')
+  describe("Event emission", () => {
+    test("Emitting a @notification event directly triggers a notification", async () => {
+      const catalog = await cds.connect.to("CatalogService")
       await expect(
-        catalog.emit('BookOrderedNotify', {
-          title: 'Moby Dick',
-          buyer: 'reader@bookshop.com',
-          recipients: ['reader@bookshop.com']
+        catalog.emit("BookOrderedNotify", {
+          title: "Moby Dick",
+          buyer: "reader@bookshop.com",
+          recipients: ["reader@bookshop.com"]
         })
       ).resolves.not.toThrow()
       if (!usesRestService) {
-        expect(log.output).toContain('BookOrderedNotify')
-        expect(log.output).toContain('Moby Dick')
+        expect(log.output).toContain("BookOrderedNotify")
+        expect(log.output).toContain("Moby Dick")
       }
     })
 
-    test('Emitting a @notification event with dynamic xpr priority evaluates priority via db', async () => {
-      const catalog = await cds.connect.to('CatalogService')
+    test("Emitting a @notification event with dynamic xpr priority evaluates priority via db", async () => {
+      const catalog = await cds.connect.to("CatalogService")
       let capturedPriority
 
       const handler = msg => {
         capturedPriority = msg.data.Priority
       }
-      alert.before('*', handler)
+      alert.before("*", handler)
 
       try {
         // quantity > 5 -> High
         await expect(
-          catalog.emit('BookOrderedNotify', {
-            title: 'Bulk Order',
-            buyer: 'reader@bookshop.example',
+          catalog.emit("BookOrderedNotify", {
+            title: "Bulk Order",
+            buyer: "reader@bookshop.example",
             quantity: 10,
-            recipients: ['reader@bookshop.example']
+            recipients: ["reader@bookshop.example"]
           })
         ).resolves.not.toThrow()
-        expect(capturedPriority).toBe('HIGH')
+        expect(capturedPriority).toBe("HIGH")
 
         capturedPriority = undefined
 
         // quantity <= 5 -> Low
         await expect(
-          catalog.emit('BookOrderedNotify', {
-            title: 'Small Order',
-            buyer: 'reader@bookshop.example',
+          catalog.emit("BookOrderedNotify", {
+            title: "Small Order",
+            buyer: "reader@bookshop.example",
             quantity: 2,
-            recipients: ['reader@bookshop.example']
+            recipients: ["reader@bookshop.example"]
           })
         ).resolves.not.toThrow()
-        expect(capturedPriority).toBe('LOW')
+        expect(capturedPriority).toBe("LOW")
       } finally {
         alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
       }
     })
 
-    test('Dynamic priority using a db function (days_between) is evaluated by the database', async () => {
-      const catalog = await cds.connect.to('CatalogService')
+    test("Dynamic priority using a db function (days_between) is evaluated by the database", async () => {
+      const catalog = await cds.connect.to("CatalogService")
       let capturedPriority
 
       const handler = msg => {
         capturedPriority = msg.data.Priority
       }
-      alert.before('*', handler)
+      alert.before("*", handler)
 
       try {
         // 30 days apart → High
         await expect(
-          catalog.emit('LateDeliveryNotify', {
-            title: 'Late delivery',
-            orderDate: '2024-01-01',
-            deliveryDate: '2024-02-01',
-            recipients: ['reader@bookshop.example']
+          catalog.emit("LateDeliveryNotify", {
+            title: "Late delivery",
+            orderDate: "2024-01-01",
+            deliveryDate: "2024-02-01",
+            recipients: ["reader@bookshop.example"]
           })
         ).resolves.not.toThrow()
-        expect(capturedPriority).toBe('HIGH')
+        expect(capturedPriority).toBe("HIGH")
 
         capturedPriority = undefined
 
         // 3 days apart → Low
         await expect(
-          catalog.emit('LateDeliveryNotify', {
-            title: 'On-time delivery',
-            orderDate: '2024-01-01',
-            deliveryDate: '2024-01-04',
-            recipients: ['reader@bookshop.example']
+          catalog.emit("LateDeliveryNotify", {
+            title: "On-time delivery",
+            orderDate: "2024-01-01",
+            deliveryDate: "2024-01-04",
+            recipients: ["reader@bookshop.example"]
           })
         ).resolves.not.toThrow()
-        expect(capturedPriority).toBe('LOW')
+        expect(capturedPriority).toBe("LOW")
       } finally {
         alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
       }
     })
 
-    test('Throw when a notification event has an element name exceeding 128 characters', () => {
-      const longName = 'a'.repeat(129)
+    test("Throw when a notification event has an element name exceeding 128 characters", () => {
+      const longName = "a".repeat(129)
       const model = cds.linked(cds.parse.cdl(`@notification event OversizedEvent { ${longName}: String; }`))
       expect(() => notificationTypesFromModel(model)).toThrow(
         "Event 'OversizedEvent' has elements exceeding the maximum key length of 128 characters"
       )
     })
 
-    test('Submitting an order triggers a notification', async () => {
-      const catalog = await cds.connect.to('CatalogService')
+    test("Submitting an order triggers a notification", async () => {
+      const catalog = await cds.connect.to("CatalogService")
       await expect(
         catalog.send({
-          event: 'submitOrder',
-          data: { book: '201', quantity: 1 },
-          user: new cds.User('reader@bookshop.com')
+          event: "submitOrder",
+          data: { book: "201", quantity: 1 },
+          user: new cds.User("reader@bookshop.com")
         })
       ).resolves.not.toThrow()
 
       if (!usesRestService) {
-        expect(log.output).toContain('bookshop/BookOrderedNotify')
-        expect(log.output).toContain('Wuthering Heights')
+        expect(log.output).toContain("bookshop/BookOrderedNotify")
+        expect(log.output).toContain("Wuthering Heights")
       }
     })
   })
 
-  describe('Model validation', () => {
-    test('Throw when a notification event has an element name exceeding 128 characters', () => {
-      const longName = 'a'.repeat(129)
+  describe("Model validation", () => {
+    test("Throw when a notification event has an element name exceeding 128 characters", () => {
+      const longName = "a".repeat(129)
       const model = cds.linked(cds.parse.cdl(`@notification event OversizedEvent { ${longName}: String; }`))
       expect(() => notificationTypesFromModel(model)).toThrow(
         "Event 'OversizedEvent' has elements exceeding the maximum key length of 128 characters"
@@ -256,70 +256,70 @@ describe('Notifications Integration', () => {
     })
   })
 
-  test('Batch of typed notifications logs each one to console', async () => {
+  test("Batch of typed notifications logs each one to console", async () => {
     const captured = []
     const handler = msg => {
       captured.push(...(Array.isArray(msg.data) ? msg.data : [msg.data]))
     }
-    alert.before('*', handler)
+    alert.before("*", handler)
 
     try {
       await expect(
-        alert.notify('BookOrderedNotify', [
-          { recipients: ['reader1@bookshop.com'], data: { title: 'Moby Dick', buyer: 'reader1@bookshop.com' } },
-          { recipients: ['reader2@bookshop.com'], data: { title: 'Wuthering Heights', buyer: 'reader2@bookshop.com' } }
+        alert.notify("BookOrderedNotify", [
+          { recipients: ["reader1@bookshop.com"], data: { title: "Moby Dick", buyer: "reader1@bookshop.com" } },
+          { recipients: ["reader2@bookshop.com"], data: { title: "Wuthering Heights", buyer: "reader2@bookshop.com" } }
         ])
       ).resolves.not.toThrow()
 
       const titles = captured.flatMap(n => n.Properties?.map(p => p.Value) ?? [])
       const recipients = captured.flatMap(n => n.Recipients?.map(r => r.RecipientId) ?? [])
-      expect(titles).toContain('Moby Dick')
-      expect(titles).toContain('Wuthering Heights')
-      expect(recipients).toContain('reader1@bookshop.com')
-      expect(recipients).toContain('reader2@bookshop.com')
+      expect(titles).toContain("Moby Dick")
+      expect(titles).toContain("Wuthering Heights")
+      expect(recipients).toContain("reader1@bookshop.com")
+      expect(recipients).toContain("reader2@bookshop.com")
       if (!usesRestService) {
-        expect(log.output).not.toContain('is not in the notification types file')
+        expect(log.output).not.toContain("is not in the notification types file")
       }
     } finally {
       alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
     }
   })
 
-  test('Batch of default notifications logs each one to console', async () => {
+  test("Batch of default notifications logs each one to console", async () => {
     const captured = []
     const handler = msg => {
       captured.push(...(Array.isArray(msg.data) ? msg.data : [msg.data]))
     }
-    alert.before('*', handler)
+    alert.before("*", handler)
 
     try {
       await expect(
         alert.notify([
-          { recipients: ['alice@bookshop.com'], title: 'Order #1 confirmed', description: 'Your order is on its way.' },
-          { recipients: ['bob@bookshop.com'], title: 'Order #2 confirmed', description: 'Your order is on its way.' }
+          { recipients: ["alice@bookshop.com"], title: "Order #1 confirmed", description: "Your order is on its way." },
+          { recipients: ["bob@bookshop.com"], title: "Order #2 confirmed", description: "Your order is on its way." }
         ])
       ).resolves.not.toThrow()
 
       const titles = captured.flatMap(n => n.Properties?.map(p => p.Value) ?? [])
       const recipients = captured.flatMap(n => n.Recipients?.map(r => r.RecipientId) ?? [])
-      expect(titles).toContain('Order #1 confirmed')
-      expect(titles).toContain('Order #2 confirmed')
-      expect(recipients).toContain('alice@bookshop.com')
-      expect(recipients).toContain('bob@bookshop.com')
+      expect(titles).toContain("Order #1 confirmed")
+      expect(titles).toContain("Order #2 confirmed")
+      expect(recipients).toContain("alice@bookshop.com")
+      expect(recipients).toContain("bob@bookshop.com")
     } finally {
       alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
     }
   })
 
-  test('Email html is loaded from file with i18n resolved per locale', () => {
-    const type = cds.notifications.local.types['bookshop/BookOrderedNotify']['1']
-    const en = type.Templates.find(t => t.Language === 'en')
-    const de = type.Templates.find(t => t.Language === 'de')
+  test("Email html is loaded from file with i18n resolved per locale", () => {
+    const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
+    const en = type.Templates.find(t => t.Language === "en")
+    const de = type.Templates.find(t => t.Language === "de")
     expect(en.EmailHtml).toBe(
-      '<h1>Book Ordered</h1>\n<p>Hi {{buyer}}, your order for <b>{{title}}</b> has been placed.</p>\n'
+      "<h1>Book Ordered</h1>\n<p>Hi {{buyer}}, your order for <b>{{title}}</b> has been placed.</p>\n"
     )
     expect(de.EmailHtml).toBe(
-      '<h1>Buch bestellt</h1>\n<p>Hallo {{buyer}}, deine Bestellung für <b>{{title}}</b> wurde aufgegeben.</p>\n'
+      "<h1>Buch bestellt</h1>\n<p>Hallo {{buyer}}, deine Bestellung für <b>{{title}}</b> wurde aufgegeben.</p>\n"
     )
   })
 
@@ -334,35 +334,35 @@ describe('Notifications Integration', () => {
       alert._handlers.before.splice(beforeHandlers)
     })
 
-    test('is called before a notification is sent and receives msg.event and msg.data', async () => {
+    test("is called before a notification is sent and receives msg.event and msg.data", async () => {
       let capturedEvent, capturedData
-      alert.before('*', msg => {
+      alert.before("*", msg => {
         capturedEvent = msg.event
         capturedData = msg.data
       })
 
-      await alert.notify('BookOrderedNotify', {
-        recipients: ['reader@bookshop.com'],
-        data: { title: 'Moby Dick', buyer: 'reader@bookshop.com' }
+      await alert.notify("BookOrderedNotify", {
+        recipients: ["reader@bookshop.com"],
+        data: { title: "Moby Dick", buyer: "reader@bookshop.com" }
       })
 
-      expect(capturedEvent).toBe('BookOrderedNotify')
+      expect(capturedEvent).toBe("BookOrderedNotify")
       expect(capturedData).toMatchObject({
-        NotificationTypeKey: expect.stringContaining('BookOrderedNotify'),
-        Recipients: expect.arrayContaining([expect.objectContaining({ RecipientId: 'reader@bookshop.com' })])
+        NotificationTypeKey: expect.stringContaining("BookOrderedNotify"),
+        Recipients: expect.arrayContaining([expect.objectContaining({ RecipientId: "reader@bookshop.com" })])
       })
     })
 
-    test('can suppress a notification by throwing', async () => {
-      alert.before('*', () => {
-        throw new cds.error('Recipient not eligible')
+    test("can suppress a notification by throwing", async () => {
+      alert.before("*", () => {
+        throw new cds.error("Recipient not eligible")
       })
 
-      await expect(alert.notify({ recipients: ['reader@bookshop.com'], title: 'New book arrived' })).rejects.toThrow(
-        'Recipient not eligible'
+      await expect(alert.notify({ recipients: ["reader@bookshop.com"], title: "New book arrived" })).rejects.toThrow(
+        "Recipient not eligible"
       )
 
-      expect(log.output).not.toContain('Notification:')
+      expect(log.output).not.toContain("Notification:")
     })
   })
 })

--- a/tests/integration/bookshop.test.js
+++ b/tests/integration/bookshop.test.js
@@ -1,254 +1,254 @@
-const cds = require("@sap/cds")
-const { join } = require("path")
-const { messages } = require("../../lib/utils")
-const { notificationTypesFromModel } = require("../../lib/compile")
+const cds = require('@sap/cds')
+const { join } = require('path')
+const { messages } = require('../../lib/utils')
+const { notificationTypesFromModel } = require('../../lib/compile')
 
-const usesRestService = ["hybrid", "production"].includes(process.env.CDS_ENV)
+const usesRestService = ['hybrid', 'production'].includes(process.env.CDS_ENV)
 
-cds.test(join(__dirname, "../bookshop"))
+cds.test(join(__dirname, '../bookshop'))
 
-describe("Notifications Integration", () => {
+describe('Notifications Integration', () => {
   let log = cds.test.log()
   let alert
 
   beforeAll(async () => {
-    alert = await cds.connect.to("notifications")
+    alert = await cds.connect.to('notifications')
   })
 
-  describe("Service implementation", () => {
-    test("Resolves to correct implementation", () => {
+  describe('Service implementation', () => {
+    test('Resolves to correct implementation', () => {
       if (!usesRestService) {
-        expect(alert.constructor.name).toBe("NotifyToConsole")
+        expect(alert.constructor.name).toBe('NotifyToConsole')
       } else {
-        expect(alert.constructor.name).toBe("NotifyToRest")
+        expect(alert.constructor.name).toBe('NotifyToRest')
       }
     })
   })
 
-  describe("Startup", () => {
-    test("Notification types are loaded into cds.notifications on startup", () => {
+  describe('Startup', () => {
+    test('Notification types are loaded into cds.notifications on startup', () => {
       expect(cds.notifications?.local?.types).toBeDefined()
-      expect(cds.notifications.local.types).toHaveProperty("bookshop/BookOrderedNotify")
+      expect(cds.notifications.local.types).toHaveProperty('bookshop/BookOrderedNotify')
     })
 
-    test("Notification types from CDS and JSON are merged", () => {
-      expect(cds.notifications.local.types).toHaveProperty("bookshop/BookOrderedNotify")
-      expect(cds.notifications.local.types).toHaveProperty("bookshop/BookReturned")
+    test('Notification types from CDS and JSON are merged', () => {
+      expect(cds.notifications.local.types).toHaveProperty('bookshop/BookOrderedNotify')
+      expect(cds.notifications.local.types).toHaveProperty('bookshop/BookReturned')
     })
   })
 
-  test("Sending a default notification logs to console", async () => {
+  test('Sending a default notification logs to console', async () => {
     await alert.notify({
-      recipients: ["reader@bookshop.com"],
-      title: "New book arrived",
-      description: "A new book has been added to the catalog."
+      recipients: ['reader@bookshop.com'],
+      title: 'New book arrived',
+      description: 'A new book has been added to the catalog.'
     })
   })
 
-  describe("i18n", () => {
-    test("Notification type templates have resolved i18n values", () => {
-      const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
-      const en = type.Templates.find(t => t.Language === "en")
-      expect(en.TemplateSensitive).toBe("Book Ordered")
-      expect(en.Subtitle).toBe("{{buyer}} ordered {{title}}")
+  describe('i18n', () => {
+    test('Notification type templates have resolved i18n values', () => {
+      const type = cds.notifications.local.types['bookshop/BookOrderedNotify']['1']
+      const en = type.Templates.find(t => t.Language === 'en')
+      expect(en.TemplateSensitive).toBe('Book Ordered')
+      expect(en.Subtitle).toBe('{{buyer}} ordered {{title}}')
     })
 
-    test("Notification type for BookOrderedNotify has templates for all available languages", () => {
-      const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
+    test('Notification type for BookOrderedNotify has templates for all available languages', () => {
+      const type = cds.notifications.local.types['bookshop/BookOrderedNotify']['1']
       expect(type.Templates).toHaveLength(2)
-      expect(type.Templates.map(t => t.Language)).toContain("en")
-      expect(type.Templates.map(t => t.Language)).toContain("de")
+      expect(type.Templates.map(t => t.Language)).toContain('en')
+      expect(type.Templates.map(t => t.Language)).toContain('de')
     })
 
-    test("German template for BookOrderedNotify has German translation", () => {
-      const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
-      const de = type.Templates.find(t => t.Language === "de")
-      expect(de.TemplateSensitive).toBe("Buch bestellt")
-      expect(de.Subtitle).toBe("{{buyer}} hat {{title}} bestellt")
+    test('German template for BookOrderedNotify has German translation', () => {
+      const type = cds.notifications.local.types['bookshop/BookOrderedNotify']['1']
+      const de = type.Templates.find(t => t.Language === 'de')
+      expect(de.TemplateSensitive).toBe('Buch bestellt')
+      expect(de.Subtitle).toBe('{{buyer}} hat {{title}} bestellt')
     })
 
-    test("Email html is loaded from file with i18n resolved per locale", () => {
-      const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
-      const en = type.Templates.find(t => t.Language === "en")
-      const de = type.Templates.find(t => t.Language === "de")
+    test('Email html is loaded from file with i18n resolved per locale', () => {
+      const type = cds.notifications.local.types['bookshop/BookOrderedNotify']['1']
+      const en = type.Templates.find(t => t.Language === 'en')
+      const de = type.Templates.find(t => t.Language === 'de')
       expect(en.EmailHtml).toBe(
-        "<h1>Book Ordered</h1>\n<p>Hi {{buyer}}, your order for <b>{{title}}</b> has been placed.</p>\n"
+        '<h1>Book Ordered</h1>\n<p>Hi {{buyer}}, your order for <b>{{title}}</b> has been placed.</p>\n'
       )
       expect(de.EmailHtml).toBe(
-        "<h1>Buch bestellt</h1>\n<p>Hallo {{buyer}}, deine Bestellung für <b>{{title}}</b> wurde aufgegeben.</p>\n"
+        '<h1>Buch bestellt</h1>\n<p>Hallo {{buyer}}, deine Bestellung für <b>{{title}}</b> wurde aufgegeben.</p>\n'
       )
     })
   })
 
-  describe("Sending notifications", () => {
-    test("Sending a notification with no arguments warns and does nothing", async () => {
+  describe('Sending notifications', () => {
+    test('Sending a notification with no arguments warns and does nothing', async () => {
       await alert.notify()
       expect(log.output).toContain(messages.NO_OBJECT_FOR_NOTIFY)
     })
 
-    test("Sending a default notification reaches the service without error", async () => {
+    test('Sending a default notification reaches the service without error', async () => {
       await expect(
         alert.notify({
-          recipients: ["reader@bookshop.com"],
-          title: "New book arrived",
-          description: "A new book has been added to the catalogue"
+          recipients: ['reader@bookshop.com'],
+          title: 'New book arrived',
+          description: 'A new book has been added to the catalogue'
         })
       ).resolves.not.toThrow()
 
       if (!usesRestService) {
-        expect(log.output).toContain("Notification:")
+        expect(log.output).toContain('Notification:')
         expect(log.output).toContain("NotificationTypeKey: 'Default'")
         expect(log.output).toContain("RecipientId: 'reader@bookshop.com'")
         expect(log.output).toContain("Value: 'New book arrived'")
       }
     })
 
-    test("Custom typed notification uses prefixed type key", async () => {
+    test('Custom typed notification uses prefixed type key', async () => {
       await expect(
-        alert.notify("BookOrderedNotify", {
-          recipients: ["reader@bookshop.com"],
-          data: { title: "Moby Dick", buyer: "reader@bookshop.com" }
+        alert.notify('BookOrderedNotify', {
+          recipients: ['reader@bookshop.com'],
+          data: { title: 'Moby Dick', buyer: 'reader@bookshop.com' }
         })
       ).resolves.not.toThrow()
 
       if (!usesRestService) {
-        expect(log.output).toContain("bookshop/BookOrderedNotify")
-        expect(log.output).not.toContain("is not in the notification types file")
+        expect(log.output).toContain('bookshop/BookOrderedNotify')
+        expect(log.output).not.toContain('is not in the notification types file')
       }
     })
 
-    test("Sending a notification with unknown type key gives a warning (dev only)", async () => {
+    test('Sending a notification with unknown type key gives a warning (dev only)', async () => {
       if (usesRestService) return
 
-      await alert.notify("UnknownType", {
-        recipients: ["reader@bookshop.com"],
-        data: { title: "test" }
+      await alert.notify('UnknownType', {
+        recipients: ['reader@bookshop.com'],
+        data: { title: 'test' }
       })
 
-      expect(log.output).toContain("UnknownType is not in the notification types file")
+      expect(log.output).toContain('UnknownType is not in the notification types file')
     })
   })
 
-  describe("Event emission", () => {
-    test("Emitting a @notification event directly triggers a notification", async () => {
-      const catalog = await cds.connect.to("CatalogService")
+  describe('Event emission', () => {
+    test('Emitting a @notification event directly triggers a notification', async () => {
+      const catalog = await cds.connect.to('CatalogService')
       await expect(
-        catalog.emit("BookOrderedNotify", {
-          title: "Moby Dick",
-          buyer: "reader@bookshop.com",
-          recipients: ["reader@bookshop.com"]
+        catalog.emit('BookOrderedNotify', {
+          title: 'Moby Dick',
+          buyer: 'reader@bookshop.com',
+          recipients: ['reader@bookshop.com']
         })
       ).resolves.not.toThrow()
       if (!usesRestService) {
-        expect(log.output).toContain("BookOrderedNotify")
-        expect(log.output).toContain("Moby Dick")
+        expect(log.output).toContain('BookOrderedNotify')
+        expect(log.output).toContain('Moby Dick')
       }
     })
 
-    test("Emitting a @notification event with dynamic xpr priority evaluates priority via db", async () => {
-      const catalog = await cds.connect.to("CatalogService")
+    test('Emitting a @notification event with dynamic xpr priority evaluates priority via db', async () => {
+      const catalog = await cds.connect.to('CatalogService')
       let capturedPriority
 
       const handler = msg => {
         capturedPriority = msg.data.Priority
       }
-      alert.before("*", handler)
+      alert.before('*', handler)
 
       try {
         // quantity > 5 -> High
         await expect(
-          catalog.emit("BookOrderedNotify", {
-            title: "Bulk Order",
-            buyer: "reader@bookshop.example",
+          catalog.emit('BookOrderedNotify', {
+            title: 'Bulk Order',
+            buyer: 'reader@bookshop.example',
             quantity: 10,
-            recipients: ["reader@bookshop.example"]
+            recipients: ['reader@bookshop.example']
           })
         ).resolves.not.toThrow()
-        expect(capturedPriority).toBe("HIGH")
+        expect(capturedPriority).toBe('HIGH')
 
         capturedPriority = undefined
 
         // quantity <= 5 -> Low
         await expect(
-          catalog.emit("BookOrderedNotify", {
-            title: "Small Order",
-            buyer: "reader@bookshop.example",
+          catalog.emit('BookOrderedNotify', {
+            title: 'Small Order',
+            buyer: 'reader@bookshop.example',
             quantity: 2,
-            recipients: ["reader@bookshop.example"]
+            recipients: ['reader@bookshop.example']
           })
         ).resolves.not.toThrow()
-        expect(capturedPriority).toBe("LOW")
+        expect(capturedPriority).toBe('LOW')
       } finally {
         alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
       }
     })
 
-    test("Dynamic priority using a db function (days_between) is evaluated by the database", async () => {
-      const catalog = await cds.connect.to("CatalogService")
+    test('Dynamic priority using a db function (days_between) is evaluated by the database', async () => {
+      const catalog = await cds.connect.to('CatalogService')
       let capturedPriority
 
       const handler = msg => {
         capturedPriority = msg.data.Priority
       }
-      alert.before("*", handler)
+      alert.before('*', handler)
 
       try {
         // 30 days apart → High
         await expect(
-          catalog.emit("LateDeliveryNotify", {
-            title: "Late delivery",
-            orderDate: "2024-01-01",
-            deliveryDate: "2024-02-01",
-            recipients: ["reader@bookshop.example"]
+          catalog.emit('LateDeliveryNotify', {
+            title: 'Late delivery',
+            orderDate: '2024-01-01',
+            deliveryDate: '2024-02-01',
+            recipients: ['reader@bookshop.example']
           })
         ).resolves.not.toThrow()
-        expect(capturedPriority).toBe("HIGH")
+        expect(capturedPriority).toBe('HIGH')
 
         capturedPriority = undefined
 
         // 3 days apart → Low
         await expect(
-          catalog.emit("LateDeliveryNotify", {
-            title: "On-time delivery",
-            orderDate: "2024-01-01",
-            deliveryDate: "2024-01-04",
-            recipients: ["reader@bookshop.example"]
+          catalog.emit('LateDeliveryNotify', {
+            title: 'On-time delivery',
+            orderDate: '2024-01-01',
+            deliveryDate: '2024-01-04',
+            recipients: ['reader@bookshop.example']
           })
         ).resolves.not.toThrow()
-        expect(capturedPriority).toBe("LOW")
+        expect(capturedPriority).toBe('LOW')
       } finally {
         alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
       }
     })
 
-    test("Throw when a notification event has an element name exceeding 128 characters", () => {
-      const longName = "a".repeat(129)
+    test('Throw when a notification event has an element name exceeding 128 characters', () => {
+      const longName = 'a'.repeat(129)
       const model = cds.linked(cds.parse.cdl(`@notification event OversizedEvent { ${longName}: String; }`))
       expect(() => notificationTypesFromModel(model)).toThrow(
         "Event 'OversizedEvent' has elements exceeding the maximum key length of 128 characters"
       )
     })
 
-    test("Submitting an order triggers a notification", async () => {
-      const catalog = await cds.connect.to("CatalogService")
+    test('Submitting an order triggers a notification', async () => {
+      const catalog = await cds.connect.to('CatalogService')
       await expect(
         catalog.send({
-          event: "submitOrder",
-          data: { book: "201", quantity: 1 },
-          user: new cds.User("reader@bookshop.com")
+          event: 'submitOrder',
+          data: { book: '201', quantity: 1 },
+          user: new cds.User('reader@bookshop.com')
         })
       ).resolves.not.toThrow()
 
       if (!usesRestService) {
-        expect(log.output).toContain("bookshop/BookOrderedNotify")
-        expect(log.output).toContain("Wuthering Heights")
+        expect(log.output).toContain('bookshop/BookOrderedNotify')
+        expect(log.output).toContain('Wuthering Heights')
       }
     })
   })
 
-  describe("Model validation", () => {
-    test("Throw when a notification event has an element name exceeding 128 characters", () => {
-      const longName = "a".repeat(129)
+  describe('Model validation', () => {
+    test('Throw when a notification event has an element name exceeding 128 characters', () => {
+      const longName = 'a'.repeat(129)
       const model = cds.linked(cds.parse.cdl(`@notification event OversizedEvent { ${longName}: String; }`))
       expect(() => notificationTypesFromModel(model)).toThrow(
         "Event 'OversizedEvent' has elements exceeding the maximum key length of 128 characters"
@@ -256,70 +256,70 @@ describe("Notifications Integration", () => {
     })
   })
 
-  test("Batch of typed notifications logs each one to console", async () => {
+  test('Batch of typed notifications logs each one to console', async () => {
     const captured = []
     const handler = msg => {
       captured.push(...(Array.isArray(msg.data) ? msg.data : [msg.data]))
     }
-    alert.before("*", handler)
+    alert.before('*', handler)
 
     try {
       await expect(
-        alert.notify("BookOrderedNotify", [
-          { recipients: ["reader1@bookshop.com"], data: { title: "Moby Dick", buyer: "reader1@bookshop.com" } },
-          { recipients: ["reader2@bookshop.com"], data: { title: "Wuthering Heights", buyer: "reader2@bookshop.com" } }
+        alert.notify('BookOrderedNotify', [
+          { recipients: ['reader1@bookshop.com'], data: { title: 'Moby Dick', buyer: 'reader1@bookshop.com' } },
+          { recipients: ['reader2@bookshop.com'], data: { title: 'Wuthering Heights', buyer: 'reader2@bookshop.com' } }
         ])
       ).resolves.not.toThrow()
 
       const titles = captured.flatMap(n => n.Properties?.map(p => p.Value) ?? [])
       const recipients = captured.flatMap(n => n.Recipients?.map(r => r.RecipientId) ?? [])
-      expect(titles).toContain("Moby Dick")
-      expect(titles).toContain("Wuthering Heights")
-      expect(recipients).toContain("reader1@bookshop.com")
-      expect(recipients).toContain("reader2@bookshop.com")
+      expect(titles).toContain('Moby Dick')
+      expect(titles).toContain('Wuthering Heights')
+      expect(recipients).toContain('reader1@bookshop.com')
+      expect(recipients).toContain('reader2@bookshop.com')
       if (!usesRestService) {
-        expect(log.output).not.toContain("is not in the notification types file")
+        expect(log.output).not.toContain('is not in the notification types file')
       }
     } finally {
       alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
     }
   })
 
-  test("Batch of default notifications logs each one to console", async () => {
+  test('Batch of default notifications logs each one to console', async () => {
     const captured = []
     const handler = msg => {
       captured.push(...(Array.isArray(msg.data) ? msg.data : [msg.data]))
     }
-    alert.before("*", handler)
+    alert.before('*', handler)
 
     try {
       await expect(
         alert.notify([
-          { recipients: ["alice@bookshop.com"], title: "Order #1 confirmed", description: "Your order is on its way." },
-          { recipients: ["bob@bookshop.com"], title: "Order #2 confirmed", description: "Your order is on its way." }
+          { recipients: ['alice@bookshop.com'], title: 'Order #1 confirmed', description: 'Your order is on its way.' },
+          { recipients: ['bob@bookshop.com'], title: 'Order #2 confirmed', description: 'Your order is on its way.' }
         ])
       ).resolves.not.toThrow()
 
       const titles = captured.flatMap(n => n.Properties?.map(p => p.Value) ?? [])
       const recipients = captured.flatMap(n => n.Recipients?.map(r => r.RecipientId) ?? [])
-      expect(titles).toContain("Order #1 confirmed")
-      expect(titles).toContain("Order #2 confirmed")
-      expect(recipients).toContain("alice@bookshop.com")
-      expect(recipients).toContain("bob@bookshop.com")
+      expect(titles).toContain('Order #1 confirmed')
+      expect(titles).toContain('Order #2 confirmed')
+      expect(recipients).toContain('alice@bookshop.com')
+      expect(recipients).toContain('bob@bookshop.com')
     } finally {
       alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
     }
   })
 
-  test("Email html is loaded from file with i18n resolved per locale", () => {
-    const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
-    const en = type.Templates.find(t => t.Language === "en")
-    const de = type.Templates.find(t => t.Language === "de")
+  test('Email html is loaded from file with i18n resolved per locale', () => {
+    const type = cds.notifications.local.types['bookshop/BookOrderedNotify']['1']
+    const en = type.Templates.find(t => t.Language === 'en')
+    const de = type.Templates.find(t => t.Language === 'de')
     expect(en.EmailHtml).toBe(
-      "<h1>Book Ordered</h1>\n<p>Hi {{buyer}}, your order for <b>{{title}}</b> has been placed.</p>\n"
+      '<h1>Book Ordered</h1>\n<p>Hi {{buyer}}, your order for <b>{{title}}</b> has been placed.</p>\n'
     )
     expect(de.EmailHtml).toBe(
-      "<h1>Buch bestellt</h1>\n<p>Hallo {{buyer}}, deine Bestellung für <b>{{title}}</b> wurde aufgegeben.</p>\n"
+      '<h1>Buch bestellt</h1>\n<p>Hallo {{buyer}}, deine Bestellung für <b>{{title}}</b> wurde aufgegeben.</p>\n'
     )
   })
 
@@ -334,35 +334,35 @@ describe("Notifications Integration", () => {
       alert._handlers.before.splice(beforeHandlers)
     })
 
-    test("is called before a notification is sent and receives msg.event and msg.data", async () => {
+    test('is called before a notification is sent and receives msg.event and msg.data', async () => {
       let capturedEvent, capturedData
-      alert.before("*", msg => {
+      alert.before('*', msg => {
         capturedEvent = msg.event
         capturedData = msg.data
       })
 
-      await alert.notify("BookOrderedNotify", {
-        recipients: ["reader@bookshop.com"],
-        data: { title: "Moby Dick", buyer: "reader@bookshop.com" }
+      await alert.notify('BookOrderedNotify', {
+        recipients: ['reader@bookshop.com'],
+        data: { title: 'Moby Dick', buyer: 'reader@bookshop.com' }
       })
 
-      expect(capturedEvent).toBe("BookOrderedNotify")
+      expect(capturedEvent).toBe('BookOrderedNotify')
       expect(capturedData).toMatchObject({
-        NotificationTypeKey: expect.stringContaining("BookOrderedNotify"),
-        Recipients: expect.arrayContaining([expect.objectContaining({ RecipientId: "reader@bookshop.com" })])
+        NotificationTypeKey: expect.stringContaining('BookOrderedNotify'),
+        Recipients: expect.arrayContaining([expect.objectContaining({ RecipientId: 'reader@bookshop.com' })])
       })
     })
 
-    test("can suppress a notification by throwing", async () => {
-      alert.before("*", () => {
-        throw new cds.error("Recipient not eligible")
+    test('can suppress a notification by throwing', async () => {
+      alert.before('*', () => {
+        throw new cds.error('Recipient not eligible')
       })
 
-      await expect(alert.notify({ recipients: ["reader@bookshop.com"], title: "New book arrived" })).rejects.toThrow(
-        "Recipient not eligible"
+      await expect(alert.notify({ recipients: ['reader@bookshop.com'], title: 'New book arrived' })).rejects.toThrow(
+        'Recipient not eligible'
       )
 
-      expect(log.output).not.toContain("Notification:")
+      expect(log.output).not.toContain('Notification:')
     })
   })
 })

--- a/tests/integration/bookshop.test.js
+++ b/tests/integration/bookshop.test.js
@@ -48,7 +48,7 @@ describe("Notifications Integration", () => {
   describe("i18n", () => {
     test("Notification type templates have resolved i18n values", () => {
       const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
-      const en = type.Templates.find(t => t.Language === 'en')
+      const en = type.Templates.find(t => t.Language === "en")
       expect(en.TemplateSensitive).toBe("Book Ordered")
       expect(en.Subtitle).toBe("{{buyer}} ordered {{title}}")
     })
@@ -69,8 +69,8 @@ describe("Notifications Integration", () => {
 
     test("Email html is loaded from file with i18n resolved per locale", () => {
       const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
-      const en = type.Templates.find(t => t.Language === 'en')
-      const de = type.Templates.find(t => t.Language === 'de')
+      const en = type.Templates.find(t => t.Language === "en")
+      const de = type.Templates.find(t => t.Language === "de")
       expect(en.EmailHtml).toBe(
         "<h1>Book Ordered</h1>\n<p>Hi {{buyer}}, your order for <b>{{title}}</b> has been placed.</p>\n"
       )
@@ -87,11 +87,13 @@ describe("Notifications Integration", () => {
     })
 
     test("Sending a default notification reaches the service without error", async () => {
-      await expect(alert.notify({
-        recipients: ["reader@bookshop.com"],
-        title: "New book arrived",
-        description: "A new book has been added to the catalogue"
-      })).resolves.not.toThrow()
+      await expect(
+        alert.notify({
+          recipients: ["reader@bookshop.com"],
+          title: "New book arrived",
+          description: "A new book has been added to the catalogue"
+        })
+      ).resolves.not.toThrow()
 
       if (!usesRestService) {
         expect(log.output).toContain("Notification:")
@@ -102,10 +104,12 @@ describe("Notifications Integration", () => {
     })
 
     test("Custom typed notification uses prefixed type key", async () => {
-      await expect(alert.notify("BookOrderedNotify", {
-        recipients: ["reader@bookshop.com"],
-        data: { title: "Moby Dick", buyer: "reader@bookshop.com" }
-      })).resolves.not.toThrow()
+      await expect(
+        alert.notify("BookOrderedNotify", {
+          recipients: ["reader@bookshop.com"],
+          data: { title: "Moby Dick", buyer: "reader@bookshop.com" }
+        })
+      ).resolves.not.toThrow()
 
       if (!usesRestService) {
         expect(log.output).toContain("bookshop/BookOrderedNotify")
@@ -127,84 +131,98 @@ describe("Notifications Integration", () => {
 
   describe("Event emission", () => {
     test("Emitting a @notification event directly triggers a notification", async () => {
-      const catalog = await cds.connect.to('CatalogService')
-      await expect(catalog.emit('BookOrderedNotify', {
-        title: 'Moby Dick',
-        buyer: 'reader@bookshop.com',
-        recipients: ['reader@bookshop.com'],
-      })).resolves.not.toThrow()
+      const catalog = await cds.connect.to("CatalogService")
+      await expect(
+        catalog.emit("BookOrderedNotify", {
+          title: "Moby Dick",
+          buyer: "reader@bookshop.com",
+          recipients: ["reader@bookshop.com"]
+        })
+      ).resolves.not.toThrow()
       if (!usesRestService) {
         expect(log.output).toContain("BookOrderedNotify")
         expect(log.output).toContain("Moby Dick")
       }
     })
-    
+
     test("Emitting a @notification event with dynamic xpr priority evaluates priority via db", async () => {
-      const catalog = await cds.connect.to('CatalogService')
+      const catalog = await cds.connect.to("CatalogService")
       let capturedPriority
 
-      const handler = msg => { capturedPriority = msg.data.Priority }
-      alert.before('*', handler)
+      const handler = msg => {
+        capturedPriority = msg.data.Priority
+      }
+      alert.before("*", handler)
 
       try {
         // quantity > 5 -> High
-        await expect(catalog.emit('BookOrderedNotify', {
-          title: 'Bulk Order',
-          buyer: 'reader@bookshop.example',
-          quantity: 10,
-          recipients: ['reader@bookshop.example'],
-        })).resolves.not.toThrow()
-        expect(capturedPriority).toBe('HIGH')
+        await expect(
+          catalog.emit("BookOrderedNotify", {
+            title: "Bulk Order",
+            buyer: "reader@bookshop.example",
+            quantity: 10,
+            recipients: ["reader@bookshop.example"]
+          })
+        ).resolves.not.toThrow()
+        expect(capturedPriority).toBe("HIGH")
 
         capturedPriority = undefined
 
         // quantity <= 5 -> Low
-        await expect(catalog.emit('BookOrderedNotify', {
-          title: 'Small Order',
-          buyer: 'reader@bookshop.example',
-          quantity: 2,
-          recipients: ['reader@bookshop.example'],
-        })).resolves.not.toThrow()
-        expect(capturedPriority).toBe('LOW')
+        await expect(
+          catalog.emit("BookOrderedNotify", {
+            title: "Small Order",
+            buyer: "reader@bookshop.example",
+            quantity: 2,
+            recipients: ["reader@bookshop.example"]
+          })
+        ).resolves.not.toThrow()
+        expect(capturedPriority).toBe("LOW")
       } finally {
         alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
       }
     })
 
     test("Dynamic priority using a db function (days_between) is evaluated by the database", async () => {
-      const catalog = await cds.connect.to('CatalogService')
+      const catalog = await cds.connect.to("CatalogService")
       let capturedPriority
 
-      const handler = msg => { capturedPriority = msg.data.Priority }
-      alert.before('*', handler)
+      const handler = msg => {
+        capturedPriority = msg.data.Priority
+      }
+      alert.before("*", handler)
 
       try {
         // 30 days apart → High
-        await expect(catalog.emit('LateDeliveryNotify', {
-          title: 'Late delivery',
-          orderDate: '2024-01-01',
-          deliveryDate: '2024-02-01',
-          recipients: ['reader@bookshop.example'],
-        })).resolves.not.toThrow()
-        expect(capturedPriority).toBe('HIGH')
+        await expect(
+          catalog.emit("LateDeliveryNotify", {
+            title: "Late delivery",
+            orderDate: "2024-01-01",
+            deliveryDate: "2024-02-01",
+            recipients: ["reader@bookshop.example"]
+          })
+        ).resolves.not.toThrow()
+        expect(capturedPriority).toBe("HIGH")
 
         capturedPriority = undefined
 
         // 3 days apart → Low
-        await expect(catalog.emit('LateDeliveryNotify', {
-          title: 'On-time delivery',
-          orderDate: '2024-01-01',
-          deliveryDate: '2024-01-04',
-          recipients: ['reader@bookshop.example'],
-        })).resolves.not.toThrow()
-        expect(capturedPriority).toBe('LOW')
+        await expect(
+          catalog.emit("LateDeliveryNotify", {
+            title: "On-time delivery",
+            orderDate: "2024-01-01",
+            deliveryDate: "2024-01-04",
+            recipients: ["reader@bookshop.example"]
+          })
+        ).resolves.not.toThrow()
+        expect(capturedPriority).toBe("LOW")
       } finally {
         alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
       }
     })
 
     test("Throw when a notification event has an element name exceeding 128 characters", () => {
-      const longName = 'a'.repeat(129)
+      const longName = "a".repeat(129)
       const model = cds.linked(cds.parse.cdl(`@notification event OversizedEvent { ${longName}: String; }`))
       expect(() => notificationTypesFromModel(model)).toThrow(
         "Event 'OversizedEvent' has elements exceeding the maximum key length of 128 characters"
@@ -212,12 +230,14 @@ describe("Notifications Integration", () => {
     })
 
     test("Submitting an order triggers a notification", async () => {
-      const catalog = await cds.connect.to('CatalogService')
-      await expect(catalog.send({
-        event: 'submitOrder',
-        data: { book: '201', quantity: 1 },
-        user: new cds.User('reader@bookshop.com')
-      })).resolves.not.toThrow()
+      const catalog = await cds.connect.to("CatalogService")
+      await expect(
+        catalog.send({
+          event: "submitOrder",
+          data: { book: "201", quantity: 1 },
+          user: new cds.User("reader@bookshop.com")
+        })
+      ).resolves.not.toThrow()
 
       if (!usesRestService) {
         expect(log.output).toContain("bookshop/BookOrderedNotify")
@@ -228,7 +248,7 @@ describe("Notifications Integration", () => {
 
   describe("Model validation", () => {
     test("Throw when a notification event has an element name exceeding 128 characters", () => {
-      const longName = 'a'.repeat(129)
+      const longName = "a".repeat(129)
       const model = cds.linked(cds.parse.cdl(`@notification event OversizedEvent { ${longName}: String; }`))
       expect(() => notificationTypesFromModel(model)).toThrow(
         "Event 'OversizedEvent' has elements exceeding the maximum key length of 128 characters"
@@ -238,14 +258,18 @@ describe("Notifications Integration", () => {
 
   test("Batch of typed notifications logs each one to console", async () => {
     const captured = []
-    const handler = msg => { captured.push(...(Array.isArray(msg.data) ? msg.data : [msg.data])) }
-    alert.before('*', handler)
+    const handler = msg => {
+      captured.push(...(Array.isArray(msg.data) ? msg.data : [msg.data]))
+    }
+    alert.before("*", handler)
 
     try {
-      await expect(alert.notify("BookOrderedNotify", [
-        { recipients: ["reader1@bookshop.com"], data: { title: "Moby Dick",        buyer: "reader1@bookshop.com" } },
-        { recipients: ["reader2@bookshop.com"], data: { title: "Wuthering Heights", buyer: "reader2@bookshop.com" } },
-      ])).resolves.not.toThrow()
+      await expect(
+        alert.notify("BookOrderedNotify", [
+          { recipients: ["reader1@bookshop.com"], data: { title: "Moby Dick", buyer: "reader1@bookshop.com" } },
+          { recipients: ["reader2@bookshop.com"], data: { title: "Wuthering Heights", buyer: "reader2@bookshop.com" } }
+        ])
+      ).resolves.not.toThrow()
 
       const titles = captured.flatMap(n => n.Properties?.map(p => p.Value) ?? [])
       const recipients = captured.flatMap(n => n.Recipients?.map(r => r.RecipientId) ?? [])
@@ -263,14 +287,18 @@ describe("Notifications Integration", () => {
 
   test("Batch of default notifications logs each one to console", async () => {
     const captured = []
-    const handler = msg => { captured.push(...(Array.isArray(msg.data) ? msg.data : [msg.data])) }
-    alert.before('*', handler)
+    const handler = msg => {
+      captured.push(...(Array.isArray(msg.data) ? msg.data : [msg.data]))
+    }
+    alert.before("*", handler)
 
     try {
-      await expect(alert.notify([
-        { recipients: ["alice@bookshop.com"], title: "Order #1 confirmed", description: "Your order is on its way." },
-        { recipients: ["bob@bookshop.com"],   title: "Order #2 confirmed", description: "Your order is on its way." },
-      ])).resolves.not.toThrow()
+      await expect(
+        alert.notify([
+          { recipients: ["alice@bookshop.com"], title: "Order #1 confirmed", description: "Your order is on its way." },
+          { recipients: ["bob@bookshop.com"], title: "Order #2 confirmed", description: "Your order is on its way." }
+        ])
+      ).resolves.not.toThrow()
 
       const titles = captured.flatMap(n => n.Properties?.map(p => p.Value) ?? [])
       const recipients = captured.flatMap(n => n.Recipients?.map(r => r.RecipientId) ?? [])
@@ -285,8 +313,8 @@ describe("Notifications Integration", () => {
 
   test("Email html is loaded from file with i18n resolved per locale", () => {
     const type = cds.notifications.local.types["bookshop/BookOrderedNotify"]["1"]
-    const en = type.Templates.find(t => t.Language === 'en')
-    const de = type.Templates.find(t => t.Language === 'de')
+    const en = type.Templates.find(t => t.Language === "en")
+    const de = type.Templates.find(t => t.Language === "de")
     expect(en.EmailHtml).toBe(
       "<h1>Book Ordered</h1>\n<p>Hi {{buyer}}, your order for <b>{{title}}</b> has been placed.</p>\n"
     )
@@ -294,7 +322,7 @@ describe("Notifications Integration", () => {
       "<h1>Buch bestellt</h1>\n<p>Hallo {{buyer}}, deine Bestellung für <b>{{title}}</b> wurde aufgegeben.</p>\n"
     )
   })
-  
+
   describe("before('*') hook", () => {
     let beforeHandlers
 
@@ -308,7 +336,7 @@ describe("Notifications Integration", () => {
 
     test("is called before a notification is sent and receives msg.event and msg.data", async () => {
       let capturedEvent, capturedData
-      alert.before('*', msg => {
+      alert.before("*", msg => {
         capturedEvent = msg.event
         capturedData = msg.data
       })
@@ -321,16 +349,18 @@ describe("Notifications Integration", () => {
       expect(capturedEvent).toBe("BookOrderedNotify")
       expect(capturedData).toMatchObject({
         NotificationTypeKey: expect.stringContaining("BookOrderedNotify"),
-        Recipients: expect.arrayContaining([expect.objectContaining({ RecipientId: "reader@bookshop.com" })]),
+        Recipients: expect.arrayContaining([expect.objectContaining({ RecipientId: "reader@bookshop.com" })])
       })
     })
 
     test("can suppress a notification by throwing", async () => {
-      alert.before('*', () => { throw new cds.error("Recipient not eligible") })
+      alert.before("*", () => {
+        throw new cds.error("Recipient not eligible")
+      })
 
-      await expect(
-        alert.notify({ recipients: ["reader@bookshop.com"], title: "New book arrived" })
-      ).rejects.toThrow("Recipient not eligible")
+      await expect(alert.notify({ recipients: ["reader@bookshop.com"], title: "New book arrived" })).rejects.toThrow(
+        "Recipient not eligible"
+      )
 
       expect(log.output).not.toContain("Notification:")
     })

--- a/tests/unit/lib/build.test.js
+++ b/tests/unit/lib/build.test.js
@@ -1,4 +1,4 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 const { join } = cds.utils.path
 
 // cds.build.Plugin is only available during a real `cds build` run, so we stub it here
@@ -16,17 +16,17 @@ class MockBuildPlugin {
 }
 cds.build = { Plugin: MockBuildPlugin }
 
-const BuildPlugin = require('../../../lib/build')
+const BuildPlugin = require("../../../lib/build")
 
 function makePlugin(overrides = {}) {
-  const plugin = new BuildPlugin({ src: join(__dirname, '../../bookshop/srv') })
-  plugin.task = { dest: '/tmp' }
+  const plugin = new BuildPlugin({ src: join(__dirname, "../../bookshop/srv") })
+  plugin.task = { dest: "/tmp" }
   plugin.write = jest.fn(() => ({ to: jest.fn().mockResolvedValue(undefined) }))
   Object.assign(plugin, overrides)
   return plugin
 }
 
-describe('Notifications Build Plugin', () => {
+describe("Notifications Build Plugin", () => {
   beforeEach(() => {
     cds.env.requires.notifications ??= {}
   })
@@ -35,35 +35,35 @@ describe('Notifications Build Plugin', () => {
     delete cds.env.requires.notifications.types
   })
 
-  test('hasTask returns true when notifications is configured', () => {
+  test("hasTask returns true when notifications is configured", () => {
     expect(BuildPlugin.hasTask()).toBe(true)
   })
 
-  test('hasTask returns false when notifications is not configured', () => {
+  test("hasTask returns false when notifications is not configured", () => {
     const saved = cds.env.requires.notifications
     delete cds.env.requires.notifications
     expect(BuildPlugin.hasTask()).toBe(false)
     cds.env.requires.notifications = saved
   })
 
-  test('Build succeeds with a raw unlinked model', async () => {
+  test("Build succeeds with a raw unlinked model", async () => {
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
+      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
     })
     await expect(plugin.build()).resolves.not.toThrow()
   })
 
-  test('Build writes notification-types.json when types are found', async () => {
+  test("Build writes notification-types.json when types are found", async () => {
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
+      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
     })
     await plugin.build()
     expect(plugin.write).toHaveBeenCalled()
     const written = JSON.parse(plugin.write.mock.calls[0][0])
-    expect(written.some(t => t.NotificationTypeKey === 'BookOrderedNotify')).toBe(true)
+    expect(written.some(t => t.NotificationTypeKey === "BookOrderedNotify")).toBe(true)
   })
 
-  test('Build does not write output when model has no notification events', async () => {
+  test("Build does not write output when model has no notification events", async () => {
     const plugin = makePlugin({
       model: () => Promise.resolve(cds.linked({ definitions: [] }))
     })
@@ -71,24 +71,24 @@ describe('Notifications Build Plugin', () => {
     expect(plugin.write).not.toHaveBeenCalled()
   })
 
-  test('Build merges types from JSON file with model types', async () => {
-    cds.env.requires.notifications.types = join(__dirname, '../../bookshop/srv/notification-types.json')
+  test("Build merges types from JSON file with model types", async () => {
+    cds.env.requires.notifications.types = join(__dirname, "../../bookshop/srv/notification-types.json")
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
+      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
     })
     await plugin.build()
     const written = JSON.parse(plugin.write.mock.calls[0][0])
-    expect(written.some(t => t.NotificationTypeKey === 'BookOrderedNotify')).toBe(true)
-    expect(written.some(t => t.NotificationTypeKey === 'BookReturned')).toBe(true)
+    expect(written.some(t => t.NotificationTypeKey === "BookOrderedNotify")).toBe(true)
+    expect(written.some(t => t.NotificationTypeKey === "BookReturned")).toBe(true)
   })
 
-  test('Build output includes an English template', async () => {
+  test("Build output includes an English template", async () => {
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
+      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
     })
     await plugin.build()
     const written = JSON.parse(plugin.write.mock.calls[0][0])
-    const type = written.find(t => t.NotificationTypeKey === 'BookOrderedNotify')
-    expect(type.Templates.map(t => t.Language)).toContain('en')
+    const type = written.find(t => t.NotificationTypeKey === "BookOrderedNotify")
+    expect(type.Templates.map(t => t.Language)).toContain("en")
   })
 })

--- a/tests/unit/lib/build.test.js
+++ b/tests/unit/lib/build.test.js
@@ -1,4 +1,4 @@
-const cds = require("@sap/cds")
+const cds = require('@sap/cds')
 const { join } = cds.utils.path
 
 // cds.build.Plugin is only available during a real `cds build` run, so we stub it here
@@ -16,17 +16,17 @@ class MockBuildPlugin {
 }
 cds.build = { Plugin: MockBuildPlugin }
 
-const BuildPlugin = require("../../../lib/build")
+const BuildPlugin = require('../../../lib/build')
 
 function makePlugin(overrides = {}) {
-  const plugin = new BuildPlugin({ src: join(__dirname, "../../bookshop/srv") })
-  plugin.task = { dest: "/tmp" }
+  const plugin = new BuildPlugin({ src: join(__dirname, '../../bookshop/srv') })
+  plugin.task = { dest: '/tmp' }
   plugin.write = jest.fn(() => ({ to: jest.fn().mockResolvedValue(undefined) }))
   Object.assign(plugin, overrides)
   return plugin
 }
 
-describe("Notifications Build Plugin", () => {
+describe('Notifications Build Plugin', () => {
   beforeEach(() => {
     cds.env.requires.notifications ??= {}
   })
@@ -35,35 +35,35 @@ describe("Notifications Build Plugin", () => {
     delete cds.env.requires.notifications.types
   })
 
-  test("hasTask returns true when notifications is configured", () => {
+  test('hasTask returns true when notifications is configured', () => {
     expect(BuildPlugin.hasTask()).toBe(true)
   })
 
-  test("hasTask returns false when notifications is not configured", () => {
+  test('hasTask returns false when notifications is not configured', () => {
     const saved = cds.env.requires.notifications
     delete cds.env.requires.notifications
     expect(BuildPlugin.hasTask()).toBe(false)
     cds.env.requires.notifications = saved
   })
 
-  test("Build succeeds with a raw unlinked model", async () => {
+  test('Build succeeds with a raw unlinked model', async () => {
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
+      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
     })
     await expect(plugin.build()).resolves.not.toThrow()
   })
 
-  test("Build writes notification-types.json when types are found", async () => {
+  test('Build writes notification-types.json when types are found', async () => {
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
+      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
     })
     await plugin.build()
     expect(plugin.write).toHaveBeenCalled()
     const written = JSON.parse(plugin.write.mock.calls[0][0])
-    expect(written.some(t => t.NotificationTypeKey === "BookOrderedNotify")).toBe(true)
+    expect(written.some(t => t.NotificationTypeKey === 'BookOrderedNotify')).toBe(true)
   })
 
-  test("Build does not write output when model has no notification events", async () => {
+  test('Build does not write output when model has no notification events', async () => {
     const plugin = makePlugin({
       model: () => Promise.resolve(cds.linked({ definitions: [] }))
     })
@@ -71,24 +71,24 @@ describe("Notifications Build Plugin", () => {
     expect(plugin.write).not.toHaveBeenCalled()
   })
 
-  test("Build merges types from JSON file with model types", async () => {
-    cds.env.requires.notifications.types = join(__dirname, "../../bookshop/srv/notification-types.json")
+  test('Build merges types from JSON file with model types', async () => {
+    cds.env.requires.notifications.types = join(__dirname, '../../bookshop/srv/notification-types.json')
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
+      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
     })
     await plugin.build()
     const written = JSON.parse(plugin.write.mock.calls[0][0])
-    expect(written.some(t => t.NotificationTypeKey === "BookOrderedNotify")).toBe(true)
-    expect(written.some(t => t.NotificationTypeKey === "BookReturned")).toBe(true)
+    expect(written.some(t => t.NotificationTypeKey === 'BookOrderedNotify')).toBe(true)
+    expect(written.some(t => t.NotificationTypeKey === 'BookReturned')).toBe(true)
   })
 
-  test("Build output includes an English template", async () => {
+  test('Build output includes an English template', async () => {
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
+      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
     })
     await plugin.build()
     const written = JSON.parse(plugin.write.mock.calls[0][0])
-    const type = written.find(t => t.NotificationTypeKey === "BookOrderedNotify")
-    expect(type.Templates.map(t => t.Language)).toContain("en")
+    const type = written.find(t => t.NotificationTypeKey === 'BookOrderedNotify')
+    expect(type.Templates.map(t => t.Language)).toContain('en')
   })
 })

--- a/tests/unit/lib/build.test.js
+++ b/tests/unit/lib/build.test.js
@@ -1,26 +1,32 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 const { join } = cds.utils.path
 
 // cds.build.Plugin is only available during a real `cds build` run, so we stub it here
 // before requiring lib/build, which extends it at module evaluation time
 class MockBuildPlugin {
-  constructor(options) { this.options = options }
-  static hasTask() { return false }
-  async model() { return null }
+  constructor(options) {
+    this.options = options
+  }
+  static hasTask() {
+    return false
+  }
+  async model() {
+    return null
+  }
 }
 cds.build = { Plugin: MockBuildPlugin }
 
-const BuildPlugin = require('../../../lib/build')
+const BuildPlugin = require("../../../lib/build")
 
 function makePlugin(overrides = {}) {
-  const plugin = new BuildPlugin({ src: join(__dirname, '../../bookshop/srv') })
-  plugin.task = { dest: '/tmp' }
+  const plugin = new BuildPlugin({ src: join(__dirname, "../../bookshop/srv") })
+  plugin.task = { dest: "/tmp" }
   plugin.write = jest.fn(() => ({ to: jest.fn().mockResolvedValue(undefined) }))
   Object.assign(plugin, overrides)
   return plugin
 }
 
-describe('Notifications Build Plugin', () => {
+describe("Notifications Build Plugin", () => {
   beforeEach(() => {
     cds.env.requires.notifications ??= {}
   })
@@ -29,35 +35,35 @@ describe('Notifications Build Plugin', () => {
     delete cds.env.requires.notifications.types
   })
 
-  test('hasTask returns true when notifications is configured', () => {
+  test("hasTask returns true when notifications is configured", () => {
     expect(BuildPlugin.hasTask()).toBe(true)
   })
 
-  test('hasTask returns false when notifications is not configured', () => {
+  test("hasTask returns false when notifications is not configured", () => {
     const saved = cds.env.requires.notifications
     delete cds.env.requires.notifications
     expect(BuildPlugin.hasTask()).toBe(false)
     cds.env.requires.notifications = saved
   })
 
-  test('Build succeeds with a raw unlinked model', async () => {
+  test("Build succeeds with a raw unlinked model", async () => {
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
+      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
     })
     await expect(plugin.build()).resolves.not.toThrow()
   })
 
-  test('Build writes notification-types.json when types are found', async () => {
+  test("Build writes notification-types.json when types are found", async () => {
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
+      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
     })
     await plugin.build()
     expect(plugin.write).toHaveBeenCalled()
     const written = JSON.parse(plugin.write.mock.calls[0][0])
-    expect(written.some(t => t.NotificationTypeKey === 'BookOrderedNotify')).toBe(true)
+    expect(written.some(t => t.NotificationTypeKey === "BookOrderedNotify")).toBe(true)
   })
 
-  test('Build does not write output when model has no notification events', async () => {
+  test("Build does not write output when model has no notification events", async () => {
     const plugin = makePlugin({
       model: () => Promise.resolve(cds.linked({ definitions: [] }))
     })
@@ -65,24 +71,24 @@ describe('Notifications Build Plugin', () => {
     expect(plugin.write).not.toHaveBeenCalled()
   })
 
-  test('Build merges types from JSON file with model types', async () => {
-    cds.env.requires.notifications.types = join(__dirname, '../../bookshop/srv/notification-types.json')
+  test("Build merges types from JSON file with model types", async () => {
+    cds.env.requires.notifications.types = join(__dirname, "../../bookshop/srv/notification-types.json")
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
+      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
     })
     await plugin.build()
     const written = JSON.parse(plugin.write.mock.calls[0][0])
-    expect(written.some(t => t.NotificationTypeKey === 'BookOrderedNotify')).toBe(true)
-    expect(written.some(t => t.NotificationTypeKey === 'BookReturned')).toBe(true)
+    expect(written.some(t => t.NotificationTypeKey === "BookOrderedNotify")).toBe(true)
+    expect(written.some(t => t.NotificationTypeKey === "BookReturned")).toBe(true)
   })
 
-  test('Build output includes an English template', async () => {
+  test("Build output includes an English template", async () => {
     const plugin = makePlugin({
-      model: () => cds.load(join(__dirname, '../../bookshop/srv'))
+      model: () => cds.load(join(__dirname, "../../bookshop/srv"))
     })
     await plugin.build()
     const written = JSON.parse(plugin.write.mock.calls[0][0])
-    const type = written.find(t => t.NotificationTypeKey === 'BookOrderedNotify')
-    expect(type.Templates.map(t => t.Language)).toContain('en')
+    const type = written.find(t => t.NotificationTypeKey === "BookOrderedNotify")
+    expect(type.Templates.map(t => t.Language)).toContain("en")
   })
 })

--- a/tests/unit/lib/compile.test.js
+++ b/tests/unit/lib/compile.test.js
@@ -1,23 +1,23 @@
-jest.mock('fs', () => ({
-  ...jest.requireActual('fs'),
+jest.mock("fs", () => ({
+  ...jest.requireActual("fs"),
   existsSync: jest.fn(),
-  readFileSync: jest.fn(),
+  readFileSync: jest.fn()
 }))
 
-const { existsSync, readFileSync } = require('fs')
+const { existsSync, readFileSync } = require("fs")
 const { notificationTypesFromModel } = require("../../../lib/compile")
 
 function makeModel(defs) {
   return { definitions: Object.values(defs) }
 }
 
-function makeEventWithHtml(html, file = 'srv/notifications.cds') {
+function makeEventWithHtml(html, file = "srv/notifications.cds") {
   return {
-    kind: 'event',
-    name: 'E',
-    '@notification.title': 't',
-    '@notification.email.html': html,
-    $location: { file, line: 1, col: 1 },
+    kind: "event",
+    name: "E",
+    "@notification.title": "t",
+    "@notification.email.html": html,
+    $location: { file, line: 1, col: 1 }
   }
 }
 
@@ -29,15 +29,15 @@ describe("Notification Types from Model", () => {
 
   test("Return empty array when no events have @notification", () => {
     const model = makeModel({
-      "MyEntity": { kind: "entity", name: "MyEntity" },
-      "PlainEvent": { kind: "event", name: "PlainEvent" }
+      MyEntity: { kind: "entity", name: "MyEntity" },
+      PlainEvent: { kind: "event", name: "PlainEvent" }
     })
     expect(notificationTypesFromModel(model)).toEqual([])
   })
 
   test("Handle @notification with no template property", () => {
     const model = makeModel({
-      "E": {
+      E: {
         kind: "event",
         name: "E",
         "@notification": {}
@@ -52,7 +52,7 @@ describe("Notification Types from Model", () => {
 
   test("Convert a fully annotated event to a notification type", () => {
     const model = makeModel({
-      "BookOrderedNotify": {
+      BookOrderedNotify: {
         kind: "event",
         name: "BookOrderedNotify",
         "@description": "Book Ordered",
@@ -84,12 +84,14 @@ describe("Notification Types from Model", () => {
     expect(tmpl.TemplateGrouped).toBe("Bookshop Updates")
     expect(tmpl.EmailSubject).toBe("Your order")
 
-    expect(type.DeliveryChannels).toEqual([{ Type: "MAIL", Enabled: true, DefaultPreference: true, EditablePreference: true }])
+    expect(type.DeliveryChannels).toEqual([
+      { Type: "MAIL", Enabled: true, DefaultPreference: true, EditablePreference: true }
+    ])
   })
 
   test("Handle minimal annotation (only @notification present)", () => {
     const model = makeModel({
-      "SimpleEvent": {
+      SimpleEvent: {
         kind: "event",
         name: "SimpleEvent",
         "@notification.title": "Hello"
@@ -103,7 +105,9 @@ describe("Notification Types from Model", () => {
     expect(type.Templates[0].TemplateSensitive).toBe("Hello")
     expect(type.Templates[0].TemplatePublic).toBeUndefined()
     expect(type.NavigationTargetObject).toBeUndefined()
-    expect(type.DeliveryChannels).toEqual([{ Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }])
+    expect(type.DeliveryChannels).toEqual([
+      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
+    ])
   })
 
   test("Strip namespace prefix from event name", () => {
@@ -121,7 +125,7 @@ describe("Notification Types from Model", () => {
 
   test("Map 'email' string to MAIL channel type", () => {
     const model = makeModel({
-      "E": {
+      E: {
         kind: "event",
         name: "E",
         "@notification.title": "t",
@@ -136,7 +140,7 @@ describe("Notification Types from Model", () => {
 
   test("Unwrap plain string enum values in channels", () => {
     const model = makeModel({
-      "E": {
+      E: {
         kind: "event",
         name: "E",
         "@notification.title": "t",
@@ -151,10 +155,10 @@ describe("Notification Types from Model", () => {
 
   test("Return all events with @notification from a mixed model", () => {
     const model = makeModel({
-      "A": { kind: "event", name: "A", "@notification": { template: { title: "a" } } },
-      "B": { kind: "entity", name: "B" },
-      "C": { kind: "event", name: "C", "@notification": { template: { title: "c" } } },
-      "D": { kind: "event", name: "D" }
+      A: { kind: "event", name: "A", "@notification": { template: { title: "a" } } },
+      B: { kind: "entity", name: "B" },
+      C: { kind: "event", name: "C", "@notification": { template: { title: "c" } } },
+      D: { kind: "event", name: "D" }
     })
 
     const types = notificationTypesFromModel(model)
@@ -164,7 +168,7 @@ describe("Notification Types from Model", () => {
 
   test("Always include Enabled, DefaultPreference, EditablePreference as true for plain enum channels", () => {
     const model = makeModel({
-      "E": {
+      E: {
         kind: "event",
         name: "E",
         "@notification.title": "t",
@@ -183,25 +187,32 @@ describe("Notification Types from Model", () => {
 
   test("Support object form with just channel name", () => {
     const model = makeModel({
-      "E": {
+      E: {
         kind: "event",
         name: "E",
         "@notification.title": "t",
-        "@notification.channels": [
-          "email",
-          { channel: "workzone" }
-        ]
+        "@notification.channels": ["email", { channel: "workzone" }]
       }
     })
 
     const [type] = notificationTypesFromModel(model)
-    expect(type.DeliveryChannels[0]).toEqual({ Type: "MAIL", Enabled: true, DefaultPreference: true, EditablePreference: true })
-    expect(type.DeliveryChannels[1]).toEqual({ Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true })
+    expect(type.DeliveryChannels[0]).toEqual({
+      Type: "MAIL",
+      Enabled: true,
+      DefaultPreference: true,
+      EditablePreference: true
+    })
+    expect(type.DeliveryChannels[1]).toEqual({
+      Type: "WEB",
+      Enabled: true,
+      DefaultPreference: true,
+      EditablePreference: true
+    })
   })
 
   test("Skip channel entry when value is not a string", () => {
     const model = makeModel({
-      "E": {
+      E: {
         kind: "event",
         name: "E",
         "@notification.title": "t",
@@ -215,28 +226,31 @@ describe("Notification Types from Model", () => {
 })
 
 describe("i18n integration", () => {
-  const cds = require('@sap/cds')
+  const cds = require("@sap/cds")
   let originalI18nDescriptor
 
   beforeEach(() => {
-    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, 'i18n')
+    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, "i18n")
   })
 
   afterEach(() => {
     jest.restoreAllMocks()
-    if (originalI18nDescriptor) Object.defineProperty(cds, 'i18n', originalI18nDescriptor)
+    if (originalI18nDescriptor) Object.defineProperty(cds, "i18n", originalI18nDescriptor)
   })
 
   function mockLabels(allImpl, atImpl) {
-    jest.spyOn(cds.i18n.labels, 'all').mockImplementation(allImpl)
-    jest.spyOn(cds.i18n.labels, 'at').mockImplementation(atImpl)
+    jest.spyOn(cds.i18n.labels, "all").mockImplementation(allImpl)
+    jest.spyOn(cds.i18n.labels, "at").mockImplementation(atImpl)
   }
 
   test("Fall back to single English template when no i18n files found", () => {
-    mockLabels(() => ({}), () => undefined)
+    mockLabels(
+      () => ({}),
+      () => undefined
+    )
 
     const model = makeModel({
-      "E": { kind: "event", name: "E", "@notification.title": "Hello" }
+      E: { kind: "event", name: "E", "@notification.title": "Hello" }
     })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(1)
@@ -245,103 +259,133 @@ describe("i18n integration", () => {
   })
 
   test("Generate one template per available locale from i18n files", () => {
-    mockLabels(() => ({ en: 'Hello', de: 'Hallo' }),
-      (_, locale) => locale === 'de' ? 'Hallo' : 'Hello')
+    mockLabels(
+      () => ({ en: "Hello", de: "Hallo" }),
+      (_, locale) => (locale === "de" ? "Hallo" : "Hello")
+    )
 
-    const model = makeModel({ "E": { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
+    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(2)
-    expect(type.Templates.find(t => t.Language === 'en').TemplateSensitive).toBe('Hello')
-    expect(type.Templates.find(t => t.Language === 'de').TemplateSensitive).toBe('Hallo')
+    expect(type.Templates.find(t => t.Language === "en").TemplateSensitive).toBe("Hello")
+    expect(type.Templates.find(t => t.Language === "de").TemplateSensitive).toBe("Hallo")
   })
 
   test("Resolve {i18n>KEY} references from i18n.properties file", () => {
-    mockLabels(() => ({ en: 'Book Ordered' }), () => 'Book Ordered')
+    mockLabels(
+      () => ({ en: "Book Ordered" }),
+      () => "Book Ordered"
+    )
 
-    const model = makeModel({ "E": { kind: "event", name: "E", "@notification.title": "{i18n>BOOK_ORDERED_TITLE}" } })
+    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>BOOK_ORDERED_TITLE}" } })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates[0].TemplateSensitive).toBe("Book Ordered")
   })
 
   test("Resolve {i18n>KEY} to locale-specific translation when available", () => {
-    mockLabels(() => ({ en: 'Book Ordered', de: 'Buch bestellt' }),
-      (_, locale) => locale === 'de' ? 'Buch bestellt' : 'Book Ordered')
+    mockLabels(
+      () => ({ en: "Book Ordered", de: "Buch bestellt" }),
+      (_, locale) => (locale === "de" ? "Buch bestellt" : "Book Ordered")
+    )
 
-    const model = makeModel({ "E": { kind: "event", name: "E", "@notification.title": "{i18n>BOOK_ORDERED_TITLE}" } })
+    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>BOOK_ORDERED_TITLE}" } })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates.find(t => t.Language === 'en').TemplateSensitive).toBe("Book Ordered")
-    expect(type.Templates.find(t => t.Language === 'de').TemplateSensitive).toBe("Buch bestellt")
+    expect(type.Templates.find(t => t.Language === "en").TemplateSensitive).toBe("Book Ordered")
+    expect(type.Templates.find(t => t.Language === "de").TemplateSensitive).toBe("Buch bestellt")
   })
 
   test("Fall back to raw value when i18n key not found in any locale", () => {
-    mockLabels(() => ({}), () => undefined)
+    mockLabels(
+      () => ({}),
+      () => undefined
+    )
 
     const model = makeModel({
-      "E": { kind: "event", name: "E", "@notification.title": "{i18n>MISSING_KEY}" }
+      E: { kind: "event", name: "E", "@notification.title": "{i18n>MISSING_KEY}" }
     })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates[0].TemplateSensitive).toBe("{i18n>MISSING_KEY}")
   })
 
   test("Pass plain strings through i18n unchanged", () => {
-    mockLabels(() => ({}), () => undefined)
+    mockLabels(
+      () => ({}),
+      () => undefined
+    )
 
     const model = makeModel({
-      "E": { kind: "event", name: "E", "@notification.title": "Plain Title" }
+      E: { kind: "event", name: "E", "@notification.title": "Plain Title" }
     })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates[0].TemplateSensitive).toBe("Plain Title")
   })
 
   test("Resolve {i18n>KEY} in subtitle field", () => {
-    mockLabels(() => ({ en: 'Resolved Subtitle' }), () => 'Resolved Subtitle')
+    mockLabels(
+      () => ({ en: "Resolved Subtitle" }),
+      () => "Resolved Subtitle"
+    )
 
     const model = makeModel({
-      "E": { kind: "event", name: "E", "@notification.title": "t", "@notification.subtitle": "{i18n>SUBTITLE_KEY}" }
+      E: { kind: "event", name: "E", "@notification.title": "t", "@notification.subtitle": "{i18n>SUBTITLE_KEY}" }
     })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates[0].Subtitle).toBe("Resolved Subtitle")
   })
 
   test("Exclude locale when none of its keys differ from English", () => {
-    mockLabels(() => ({ en: 'Hello' }), () => 'Hello')
+    mockLabels(
+      () => ({ en: "Hello" }),
+      () => "Hello"
+    )
 
-    const model = makeModel({ "E": { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
+    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(1)
-    expect(type.Templates[0].Language).toBe('en')
+    expect(type.Templates[0].Language).toBe("en")
   })
 
   test("Exclude locale when its translation is identical to English", () => {
-    mockLabels(() => ({ en: 'Hello', de: 'Hello' }), () => 'Hello')
+    mockLabels(
+      () => ({ en: "Hello", de: "Hello" }),
+      () => "Hello"
+    )
 
-    const model = makeModel({ "E": { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
+    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(1)
-    expect(type.Templates[0].Language).toBe('en')
+    expect(type.Templates[0].Language).toBe("en")
   })
 
   test("Include locale only when at least one key differs from English", () => {
-    mockLabels((key) => key === 'TITLE' ? { en: 'Hello', de: 'Hallo' } : { en: 'Same', de: 'Same' },
-      (key, locale) => key === 'TITLE' ? (locale === 'de' ? 'Hallo' : 'Hello') : 'Same')
+    mockLabels(
+      key => (key === "TITLE" ? { en: "Hello", de: "Hallo" } : { en: "Same", de: "Same" }),
+      (key, locale) => (key === "TITLE" ? (locale === "de" ? "Hallo" : "Hello") : "Same")
+    )
 
-    const model = makeModel({ "E": { kind: "event", name: "E",
-      "@notification.title": "{i18n>TITLE}",
-      "@notification.subtitle": "{i18n>SUBTITLE}"
-    }})
+    const model = makeModel({
+      E: {
+        kind: "event",
+        name: "E",
+        "@notification.title": "{i18n>TITLE}",
+        "@notification.subtitle": "{i18n>SUBTITLE}"
+      }
+    })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(2)
-    expect(type.Templates.find(t => t.Language === 'de').TemplateSensitive).toBe('Hallo')
-    expect(type.Templates.find(t => t.Language === 'de').Subtitle).toBe('Same')
+    expect(type.Templates.find(t => t.Language === "de").TemplateSensitive).toBe("Hallo")
+    expect(type.Templates.find(t => t.Language === "de").Subtitle).toBe("Same")
   })
 
   test("Two events with same locale files get independent template sets", () => {
-    mockLabels((key) => key === 'A_TITLE' ? { en: 'A in English', de: 'A auf Deutsch' } : { en: 'B in English' },
-      (key, locale) => key === 'A_TITLE' ? (locale === 'de' ? 'A auf Deutsch' : 'A in English') : 'B in English')
+    mockLabels(
+      key => (key === "A_TITLE" ? { en: "A in English", de: "A auf Deutsch" } : { en: "B in English" }),
+      (key, locale) => (key === "A_TITLE" ? (locale === "de" ? "A auf Deutsch" : "A in English") : "B in English")
+    )
 
     const model = makeModel({
-      "A": { kind: "event", name: "A", "@notification.title": "{i18n>A_TITLE}" },
-      "B": { kind: "event", name: "B", "@notification.title": "{i18n>B_TITLE}" },
+      A: { kind: "event", name: "A", "@notification.title": "{i18n>A_TITLE}" },
+      B: { kind: "event", name: "B", "@notification.title": "{i18n>B_TITLE}" }
     })
     const [typeA, typeB] = notificationTypesFromModel(model)
     expect(typeA.Templates).toHaveLength(2)
@@ -349,12 +393,23 @@ describe("i18n integration", () => {
   })
 
   test("Resolve {i18n>KEY} in subtitle field via Object.defineProperty", () => {
-    Object.defineProperty(cds, 'i18n', {
-      value: { labels: { all: () => ({}), at: (key) => key === 'BOOK_ORDERED_SUBTITLE' ? '{{buyer}} ordered {{title}}' : undefined } },
-      configurable: true, writable: true
+    Object.defineProperty(cds, "i18n", {
+      value: {
+        labels: {
+          all: () => ({}),
+          at: key => (key === "BOOK_ORDERED_SUBTITLE" ? "{{buyer}} ordered {{title}}" : undefined)
+        }
+      },
+      configurable: true,
+      writable: true
     })
     const model = makeModel({
-      "E": { kind: "event", name: "E", "@notification.title": "t", "@notification.subtitle": "{i18n>BOOK_ORDERED_SUBTITLE}" }
+      E: {
+        kind: "event",
+        name: "E",
+        "@notification.title": "t",
+        "@notification.subtitle": "{i18n>BOOK_ORDERED_SUBTITLE}"
+      }
     })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates[0].Subtitle).toBe("{{buyer}} ordered {{title}}")
@@ -362,7 +417,7 @@ describe("i18n integration", () => {
 })
 
 describe("default channels config", () => {
-  const cds = require('@sap/cds')
+  const cds = require("@sap/cds")
 
   afterEach(() => {
     if (cds.env.requires?.notifications) {
@@ -372,37 +427,39 @@ describe("default channels config", () => {
 
   test("Add configured default channels when no channels annotated", () => {
     cds.env.requires.notifications ??= {}
-    cds.env.requires.notifications.channels = ['email']
+    cds.env.requires.notifications.channels = ["email"]
 
     const model = makeModel({
-      "E": { kind: "event", name: "E", "@notification.title": "t" }
-    })
-
-    const [type] = notificationTypesFromModel(model)
-    expect(type.DeliveryChannels).toEqual([{ Type: 'MAIL', Enabled: true, DefaultPreference: true, EditablePreference: true }])
-  })
-
-  test("Support multiple default channels", () => {
-    cds.env.requires.notifications ??= {}
-    cds.env.requires.notifications.channels = ['email', 'workzone']
-
-    const model = makeModel({
-      "E": { kind: "event", name: "E", "@notification.title": "t" }
+      E: { kind: "event", name: "E", "@notification.title": "t" }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels).toEqual([
-      { Type: 'MAIL', Enabled: true, DefaultPreference: true, EditablePreference: true },
-      { Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: "MAIL", Enabled: true, DefaultPreference: true, EditablePreference: true }
+    ])
+  })
+
+  test("Support multiple default channels", () => {
+    cds.env.requires.notifications ??= {}
+    cds.env.requires.notifications.channels = ["email", "workzone"]
+
+    const model = makeModel({
+      E: { kind: "event", name: "E", "@notification.title": "t" }
+    })
+
+    const [type] = notificationTypesFromModel(model)
+    expect(type.DeliveryChannels).toEqual([
+      { Type: "MAIL", Enabled: true, DefaultPreference: true, EditablePreference: true },
+      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 
   test("Do not override explicit channels annotation with default channels", () => {
     cds.env.requires.notifications ??= {}
-    cds.env.requires.notifications.channels = ['email']
+    cds.env.requires.notifications.channels = ["email"]
 
     const model = makeModel({
-      "E": {
+      E: {
         kind: "event",
         name: "E",
         "@notification.title": "t",
@@ -411,77 +468,81 @@ describe("default channels config", () => {
     })
 
     const [type] = notificationTypesFromModel(model)
-    expect(type.DeliveryChannels).toEqual([{ Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }])
+    expect(type.DeliveryChannels).toEqual([
+      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
+    ])
   })
 
   test("Default to workzone channel when channels config is not set", () => {
     const model = makeModel({
-      "E": { kind: "event", name: "E", "@notification.title": "t" }
+      E: { kind: "event", name: "E", "@notification.title": "t" }
     })
 
     const [type] = notificationTypesFromModel(model)
-    expect(type.DeliveryChannels).toEqual([{ Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }])
+    expect(type.DeliveryChannels).toEqual([
+      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
+    ])
   })
 })
 
 describe("HTML file resolution", () => {
-  const cds = require('@sap/cds')
+  const cds = require("@sap/cds")
   let originalI18nDescriptor
 
   beforeEach(() => {
-    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, 'i18n')
+    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, "i18n")
     jest.clearAllMocks()
   })
 
   afterEach(() => {
-    if (originalI18nDescriptor) Object.defineProperty(cds, 'i18n', originalI18nDescriptor)
+    if (originalI18nDescriptor) Object.defineProperty(cds, "i18n", originalI18nDescriptor)
   })
 
   test("Read html file when annotation value starts with ./", () => {
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue('<p>Hello {{buyer}}</p>')
+    readFileSync.mockReturnValue("<p>Hello {{buyer}}</p>")
 
-    const model = makeModel({ "E": makeEventWithHtml('./email.html') })
+    const model = makeModel({ E: makeEventWithHtml("./email.html") })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe('<p>Hello {{buyer}}</p>')
+    expect(type.Templates[0].EmailHtml).toBe("<p>Hello {{buyer}}</p>")
     expect(existsSync).toHaveBeenCalled()
     expect(readFileSync).toHaveBeenCalled()
   })
 
   test("Read html file when annotation value starts with ../", () => {
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue('<p>content</p>')
+    readFileSync.mockReturnValue("<p>content</p>")
 
-    const model = makeModel({ "E": makeEventWithHtml('../templates/email.html') })
+    const model = makeModel({ E: makeEventWithHtml("../templates/email.html") })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe('<p>content</p>')
+    expect(type.Templates[0].EmailHtml).toBe("<p>content</p>")
   })
 
   test("Pass through inline html unchanged (no file read)", () => {
-    const model = makeModel({ "E": makeEventWithHtml('<p>inline</p>') })
+    const model = makeModel({ E: makeEventWithHtml("<p>inline</p>") })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe('<p>inline</p>')
+    expect(type.Templates[0].EmailHtml).toBe("<p>inline</p>")
     expect(existsSync).not.toHaveBeenCalled()
   })
 
   test("Return annotation value as-is when html file not found", () => {
     existsSync.mockReturnValue(false)
 
-    const model = makeModel({ "E": makeEventWithHtml('./missing.html') })
+    const model = makeModel({ E: makeEventWithHtml("./missing.html") })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe('./missing.html')
+    expect(type.Templates[0].EmailHtml).toBe("./missing.html")
     expect(readFileSync).not.toHaveBeenCalled()
   })
 
   test("Resolve html file path relative to the cds source file", () => {
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue('<p>hi</p>')
+    readFileSync.mockReturnValue("<p>hi</p>")
 
-    const model = makeModel({ "E": makeEventWithHtml('./email.html', 'srv/notifications.cds') })
+    const model = makeModel({ E: makeEventWithHtml("./email.html", "srv/notifications.cds") })
     notificationTypesFromModel(model)
 
     const calledPath = existsSync.mock.calls[0][0]
@@ -489,26 +550,38 @@ describe("HTML file resolution", () => {
   })
 
   test("Resolve {i18n>KEY} placeholders inside html file content", () => {
-    Object.defineProperty(cds, 'i18n', {
-      value: { labels: { all: () => ({ en: 'Book Ordered' }), at: (key) => key === 'BOOK_ORDERED_DESCRIPTION' ? 'Book Ordered' : undefined } },
-      configurable: true, writable: true
+    Object.defineProperty(cds, "i18n", {
+      value: {
+        labels: {
+          all: () => ({ en: "Book Ordered" }),
+          at: key => (key === "BOOK_ORDERED_DESCRIPTION" ? "Book Ordered" : undefined)
+        }
+      },
+      configurable: true,
+      writable: true
     })
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue('<h1>{i18n>BOOK_ORDERED_DESCRIPTION}</h1>')
+    readFileSync.mockReturnValue("<h1>{i18n>BOOK_ORDERED_DESCRIPTION}</h1>")
 
-    const model = makeModel({ "E": makeEventWithHtml('./email.html') })
+    const model = makeModel({ E: makeEventWithHtml("./email.html") })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe('<h1>Book Ordered</h1>')
+    expect(type.Templates[0].EmailHtml).toBe("<h1>Book Ordered</h1>")
   })
 
   test("Resolve {i18n>KEY} embedded within inline html string", () => {
-    Object.defineProperty(cds, 'i18n', {
-      value: { labels: { all: () => ({}), at: (key) => key === 'BOOK_ORDERED_SUBTITLE' ? '{{buyer}} ordered {{title}}' : undefined } },
-      configurable: true, writable: true
+    Object.defineProperty(cds, "i18n", {
+      value: {
+        labels: {
+          all: () => ({}),
+          at: key => (key === "BOOK_ORDERED_SUBTITLE" ? "{{buyer}} ordered {{title}}" : undefined)
+        }
+      },
+      configurable: true,
+      writable: true
     })
     const model = makeModel({
-      "E": { kind: "event", name: "E", "@notification.email.html": "<p>{i18n>BOOK_ORDERED_SUBTITLE}</p>" }
+      E: { kind: "event", name: "E", "@notification.email.html": "<p>{i18n>BOOK_ORDERED_SUBTITLE}</p>" }
     })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates[0].EmailHtml).toBe("<p>{{buyer}} ordered {{title}}</p>")
@@ -517,9 +590,9 @@ describe("HTML file resolution", () => {
 
 describe("Element name length validation", () => {
   test("Throw when an element name exceeds 128 characters", () => {
-    const longName = 'a'.repeat(129)
+    const longName = "a".repeat(129)
     const model = makeModel({
-      "E": {
+      E: {
         kind: "event",
         name: "E",
         "@notification": {},
@@ -531,9 +604,9 @@ describe("Element name length validation", () => {
   })
 
   test("No error for element names at exactly 128 characters", () => {
-    const exactName = 'a'.repeat(128)
+    const exactName = "a".repeat(128)
     const model = makeModel({
-      "E": {
+      E: {
         kind: "event",
         name: "E",
         "@notification": {},
@@ -545,7 +618,7 @@ describe("Element name length validation", () => {
 
   test("No error when all element names are within the 128-character limit", () => {
     const model = makeModel({
-      "E": {
+      E: {
         kind: "event",
         name: "E",
         "@notification": {},
@@ -556,10 +629,10 @@ describe("Element name length validation", () => {
   })
 
   test("Report all violating element names in the error message", () => {
-    const b = 'b'.repeat(129)
-    const c = 'c'.repeat(130)
+    const b = "b".repeat(129)
+    const c = "c".repeat(130)
     const model = makeModel({
-      "E": {
+      E: {
         kind: "event",
         name: "E",
         "@notification": {},
@@ -575,7 +648,7 @@ describe("Element name length validation", () => {
   })
 
   test("Use stripped event name in error when event has a namespace prefix", () => {
-    const longName = 'x'.repeat(129)
+    const longName = "x".repeat(129)
     const model = makeModel({
       "My.Namespace.OrderPlaced": {
         kind: "event",
@@ -589,7 +662,7 @@ describe("Element name length validation", () => {
 
   test("No error when event has no elements", () => {
     const model = makeModel({
-      "E": { kind: "event", name: "E", "@notification": {} }
+      E: { kind: "event", name: "E", "@notification": {} }
     })
     expect(() => notificationTypesFromModel(model)).not.toThrow()
   })

--- a/tests/unit/lib/compile.test.js
+++ b/tests/unit/lib/compile.test.js
@@ -1,222 +1,222 @@
-jest.mock("fs", () => ({
-  ...jest.requireActual("fs"),
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
   existsSync: jest.fn(),
   readFileSync: jest.fn()
 }))
 
-const { existsSync, readFileSync } = require("fs")
-const { notificationTypesFromModel } = require("../../../lib/compile")
+const { existsSync, readFileSync } = require('fs')
+const { notificationTypesFromModel } = require('../../../lib/compile')
 
 function makeModel(defs) {
   return { definitions: Object.values(defs) }
 }
 
-function makeEventWithHtml(html, file = "srv/notifications.cds") {
+function makeEventWithHtml(html, file = 'srv/notifications.cds') {
   return {
-    kind: "event",
-    name: "E",
-    "@notification.title": "t",
-    "@notification.email.html": html,
+    kind: 'event',
+    name: 'E',
+    '@notification.title': 't',
+    '@notification.email.html': html,
     $location: { file, line: 1, col: 1 }
   }
 }
 
-describe("Notification Types from Model", () => {
-  test("Return empty array for null/undefined model", () => {
+describe('Notification Types from Model', () => {
+  test('Return empty array for null/undefined model', () => {
     expect(notificationTypesFromModel(null)).toEqual([])
     expect(notificationTypesFromModel(undefined)).toEqual([])
   })
 
-  test("Return empty array when no events have @notification", () => {
+  test('Return empty array when no events have @notification', () => {
     const model = makeModel({
-      MyEntity: { kind: "entity", name: "MyEntity" },
-      PlainEvent: { kind: "event", name: "PlainEvent" }
+      MyEntity: { kind: 'entity', name: 'MyEntity' },
+      PlainEvent: { kind: 'event', name: 'PlainEvent' }
     })
     expect(notificationTypesFromModel(model)).toEqual([])
   })
 
-  test("Handle @notification with no template property", () => {
+  test('Handle @notification with no template property', () => {
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification": {}
+        kind: 'event',
+        name: 'E',
+        '@notification': {}
       }
     })
 
     const [type] = notificationTypesFromModel(model)
-    expect(type.NotificationTypeKey).toBe("E")
+    expect(type.NotificationTypeKey).toBe('E')
     expect(type.Templates[0].TemplateSensitive).toBeUndefined()
-    expect(type.Templates[0].Language).toBe("en")
+    expect(type.Templates[0].Language).toBe('en')
   })
 
-  test("Convert a fully annotated event to a notification type", () => {
+  test('Convert a fully annotated event to a notification type', () => {
     const model = makeModel({
       BookOrderedNotify: {
-        kind: "event",
-        name: "BookOrderedNotify",
-        "@description": "Book Ordered",
-        "@Common.SemanticObject": "Book",
-        "@Common.SemanticObjectAction": "display",
-        "@notification.title": "Book '{{title}}' Ordered",
-        "@notification.publicTitle": "Book Ordered",
-        "@notification.subtitle": "{{buyer}} ordered {{title}}",
-        "@notification.groupedTitle": "Bookshop Updates",
-        "@notification.email.subject": "Your order",
-        "@notification.channels": ["email"]
+        kind: 'event',
+        name: 'BookOrderedNotify',
+        '@description': 'Book Ordered',
+        '@Common.SemanticObject': 'Book',
+        '@Common.SemanticObjectAction': 'display',
+        '@notification.title': "Book '{{title}}' Ordered",
+        '@notification.publicTitle': 'Book Ordered',
+        '@notification.subtitle': '{{buyer}} ordered {{title}}',
+        '@notification.groupedTitle': 'Bookshop Updates',
+        '@notification.email.subject': 'Your order',
+        '@notification.channels': ['email']
       }
     })
 
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.NotificationTypeKey).toBe("BookOrderedNotify")
-    expect(type.NotificationTypeVersion).toBe("1")
-    expect(type.NavigationTargetObject).toBe("Book")
-    expect(type.NavigationTargetAction).toBe("display")
+    expect(type.NotificationTypeKey).toBe('BookOrderedNotify')
+    expect(type.NotificationTypeVersion).toBe('1')
+    expect(type.NavigationTargetObject).toBe('Book')
+    expect(type.NavigationTargetAction).toBe('display')
 
     const tmpl = type.Templates[0]
-    expect(tmpl.Language).toBe("en")
-    expect(tmpl.TemplateLanguage).toBe("mustache")
-    expect(tmpl.Description).toBe("Book Ordered")
+    expect(tmpl.Language).toBe('en')
+    expect(tmpl.TemplateLanguage).toBe('mustache')
+    expect(tmpl.Description).toBe('Book Ordered')
     expect(tmpl.TemplateSensitive).toBe("Book '{{title}}' Ordered")
-    expect(tmpl.TemplatePublic).toBe("Book Ordered")
-    expect(tmpl.Subtitle).toBe("{{buyer}} ordered {{title}}")
-    expect(tmpl.TemplateGrouped).toBe("Bookshop Updates")
-    expect(tmpl.EmailSubject).toBe("Your order")
+    expect(tmpl.TemplatePublic).toBe('Book Ordered')
+    expect(tmpl.Subtitle).toBe('{{buyer}} ordered {{title}}')
+    expect(tmpl.TemplateGrouped).toBe('Bookshop Updates')
+    expect(tmpl.EmailSubject).toBe('Your order')
 
     expect(type.DeliveryChannels).toEqual([
-      { Type: "MAIL", Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: 'MAIL', Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 
-  test("Handle minimal annotation (only @notification present)", () => {
+  test('Handle minimal annotation (only @notification present)', () => {
     const model = makeModel({
       SimpleEvent: {
-        kind: "event",
-        name: "SimpleEvent",
-        "@notification.title": "Hello"
+        kind: 'event',
+        name: 'SimpleEvent',
+        '@notification.title': 'Hello'
       }
     })
 
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.NotificationTypeKey).toBe("SimpleEvent")
-    expect(type.NotificationTypeVersion).toBe("1")
-    expect(type.Templates[0].TemplateSensitive).toBe("Hello")
+    expect(type.NotificationTypeKey).toBe('SimpleEvent')
+    expect(type.NotificationTypeVersion).toBe('1')
+    expect(type.Templates[0].TemplateSensitive).toBe('Hello')
     expect(type.Templates[0].TemplatePublic).toBeUndefined()
     expect(type.NavigationTargetObject).toBeUndefined()
     expect(type.DeliveryChannels).toEqual([
-      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 
-  test("Strip namespace prefix from event name", () => {
+  test('Strip namespace prefix from event name', () => {
     const model = makeModel({
-      "CatalogService.BookOrderedNotify": {
-        kind: "event",
-        name: "CatalogService.BookOrderedNotify",
-        "@notification": { template: { title: "x" } }
+      'CatalogService.BookOrderedNotify': {
+        kind: 'event',
+        name: 'CatalogService.BookOrderedNotify',
+        '@notification': { template: { title: 'x' } }
       }
     })
 
     const [type] = notificationTypesFromModel(model)
-    expect(type.NotificationTypeKey).toBe("BookOrderedNotify")
+    expect(type.NotificationTypeKey).toBe('BookOrderedNotify')
   })
 
   test("Map 'email' string to MAIL channel type", () => {
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification.title": "t",
-        "@notification.channels": ["email"]
+        kind: 'event',
+        name: 'E',
+        '@notification.title': 't',
+        '@notification.channels': ['email']
       }
     })
 
     const [type] = notificationTypesFromModel(model)
-    expect(type.DeliveryChannels[0].Type).toBe("MAIL")
+    expect(type.DeliveryChannels[0].Type).toBe('MAIL')
     expect(type.DeliveryChannels[0].Enabled).toBe(true)
   })
 
-  test("Unwrap plain string enum values in channels", () => {
+  test('Unwrap plain string enum values in channels', () => {
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification.title": "t",
-        "@notification.channels": ["workzone"]
+        kind: 'event',
+        name: 'E',
+        '@notification.title': 't',
+        '@notification.channels': ['workzone']
       }
     })
 
     const [type] = notificationTypesFromModel(model)
-    expect(type.DeliveryChannels[0].Type).toBe("WEB")
+    expect(type.DeliveryChannels[0].Type).toBe('WEB')
     expect(type.DeliveryChannels[0].Enabled).toBe(true)
   })
 
-  test("Return all events with @notification from a mixed model", () => {
+  test('Return all events with @notification from a mixed model', () => {
     const model = makeModel({
-      A: { kind: "event", name: "A", "@notification": { template: { title: "a" } } },
-      B: { kind: "entity", name: "B" },
-      C: { kind: "event", name: "C", "@notification": { template: { title: "c" } } },
-      D: { kind: "event", name: "D" }
+      A: { kind: 'event', name: 'A', '@notification': { template: { title: 'a' } } },
+      B: { kind: 'entity', name: 'B' },
+      C: { kind: 'event', name: 'C', '@notification': { template: { title: 'c' } } },
+      D: { kind: 'event', name: 'D' }
     })
 
     const types = notificationTypesFromModel(model)
     expect(types).toHaveLength(2)
-    expect(types.map(t => t.NotificationTypeKey)).toEqual(expect.arrayContaining(["A", "C"]))
+    expect(types.map(t => t.NotificationTypeKey)).toEqual(expect.arrayContaining(['A', 'C']))
   })
 
-  test("Always include Enabled, DefaultPreference, EditablePreference as true for plain enum channels", () => {
+  test('Always include Enabled, DefaultPreference, EditablePreference as true for plain enum channels', () => {
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification.title": "t",
-        "@notification.channels": ["email"]
+        kind: 'event',
+        name: 'E',
+        '@notification.title': 't',
+        '@notification.channels': ['email']
       }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels[0]).toEqual({
-      Type: "MAIL",
+      Type: 'MAIL',
       Enabled: true,
       DefaultPreference: true,
       EditablePreference: true
     })
   })
 
-  test("Support object form with just channel name", () => {
+  test('Support object form with just channel name', () => {
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification.title": "t",
-        "@notification.channels": ["email", { channel: "workzone" }]
+        kind: 'event',
+        name: 'E',
+        '@notification.title': 't',
+        '@notification.channels': ['email', { channel: 'workzone' }]
       }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels[0]).toEqual({
-      Type: "MAIL",
+      Type: 'MAIL',
       Enabled: true,
       DefaultPreference: true,
       EditablePreference: true
     })
     expect(type.DeliveryChannels[1]).toEqual({
-      Type: "WEB",
+      Type: 'WEB',
       Enabled: true,
       DefaultPreference: true,
       EditablePreference: true
     })
   })
 
-  test("Skip channel entry when value is not a string", () => {
+  test('Skip channel entry when value is not a string', () => {
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification.title": "t",
-        "@notification.channels": [null]
+        kind: 'event',
+        name: 'E',
+        '@notification.title': 't',
+        '@notification.channels': [null]
       }
     })
 
@@ -225,179 +225,179 @@ describe("Notification Types from Model", () => {
   })
 })
 
-describe("i18n integration", () => {
-  const cds = require("@sap/cds")
+describe('i18n integration', () => {
+  const cds = require('@sap/cds')
   let originalI18nDescriptor
 
   beforeEach(() => {
-    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, "i18n")
+    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, 'i18n')
   })
 
   afterEach(() => {
     jest.restoreAllMocks()
-    if (originalI18nDescriptor) Object.defineProperty(cds, "i18n", originalI18nDescriptor)
+    if (originalI18nDescriptor) Object.defineProperty(cds, 'i18n', originalI18nDescriptor)
   })
 
   function mockLabels(allImpl, atImpl) {
-    jest.spyOn(cds.i18n.labels, "all").mockImplementation(allImpl)
-    jest.spyOn(cds.i18n.labels, "at").mockImplementation(atImpl)
+    jest.spyOn(cds.i18n.labels, 'all').mockImplementation(allImpl)
+    jest.spyOn(cds.i18n.labels, 'at').mockImplementation(atImpl)
   }
 
-  test("Fall back to single English template when no i18n files found", () => {
+  test('Fall back to single English template when no i18n files found', () => {
     mockLabels(
       () => ({}),
       () => undefined
     )
 
     const model = makeModel({
-      E: { kind: "event", name: "E", "@notification.title": "Hello" }
+      E: { kind: 'event', name: 'E', '@notification.title': 'Hello' }
     })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(1)
-    expect(type.Templates[0].Language).toBe("en")
-    expect(type.Templates[0].TemplateSensitive).toBe("Hello")
+    expect(type.Templates[0].Language).toBe('en')
+    expect(type.Templates[0].TemplateSensitive).toBe('Hello')
   })
 
-  test("Generate one template per available locale from i18n files", () => {
+  test('Generate one template per available locale from i18n files', () => {
     mockLabels(
-      () => ({ en: "Hello", de: "Hallo" }),
-      (_, locale) => (locale === "de" ? "Hallo" : "Hello")
+      () => ({ en: 'Hello', de: 'Hallo' }),
+      (_, locale) => (locale === 'de' ? 'Hallo' : 'Hello')
     )
 
-    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
+    const model = makeModel({ E: { kind: 'event', name: 'E', '@notification.title': '{i18n>TITLE}' } })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(2)
-    expect(type.Templates.find(t => t.Language === "en").TemplateSensitive).toBe("Hello")
-    expect(type.Templates.find(t => t.Language === "de").TemplateSensitive).toBe("Hallo")
+    expect(type.Templates.find(t => t.Language === 'en').TemplateSensitive).toBe('Hello')
+    expect(type.Templates.find(t => t.Language === 'de').TemplateSensitive).toBe('Hallo')
   })
 
-  test("Resolve {i18n>KEY} references from i18n.properties file", () => {
+  test('Resolve {i18n>KEY} references from i18n.properties file', () => {
     mockLabels(
-      () => ({ en: "Book Ordered" }),
-      () => "Book Ordered"
+      () => ({ en: 'Book Ordered' }),
+      () => 'Book Ordered'
     )
 
-    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>BOOK_ORDERED_TITLE}" } })
+    const model = makeModel({ E: { kind: 'event', name: 'E', '@notification.title': '{i18n>BOOK_ORDERED_TITLE}' } })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].TemplateSensitive).toBe("Book Ordered")
+    expect(type.Templates[0].TemplateSensitive).toBe('Book Ordered')
   })
 
-  test("Resolve {i18n>KEY} to locale-specific translation when available", () => {
+  test('Resolve {i18n>KEY} to locale-specific translation when available', () => {
     mockLabels(
-      () => ({ en: "Book Ordered", de: "Buch bestellt" }),
-      (_, locale) => (locale === "de" ? "Buch bestellt" : "Book Ordered")
+      () => ({ en: 'Book Ordered', de: 'Buch bestellt' }),
+      (_, locale) => (locale === 'de' ? 'Buch bestellt' : 'Book Ordered')
     )
 
-    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>BOOK_ORDERED_TITLE}" } })
+    const model = makeModel({ E: { kind: 'event', name: 'E', '@notification.title': '{i18n>BOOK_ORDERED_TITLE}' } })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates.find(t => t.Language === "en").TemplateSensitive).toBe("Book Ordered")
-    expect(type.Templates.find(t => t.Language === "de").TemplateSensitive).toBe("Buch bestellt")
+    expect(type.Templates.find(t => t.Language === 'en').TemplateSensitive).toBe('Book Ordered')
+    expect(type.Templates.find(t => t.Language === 'de').TemplateSensitive).toBe('Buch bestellt')
   })
 
-  test("Fall back to raw value when i18n key not found in any locale", () => {
+  test('Fall back to raw value when i18n key not found in any locale', () => {
     mockLabels(
       () => ({}),
       () => undefined
     )
 
     const model = makeModel({
-      E: { kind: "event", name: "E", "@notification.title": "{i18n>MISSING_KEY}" }
+      E: { kind: 'event', name: 'E', '@notification.title': '{i18n>MISSING_KEY}' }
     })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].TemplateSensitive).toBe("{i18n>MISSING_KEY}")
+    expect(type.Templates[0].TemplateSensitive).toBe('{i18n>MISSING_KEY}')
   })
 
-  test("Pass plain strings through i18n unchanged", () => {
+  test('Pass plain strings through i18n unchanged', () => {
     mockLabels(
       () => ({}),
       () => undefined
     )
 
     const model = makeModel({
-      E: { kind: "event", name: "E", "@notification.title": "Plain Title" }
+      E: { kind: 'event', name: 'E', '@notification.title': 'Plain Title' }
     })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].TemplateSensitive).toBe("Plain Title")
+    expect(type.Templates[0].TemplateSensitive).toBe('Plain Title')
   })
 
-  test("Resolve {i18n>KEY} in subtitle field", () => {
+  test('Resolve {i18n>KEY} in subtitle field', () => {
     mockLabels(
-      () => ({ en: "Resolved Subtitle" }),
-      () => "Resolved Subtitle"
+      () => ({ en: 'Resolved Subtitle' }),
+      () => 'Resolved Subtitle'
     )
 
     const model = makeModel({
-      E: { kind: "event", name: "E", "@notification.title": "t", "@notification.subtitle": "{i18n>SUBTITLE_KEY}" }
+      E: { kind: 'event', name: 'E', '@notification.title': 't', '@notification.subtitle': '{i18n>SUBTITLE_KEY}' }
     })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].Subtitle).toBe("Resolved Subtitle")
+    expect(type.Templates[0].Subtitle).toBe('Resolved Subtitle')
   })
 
-  test("Exclude locale when none of its keys differ from English", () => {
+  test('Exclude locale when none of its keys differ from English', () => {
     mockLabels(
-      () => ({ en: "Hello" }),
-      () => "Hello"
+      () => ({ en: 'Hello' }),
+      () => 'Hello'
     )
 
-    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
+    const model = makeModel({ E: { kind: 'event', name: 'E', '@notification.title': '{i18n>TITLE}' } })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(1)
-    expect(type.Templates[0].Language).toBe("en")
+    expect(type.Templates[0].Language).toBe('en')
   })
 
-  test("Exclude locale when its translation is identical to English", () => {
+  test('Exclude locale when its translation is identical to English', () => {
     mockLabels(
-      () => ({ en: "Hello", de: "Hello" }),
-      () => "Hello"
+      () => ({ en: 'Hello', de: 'Hello' }),
+      () => 'Hello'
     )
 
-    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
+    const model = makeModel({ E: { kind: 'event', name: 'E', '@notification.title': '{i18n>TITLE}' } })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(1)
-    expect(type.Templates[0].Language).toBe("en")
+    expect(type.Templates[0].Language).toBe('en')
   })
 
-  test("Include locale only when at least one key differs from English", () => {
+  test('Include locale only when at least one key differs from English', () => {
     mockLabels(
-      key => (key === "TITLE" ? { en: "Hello", de: "Hallo" } : { en: "Same", de: "Same" }),
-      (key, locale) => (key === "TITLE" ? (locale === "de" ? "Hallo" : "Hello") : "Same")
+      key => (key === 'TITLE' ? { en: 'Hello', de: 'Hallo' } : { en: 'Same', de: 'Same' }),
+      (key, locale) => (key === 'TITLE' ? (locale === 'de' ? 'Hallo' : 'Hello') : 'Same')
     )
 
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification.title": "{i18n>TITLE}",
-        "@notification.subtitle": "{i18n>SUBTITLE}"
+        kind: 'event',
+        name: 'E',
+        '@notification.title': '{i18n>TITLE}',
+        '@notification.subtitle': '{i18n>SUBTITLE}'
       }
     })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(2)
-    expect(type.Templates.find(t => t.Language === "de").TemplateSensitive).toBe("Hallo")
-    expect(type.Templates.find(t => t.Language === "de").Subtitle).toBe("Same")
+    expect(type.Templates.find(t => t.Language === 'de').TemplateSensitive).toBe('Hallo')
+    expect(type.Templates.find(t => t.Language === 'de').Subtitle).toBe('Same')
   })
 
-  test("Two events with same locale files get independent template sets", () => {
+  test('Two events with same locale files get independent template sets', () => {
     mockLabels(
-      key => (key === "A_TITLE" ? { en: "A in English", de: "A auf Deutsch" } : { en: "B in English" }),
-      (key, locale) => (key === "A_TITLE" ? (locale === "de" ? "A auf Deutsch" : "A in English") : "B in English")
+      key => (key === 'A_TITLE' ? { en: 'A in English', de: 'A auf Deutsch' } : { en: 'B in English' }),
+      (key, locale) => (key === 'A_TITLE' ? (locale === 'de' ? 'A auf Deutsch' : 'A in English') : 'B in English')
     )
 
     const model = makeModel({
-      A: { kind: "event", name: "A", "@notification.title": "{i18n>A_TITLE}" },
-      B: { kind: "event", name: "B", "@notification.title": "{i18n>B_TITLE}" }
+      A: { kind: 'event', name: 'A', '@notification.title': '{i18n>A_TITLE}' },
+      B: { kind: 'event', name: 'B', '@notification.title': '{i18n>B_TITLE}' }
     })
     const [typeA, typeB] = notificationTypesFromModel(model)
     expect(typeA.Templates).toHaveLength(2)
     expect(typeB.Templates).toHaveLength(1)
   })
 
-  test("Resolve {i18n>KEY} in subtitle field via Object.defineProperty", () => {
-    Object.defineProperty(cds, "i18n", {
+  test('Resolve {i18n>KEY} in subtitle field via Object.defineProperty', () => {
+    Object.defineProperty(cds, 'i18n', {
       value: {
         labels: {
           all: () => ({}),
-          at: key => (key === "BOOK_ORDERED_SUBTITLE" ? "{{buyer}} ordered {{title}}" : undefined)
+          at: key => (key === 'BOOK_ORDERED_SUBTITLE' ? '{{buyer}} ordered {{title}}' : undefined)
         }
       },
       configurable: true,
@@ -405,19 +405,19 @@ describe("i18n integration", () => {
     })
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification.title": "t",
-        "@notification.subtitle": "{i18n>BOOK_ORDERED_SUBTITLE}"
+        kind: 'event',
+        name: 'E',
+        '@notification.title': 't',
+        '@notification.subtitle': '{i18n>BOOK_ORDERED_SUBTITLE}'
       }
     })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].Subtitle).toBe("{{buyer}} ordered {{title}}")
+    expect(type.Templates[0].Subtitle).toBe('{{buyer}} ordered {{title}}')
   })
 })
 
-describe("default channels config", () => {
-  const cds = require("@sap/cds")
+describe('default channels config', () => {
+  const cds = require('@sap/cds')
 
   afterEach(() => {
     if (cds.env.requires?.notifications) {
@@ -425,221 +425,221 @@ describe("default channels config", () => {
     }
   })
 
-  test("Add configured default channels when no channels annotated", () => {
+  test('Add configured default channels when no channels annotated', () => {
     cds.env.requires.notifications ??= {}
-    cds.env.requires.notifications.channels = ["email"]
+    cds.env.requires.notifications.channels = ['email']
 
     const model = makeModel({
-      E: { kind: "event", name: "E", "@notification.title": "t" }
+      E: { kind: 'event', name: 'E', '@notification.title': 't' }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels).toEqual([
-      { Type: "MAIL", Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: 'MAIL', Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 
-  test("Support multiple default channels", () => {
+  test('Support multiple default channels', () => {
     cds.env.requires.notifications ??= {}
-    cds.env.requires.notifications.channels = ["email", "workzone"]
+    cds.env.requires.notifications.channels = ['email', 'workzone']
 
     const model = makeModel({
-      E: { kind: "event", name: "E", "@notification.title": "t" }
+      E: { kind: 'event', name: 'E', '@notification.title': 't' }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels).toEqual([
-      { Type: "MAIL", Enabled: true, DefaultPreference: true, EditablePreference: true },
-      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: 'MAIL', Enabled: true, DefaultPreference: true, EditablePreference: true },
+      { Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 
-  test("Do not override explicit channels annotation with default channels", () => {
+  test('Do not override explicit channels annotation with default channels', () => {
     cds.env.requires.notifications ??= {}
-    cds.env.requires.notifications.channels = ["email"]
+    cds.env.requires.notifications.channels = ['email']
 
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification.title": "t",
-        "@notification.channels": ["workzone"]
+        kind: 'event',
+        name: 'E',
+        '@notification.title': 't',
+        '@notification.channels': ['workzone']
       }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels).toEqual([
-      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 
-  test("Default to workzone channel when channels config is not set", () => {
+  test('Default to workzone channel when channels config is not set', () => {
     const model = makeModel({
-      E: { kind: "event", name: "E", "@notification.title": "t" }
+      E: { kind: 'event', name: 'E', '@notification.title': 't' }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels).toEqual([
-      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 })
 
-describe("HTML file resolution", () => {
-  const cds = require("@sap/cds")
+describe('HTML file resolution', () => {
+  const cds = require('@sap/cds')
   let originalI18nDescriptor
 
   beforeEach(() => {
-    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, "i18n")
+    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, 'i18n')
     jest.clearAllMocks()
   })
 
   afterEach(() => {
-    if (originalI18nDescriptor) Object.defineProperty(cds, "i18n", originalI18nDescriptor)
+    if (originalI18nDescriptor) Object.defineProperty(cds, 'i18n', originalI18nDescriptor)
   })
 
-  test("Read html file when annotation value starts with ./", () => {
+  test('Read html file when annotation value starts with ./', () => {
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue("<p>Hello {{buyer}}</p>")
+    readFileSync.mockReturnValue('<p>Hello {{buyer}}</p>')
 
-    const model = makeModel({ E: makeEventWithHtml("./email.html") })
+    const model = makeModel({ E: makeEventWithHtml('./email.html') })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe("<p>Hello {{buyer}}</p>")
+    expect(type.Templates[0].EmailHtml).toBe('<p>Hello {{buyer}}</p>')
     expect(existsSync).toHaveBeenCalled()
     expect(readFileSync).toHaveBeenCalled()
   })
 
-  test("Read html file when annotation value starts with ../", () => {
+  test('Read html file when annotation value starts with ../', () => {
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue("<p>content</p>")
+    readFileSync.mockReturnValue('<p>content</p>')
 
-    const model = makeModel({ E: makeEventWithHtml("../templates/email.html") })
+    const model = makeModel({ E: makeEventWithHtml('../templates/email.html') })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe("<p>content</p>")
+    expect(type.Templates[0].EmailHtml).toBe('<p>content</p>')
   })
 
-  test("Pass through inline html unchanged (no file read)", () => {
-    const model = makeModel({ E: makeEventWithHtml("<p>inline</p>") })
+  test('Pass through inline html unchanged (no file read)', () => {
+    const model = makeModel({ E: makeEventWithHtml('<p>inline</p>') })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe("<p>inline</p>")
+    expect(type.Templates[0].EmailHtml).toBe('<p>inline</p>')
     expect(existsSync).not.toHaveBeenCalled()
   })
 
-  test("Return annotation value as-is when html file not found", () => {
+  test('Return annotation value as-is when html file not found', () => {
     existsSync.mockReturnValue(false)
 
-    const model = makeModel({ E: makeEventWithHtml("./missing.html") })
+    const model = makeModel({ E: makeEventWithHtml('./missing.html') })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe("./missing.html")
+    expect(type.Templates[0].EmailHtml).toBe('./missing.html')
     expect(readFileSync).not.toHaveBeenCalled()
   })
 
-  test("Resolve html file path relative to the cds source file", () => {
+  test('Resolve html file path relative to the cds source file', () => {
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue("<p>hi</p>")
+    readFileSync.mockReturnValue('<p>hi</p>')
 
-    const model = makeModel({ E: makeEventWithHtml("./email.html", "srv/notifications.cds") })
+    const model = makeModel({ E: makeEventWithHtml('./email.html', 'srv/notifications.cds') })
     notificationTypesFromModel(model)
 
     const calledPath = existsSync.mock.calls[0][0]
     expect(calledPath).toMatch(/srv[/\\]email\.html$/)
   })
 
-  test("Resolve {i18n>KEY} placeholders inside html file content", () => {
-    Object.defineProperty(cds, "i18n", {
+  test('Resolve {i18n>KEY} placeholders inside html file content', () => {
+    Object.defineProperty(cds, 'i18n', {
       value: {
         labels: {
-          all: () => ({ en: "Book Ordered" }),
-          at: key => (key === "BOOK_ORDERED_DESCRIPTION" ? "Book Ordered" : undefined)
+          all: () => ({ en: 'Book Ordered' }),
+          at: key => (key === 'BOOK_ORDERED_DESCRIPTION' ? 'Book Ordered' : undefined)
         }
       },
       configurable: true,
       writable: true
     })
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue("<h1>{i18n>BOOK_ORDERED_DESCRIPTION}</h1>")
+    readFileSync.mockReturnValue('<h1>{i18n>BOOK_ORDERED_DESCRIPTION}</h1>')
 
-    const model = makeModel({ E: makeEventWithHtml("./email.html") })
+    const model = makeModel({ E: makeEventWithHtml('./email.html') })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe("<h1>Book Ordered</h1>")
+    expect(type.Templates[0].EmailHtml).toBe('<h1>Book Ordered</h1>')
   })
 
-  test("Resolve {i18n>KEY} embedded within inline html string", () => {
-    Object.defineProperty(cds, "i18n", {
+  test('Resolve {i18n>KEY} embedded within inline html string', () => {
+    Object.defineProperty(cds, 'i18n', {
       value: {
         labels: {
           all: () => ({}),
-          at: key => (key === "BOOK_ORDERED_SUBTITLE" ? "{{buyer}} ordered {{title}}" : undefined)
+          at: key => (key === 'BOOK_ORDERED_SUBTITLE' ? '{{buyer}} ordered {{title}}' : undefined)
         }
       },
       configurable: true,
       writable: true
     })
     const model = makeModel({
-      E: { kind: "event", name: "E", "@notification.email.html": "<p>{i18n>BOOK_ORDERED_SUBTITLE}</p>" }
+      E: { kind: 'event', name: 'E', '@notification.email.html': '<p>{i18n>BOOK_ORDERED_SUBTITLE}</p>' }
     })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].EmailHtml).toBe("<p>{{buyer}} ordered {{title}}</p>")
+    expect(type.Templates[0].EmailHtml).toBe('<p>{{buyer}} ordered {{title}}</p>')
   })
 })
 
-describe("Element name length validation", () => {
-  test("Throw when an element name exceeds 128 characters", () => {
-    const longName = "a".repeat(129)
+describe('Element name length validation', () => {
+  test('Throw when an element name exceeds 128 characters', () => {
+    const longName = 'a'.repeat(129)
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification": {},
-        elements: { [longName]: { type: "cds.String" } }
+        kind: 'event',
+        name: 'E',
+        '@notification': {},
+        elements: { [longName]: { type: 'cds.String' } }
       }
     })
     expect(() => notificationTypesFromModel(model)).toThrow(longName)
     expect(() => notificationTypesFromModel(model)).toThrow("'E'")
   })
 
-  test("No error for element names at exactly 128 characters", () => {
-    const exactName = "a".repeat(128)
+  test('No error for element names at exactly 128 characters', () => {
+    const exactName = 'a'.repeat(128)
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification": {},
-        elements: { [exactName]: { type: "cds.String" } }
+        kind: 'event',
+        name: 'E',
+        '@notification': {},
+        elements: { [exactName]: { type: 'cds.String' } }
       }
     })
     expect(() => notificationTypesFromModel(model)).not.toThrow()
   })
 
-  test("No error when all element names are within the 128-character limit", () => {
+  test('No error when all element names are within the 128-character limit', () => {
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification": {},
-        elements: { title: { type: "cds.String" }, buyer: { type: "cds.String" } }
+        kind: 'event',
+        name: 'E',
+        '@notification': {},
+        elements: { title: { type: 'cds.String' }, buyer: { type: 'cds.String' } }
       }
     })
     expect(() => notificationTypesFromModel(model)).not.toThrow()
   })
 
-  test("Report all violating element names in the error message", () => {
-    const b = "b".repeat(129)
-    const c = "c".repeat(130)
+  test('Report all violating element names in the error message', () => {
+    const b = 'b'.repeat(129)
+    const c = 'c'.repeat(130)
     const model = makeModel({
       E: {
-        kind: "event",
-        name: "E",
-        "@notification": {},
+        kind: 'event',
+        name: 'E',
+        '@notification': {},
         elements: {
-          valid: { type: "cds.String" },
-          [b]: { type: "cds.String" },
-          [c]: { type: "cds.String" }
+          valid: { type: 'cds.String' },
+          [b]: { type: 'cds.String' },
+          [c]: { type: 'cds.String' }
         }
       }
     })
@@ -647,22 +647,22 @@ describe("Element name length validation", () => {
     expect(() => notificationTypesFromModel(model)).toThrow(c)
   })
 
-  test("Use stripped event name in error when event has a namespace prefix", () => {
-    const longName = "x".repeat(129)
+  test('Use stripped event name in error when event has a namespace prefix', () => {
+    const longName = 'x'.repeat(129)
     const model = makeModel({
-      "My.Namespace.OrderPlaced": {
-        kind: "event",
-        name: "My.Namespace.OrderPlaced",
-        "@notification": {},
-        elements: { [longName]: { type: "cds.String" } }
+      'My.Namespace.OrderPlaced': {
+        kind: 'event',
+        name: 'My.Namespace.OrderPlaced',
+        '@notification': {},
+        elements: { [longName]: { type: 'cds.String' } }
       }
     })
     expect(() => notificationTypesFromModel(model)).toThrow("'OrderPlaced'")
   })
 
-  test("No error when event has no elements", () => {
+  test('No error when event has no elements', () => {
     const model = makeModel({
-      E: { kind: "event", name: "E", "@notification": {} }
+      E: { kind: 'event', name: 'E', '@notification': {} }
     })
     expect(() => notificationTypesFromModel(model)).not.toThrow()
   })

--- a/tests/unit/lib/compile.test.js
+++ b/tests/unit/lib/compile.test.js
@@ -1,222 +1,222 @@
-jest.mock('fs', () => ({
-  ...jest.requireActual('fs'),
+jest.mock("fs", () => ({
+  ...jest.requireActual("fs"),
   existsSync: jest.fn(),
   readFileSync: jest.fn()
 }))
 
-const { existsSync, readFileSync } = require('fs')
-const { notificationTypesFromModel } = require('../../../lib/compile')
+const { existsSync, readFileSync } = require("fs")
+const { notificationTypesFromModel } = require("../../../lib/compile")
 
 function makeModel(defs) {
   return { definitions: Object.values(defs) }
 }
 
-function makeEventWithHtml(html, file = 'srv/notifications.cds') {
+function makeEventWithHtml(html, file = "srv/notifications.cds") {
   return {
-    kind: 'event',
-    name: 'E',
-    '@notification.title': 't',
-    '@notification.email.html': html,
+    kind: "event",
+    name: "E",
+    "@notification.title": "t",
+    "@notification.email.html": html,
     $location: { file, line: 1, col: 1 }
   }
 }
 
-describe('Notification Types from Model', () => {
-  test('Return empty array for null/undefined model', () => {
+describe("Notification Types from Model", () => {
+  test("Return empty array for null/undefined model", () => {
     expect(notificationTypesFromModel(null)).toEqual([])
     expect(notificationTypesFromModel(undefined)).toEqual([])
   })
 
-  test('Return empty array when no events have @notification', () => {
+  test("Return empty array when no events have @notification", () => {
     const model = makeModel({
-      MyEntity: { kind: 'entity', name: 'MyEntity' },
-      PlainEvent: { kind: 'event', name: 'PlainEvent' }
+      MyEntity: { kind: "entity", name: "MyEntity" },
+      PlainEvent: { kind: "event", name: "PlainEvent" }
     })
     expect(notificationTypesFromModel(model)).toEqual([])
   })
 
-  test('Handle @notification with no template property', () => {
+  test("Handle @notification with no template property", () => {
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification': {}
+        kind: "event",
+        name: "E",
+        "@notification": {}
       }
     })
 
     const [type] = notificationTypesFromModel(model)
-    expect(type.NotificationTypeKey).toBe('E')
+    expect(type.NotificationTypeKey).toBe("E")
     expect(type.Templates[0].TemplateSensitive).toBeUndefined()
-    expect(type.Templates[0].Language).toBe('en')
+    expect(type.Templates[0].Language).toBe("en")
   })
 
-  test('Convert a fully annotated event to a notification type', () => {
+  test("Convert a fully annotated event to a notification type", () => {
     const model = makeModel({
       BookOrderedNotify: {
-        kind: 'event',
-        name: 'BookOrderedNotify',
-        '@description': 'Book Ordered',
-        '@Common.SemanticObject': 'Book',
-        '@Common.SemanticObjectAction': 'display',
-        '@notification.title': "Book '{{title}}' Ordered",
-        '@notification.publicTitle': 'Book Ordered',
-        '@notification.subtitle': '{{buyer}} ordered {{title}}',
-        '@notification.groupedTitle': 'Bookshop Updates',
-        '@notification.email.subject': 'Your order',
-        '@notification.channels': ['email']
+        kind: "event",
+        name: "BookOrderedNotify",
+        "@description": "Book Ordered",
+        "@Common.SemanticObject": "Book",
+        "@Common.SemanticObjectAction": "display",
+        "@notification.title": "Book '{{title}}' Ordered",
+        "@notification.publicTitle": "Book Ordered",
+        "@notification.subtitle": "{{buyer}} ordered {{title}}",
+        "@notification.groupedTitle": "Bookshop Updates",
+        "@notification.email.subject": "Your order",
+        "@notification.channels": ["email"]
       }
     })
 
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.NotificationTypeKey).toBe('BookOrderedNotify')
-    expect(type.NotificationTypeVersion).toBe('1')
-    expect(type.NavigationTargetObject).toBe('Book')
-    expect(type.NavigationTargetAction).toBe('display')
+    expect(type.NotificationTypeKey).toBe("BookOrderedNotify")
+    expect(type.NotificationTypeVersion).toBe("1")
+    expect(type.NavigationTargetObject).toBe("Book")
+    expect(type.NavigationTargetAction).toBe("display")
 
     const tmpl = type.Templates[0]
-    expect(tmpl.Language).toBe('en')
-    expect(tmpl.TemplateLanguage).toBe('mustache')
-    expect(tmpl.Description).toBe('Book Ordered')
+    expect(tmpl.Language).toBe("en")
+    expect(tmpl.TemplateLanguage).toBe("mustache")
+    expect(tmpl.Description).toBe("Book Ordered")
     expect(tmpl.TemplateSensitive).toBe("Book '{{title}}' Ordered")
-    expect(tmpl.TemplatePublic).toBe('Book Ordered')
-    expect(tmpl.Subtitle).toBe('{{buyer}} ordered {{title}}')
-    expect(tmpl.TemplateGrouped).toBe('Bookshop Updates')
-    expect(tmpl.EmailSubject).toBe('Your order')
+    expect(tmpl.TemplatePublic).toBe("Book Ordered")
+    expect(tmpl.Subtitle).toBe("{{buyer}} ordered {{title}}")
+    expect(tmpl.TemplateGrouped).toBe("Bookshop Updates")
+    expect(tmpl.EmailSubject).toBe("Your order")
 
     expect(type.DeliveryChannels).toEqual([
-      { Type: 'MAIL', Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: "MAIL", Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 
-  test('Handle minimal annotation (only @notification present)', () => {
+  test("Handle minimal annotation (only @notification present)", () => {
     const model = makeModel({
       SimpleEvent: {
-        kind: 'event',
-        name: 'SimpleEvent',
-        '@notification.title': 'Hello'
+        kind: "event",
+        name: "SimpleEvent",
+        "@notification.title": "Hello"
       }
     })
 
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.NotificationTypeKey).toBe('SimpleEvent')
-    expect(type.NotificationTypeVersion).toBe('1')
-    expect(type.Templates[0].TemplateSensitive).toBe('Hello')
+    expect(type.NotificationTypeKey).toBe("SimpleEvent")
+    expect(type.NotificationTypeVersion).toBe("1")
+    expect(type.Templates[0].TemplateSensitive).toBe("Hello")
     expect(type.Templates[0].TemplatePublic).toBeUndefined()
     expect(type.NavigationTargetObject).toBeUndefined()
     expect(type.DeliveryChannels).toEqual([
-      { Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 
-  test('Strip namespace prefix from event name', () => {
+  test("Strip namespace prefix from event name", () => {
     const model = makeModel({
-      'CatalogService.BookOrderedNotify': {
-        kind: 'event',
-        name: 'CatalogService.BookOrderedNotify',
-        '@notification': { template: { title: 'x' } }
+      "CatalogService.BookOrderedNotify": {
+        kind: "event",
+        name: "CatalogService.BookOrderedNotify",
+        "@notification": { template: { title: "x" } }
       }
     })
 
     const [type] = notificationTypesFromModel(model)
-    expect(type.NotificationTypeKey).toBe('BookOrderedNotify')
+    expect(type.NotificationTypeKey).toBe("BookOrderedNotify")
   })
 
   test("Map 'email' string to MAIL channel type", () => {
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification.title': 't',
-        '@notification.channels': ['email']
+        kind: "event",
+        name: "E",
+        "@notification.title": "t",
+        "@notification.channels": ["email"]
       }
     })
 
     const [type] = notificationTypesFromModel(model)
-    expect(type.DeliveryChannels[0].Type).toBe('MAIL')
+    expect(type.DeliveryChannels[0].Type).toBe("MAIL")
     expect(type.DeliveryChannels[0].Enabled).toBe(true)
   })
 
-  test('Unwrap plain string enum values in channels', () => {
+  test("Unwrap plain string enum values in channels", () => {
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification.title': 't',
-        '@notification.channels': ['workzone']
+        kind: "event",
+        name: "E",
+        "@notification.title": "t",
+        "@notification.channels": ["workzone"]
       }
     })
 
     const [type] = notificationTypesFromModel(model)
-    expect(type.DeliveryChannels[0].Type).toBe('WEB')
+    expect(type.DeliveryChannels[0].Type).toBe("WEB")
     expect(type.DeliveryChannels[0].Enabled).toBe(true)
   })
 
-  test('Return all events with @notification from a mixed model', () => {
+  test("Return all events with @notification from a mixed model", () => {
     const model = makeModel({
-      A: { kind: 'event', name: 'A', '@notification': { template: { title: 'a' } } },
-      B: { kind: 'entity', name: 'B' },
-      C: { kind: 'event', name: 'C', '@notification': { template: { title: 'c' } } },
-      D: { kind: 'event', name: 'D' }
+      A: { kind: "event", name: "A", "@notification": { template: { title: "a" } } },
+      B: { kind: "entity", name: "B" },
+      C: { kind: "event", name: "C", "@notification": { template: { title: "c" } } },
+      D: { kind: "event", name: "D" }
     })
 
     const types = notificationTypesFromModel(model)
     expect(types).toHaveLength(2)
-    expect(types.map(t => t.NotificationTypeKey)).toEqual(expect.arrayContaining(['A', 'C']))
+    expect(types.map(t => t.NotificationTypeKey)).toEqual(expect.arrayContaining(["A", "C"]))
   })
 
-  test('Always include Enabled, DefaultPreference, EditablePreference as true for plain enum channels', () => {
+  test("Always include Enabled, DefaultPreference, EditablePreference as true for plain enum channels", () => {
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification.title': 't',
-        '@notification.channels': ['email']
+        kind: "event",
+        name: "E",
+        "@notification.title": "t",
+        "@notification.channels": ["email"]
       }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels[0]).toEqual({
-      Type: 'MAIL',
+      Type: "MAIL",
       Enabled: true,
       DefaultPreference: true,
       EditablePreference: true
     })
   })
 
-  test('Support object form with just channel name', () => {
+  test("Support object form with just channel name", () => {
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification.title': 't',
-        '@notification.channels': ['email', { channel: 'workzone' }]
+        kind: "event",
+        name: "E",
+        "@notification.title": "t",
+        "@notification.channels": ["email", { channel: "workzone" }]
       }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels[0]).toEqual({
-      Type: 'MAIL',
+      Type: "MAIL",
       Enabled: true,
       DefaultPreference: true,
       EditablePreference: true
     })
     expect(type.DeliveryChannels[1]).toEqual({
-      Type: 'WEB',
+      Type: "WEB",
       Enabled: true,
       DefaultPreference: true,
       EditablePreference: true
     })
   })
 
-  test('Skip channel entry when value is not a string', () => {
+  test("Skip channel entry when value is not a string", () => {
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification.title': 't',
-        '@notification.channels': [null]
+        kind: "event",
+        name: "E",
+        "@notification.title": "t",
+        "@notification.channels": [null]
       }
     })
 
@@ -225,179 +225,179 @@ describe('Notification Types from Model', () => {
   })
 })
 
-describe('i18n integration', () => {
-  const cds = require('@sap/cds')
+describe("i18n integration", () => {
+  const cds = require("@sap/cds")
   let originalI18nDescriptor
 
   beforeEach(() => {
-    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, 'i18n')
+    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, "i18n")
   })
 
   afterEach(() => {
     jest.restoreAllMocks()
-    if (originalI18nDescriptor) Object.defineProperty(cds, 'i18n', originalI18nDescriptor)
+    if (originalI18nDescriptor) Object.defineProperty(cds, "i18n", originalI18nDescriptor)
   })
 
   function mockLabels(allImpl, atImpl) {
-    jest.spyOn(cds.i18n.labels, 'all').mockImplementation(allImpl)
-    jest.spyOn(cds.i18n.labels, 'at').mockImplementation(atImpl)
+    jest.spyOn(cds.i18n.labels, "all").mockImplementation(allImpl)
+    jest.spyOn(cds.i18n.labels, "at").mockImplementation(atImpl)
   }
 
-  test('Fall back to single English template when no i18n files found', () => {
+  test("Fall back to single English template when no i18n files found", () => {
     mockLabels(
       () => ({}),
       () => undefined
     )
 
     const model = makeModel({
-      E: { kind: 'event', name: 'E', '@notification.title': 'Hello' }
+      E: { kind: "event", name: "E", "@notification.title": "Hello" }
     })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(1)
-    expect(type.Templates[0].Language).toBe('en')
-    expect(type.Templates[0].TemplateSensitive).toBe('Hello')
+    expect(type.Templates[0].Language).toBe("en")
+    expect(type.Templates[0].TemplateSensitive).toBe("Hello")
   })
 
-  test('Generate one template per available locale from i18n files', () => {
+  test("Generate one template per available locale from i18n files", () => {
     mockLabels(
-      () => ({ en: 'Hello', de: 'Hallo' }),
-      (_, locale) => (locale === 'de' ? 'Hallo' : 'Hello')
+      () => ({ en: "Hello", de: "Hallo" }),
+      (_, locale) => (locale === "de" ? "Hallo" : "Hello")
     )
 
-    const model = makeModel({ E: { kind: 'event', name: 'E', '@notification.title': '{i18n>TITLE}' } })
+    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(2)
-    expect(type.Templates.find(t => t.Language === 'en').TemplateSensitive).toBe('Hello')
-    expect(type.Templates.find(t => t.Language === 'de').TemplateSensitive).toBe('Hallo')
+    expect(type.Templates.find(t => t.Language === "en").TemplateSensitive).toBe("Hello")
+    expect(type.Templates.find(t => t.Language === "de").TemplateSensitive).toBe("Hallo")
   })
 
-  test('Resolve {i18n>KEY} references from i18n.properties file', () => {
+  test("Resolve {i18n>KEY} references from i18n.properties file", () => {
     mockLabels(
-      () => ({ en: 'Book Ordered' }),
-      () => 'Book Ordered'
+      () => ({ en: "Book Ordered" }),
+      () => "Book Ordered"
     )
 
-    const model = makeModel({ E: { kind: 'event', name: 'E', '@notification.title': '{i18n>BOOK_ORDERED_TITLE}' } })
+    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>BOOK_ORDERED_TITLE}" } })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].TemplateSensitive).toBe('Book Ordered')
+    expect(type.Templates[0].TemplateSensitive).toBe("Book Ordered")
   })
 
-  test('Resolve {i18n>KEY} to locale-specific translation when available', () => {
+  test("Resolve {i18n>KEY} to locale-specific translation when available", () => {
     mockLabels(
-      () => ({ en: 'Book Ordered', de: 'Buch bestellt' }),
-      (_, locale) => (locale === 'de' ? 'Buch bestellt' : 'Book Ordered')
+      () => ({ en: "Book Ordered", de: "Buch bestellt" }),
+      (_, locale) => (locale === "de" ? "Buch bestellt" : "Book Ordered")
     )
 
-    const model = makeModel({ E: { kind: 'event', name: 'E', '@notification.title': '{i18n>BOOK_ORDERED_TITLE}' } })
+    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>BOOK_ORDERED_TITLE}" } })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates.find(t => t.Language === 'en').TemplateSensitive).toBe('Book Ordered')
-    expect(type.Templates.find(t => t.Language === 'de').TemplateSensitive).toBe('Buch bestellt')
+    expect(type.Templates.find(t => t.Language === "en").TemplateSensitive).toBe("Book Ordered")
+    expect(type.Templates.find(t => t.Language === "de").TemplateSensitive).toBe("Buch bestellt")
   })
 
-  test('Fall back to raw value when i18n key not found in any locale', () => {
+  test("Fall back to raw value when i18n key not found in any locale", () => {
     mockLabels(
       () => ({}),
       () => undefined
     )
 
     const model = makeModel({
-      E: { kind: 'event', name: 'E', '@notification.title': '{i18n>MISSING_KEY}' }
+      E: { kind: "event", name: "E", "@notification.title": "{i18n>MISSING_KEY}" }
     })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].TemplateSensitive).toBe('{i18n>MISSING_KEY}')
+    expect(type.Templates[0].TemplateSensitive).toBe("{i18n>MISSING_KEY}")
   })
 
-  test('Pass plain strings through i18n unchanged', () => {
+  test("Pass plain strings through i18n unchanged", () => {
     mockLabels(
       () => ({}),
       () => undefined
     )
 
     const model = makeModel({
-      E: { kind: 'event', name: 'E', '@notification.title': 'Plain Title' }
+      E: { kind: "event", name: "E", "@notification.title": "Plain Title" }
     })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].TemplateSensitive).toBe('Plain Title')
+    expect(type.Templates[0].TemplateSensitive).toBe("Plain Title")
   })
 
-  test('Resolve {i18n>KEY} in subtitle field', () => {
+  test("Resolve {i18n>KEY} in subtitle field", () => {
     mockLabels(
-      () => ({ en: 'Resolved Subtitle' }),
-      () => 'Resolved Subtitle'
+      () => ({ en: "Resolved Subtitle" }),
+      () => "Resolved Subtitle"
     )
 
     const model = makeModel({
-      E: { kind: 'event', name: 'E', '@notification.title': 't', '@notification.subtitle': '{i18n>SUBTITLE_KEY}' }
+      E: { kind: "event", name: "E", "@notification.title": "t", "@notification.subtitle": "{i18n>SUBTITLE_KEY}" }
     })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].Subtitle).toBe('Resolved Subtitle')
+    expect(type.Templates[0].Subtitle).toBe("Resolved Subtitle")
   })
 
-  test('Exclude locale when none of its keys differ from English', () => {
+  test("Exclude locale when none of its keys differ from English", () => {
     mockLabels(
-      () => ({ en: 'Hello' }),
-      () => 'Hello'
+      () => ({ en: "Hello" }),
+      () => "Hello"
     )
 
-    const model = makeModel({ E: { kind: 'event', name: 'E', '@notification.title': '{i18n>TITLE}' } })
+    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(1)
-    expect(type.Templates[0].Language).toBe('en')
+    expect(type.Templates[0].Language).toBe("en")
   })
 
-  test('Exclude locale when its translation is identical to English', () => {
+  test("Exclude locale when its translation is identical to English", () => {
     mockLabels(
-      () => ({ en: 'Hello', de: 'Hello' }),
-      () => 'Hello'
+      () => ({ en: "Hello", de: "Hello" }),
+      () => "Hello"
     )
 
-    const model = makeModel({ E: { kind: 'event', name: 'E', '@notification.title': '{i18n>TITLE}' } })
+    const model = makeModel({ E: { kind: "event", name: "E", "@notification.title": "{i18n>TITLE}" } })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(1)
-    expect(type.Templates[0].Language).toBe('en')
+    expect(type.Templates[0].Language).toBe("en")
   })
 
-  test('Include locale only when at least one key differs from English', () => {
+  test("Include locale only when at least one key differs from English", () => {
     mockLabels(
-      key => (key === 'TITLE' ? { en: 'Hello', de: 'Hallo' } : { en: 'Same', de: 'Same' }),
-      (key, locale) => (key === 'TITLE' ? (locale === 'de' ? 'Hallo' : 'Hello') : 'Same')
+      key => (key === "TITLE" ? { en: "Hello", de: "Hallo" } : { en: "Same", de: "Same" }),
+      (key, locale) => (key === "TITLE" ? (locale === "de" ? "Hallo" : "Hello") : "Same")
     )
 
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification.title': '{i18n>TITLE}',
-        '@notification.subtitle': '{i18n>SUBTITLE}'
+        kind: "event",
+        name: "E",
+        "@notification.title": "{i18n>TITLE}",
+        "@notification.subtitle": "{i18n>SUBTITLE}"
       }
     })
     const [type] = notificationTypesFromModel(model)
     expect(type.Templates).toHaveLength(2)
-    expect(type.Templates.find(t => t.Language === 'de').TemplateSensitive).toBe('Hallo')
-    expect(type.Templates.find(t => t.Language === 'de').Subtitle).toBe('Same')
+    expect(type.Templates.find(t => t.Language === "de").TemplateSensitive).toBe("Hallo")
+    expect(type.Templates.find(t => t.Language === "de").Subtitle).toBe("Same")
   })
 
-  test('Two events with same locale files get independent template sets', () => {
+  test("Two events with same locale files get independent template sets", () => {
     mockLabels(
-      key => (key === 'A_TITLE' ? { en: 'A in English', de: 'A auf Deutsch' } : { en: 'B in English' }),
-      (key, locale) => (key === 'A_TITLE' ? (locale === 'de' ? 'A auf Deutsch' : 'A in English') : 'B in English')
+      key => (key === "A_TITLE" ? { en: "A in English", de: "A auf Deutsch" } : { en: "B in English" }),
+      (key, locale) => (key === "A_TITLE" ? (locale === "de" ? "A auf Deutsch" : "A in English") : "B in English")
     )
 
     const model = makeModel({
-      A: { kind: 'event', name: 'A', '@notification.title': '{i18n>A_TITLE}' },
-      B: { kind: 'event', name: 'B', '@notification.title': '{i18n>B_TITLE}' }
+      A: { kind: "event", name: "A", "@notification.title": "{i18n>A_TITLE}" },
+      B: { kind: "event", name: "B", "@notification.title": "{i18n>B_TITLE}" }
     })
     const [typeA, typeB] = notificationTypesFromModel(model)
     expect(typeA.Templates).toHaveLength(2)
     expect(typeB.Templates).toHaveLength(1)
   })
 
-  test('Resolve {i18n>KEY} in subtitle field via Object.defineProperty', () => {
-    Object.defineProperty(cds, 'i18n', {
+  test("Resolve {i18n>KEY} in subtitle field via Object.defineProperty", () => {
+    Object.defineProperty(cds, "i18n", {
       value: {
         labels: {
           all: () => ({}),
-          at: key => (key === 'BOOK_ORDERED_SUBTITLE' ? '{{buyer}} ordered {{title}}' : undefined)
+          at: key => (key === "BOOK_ORDERED_SUBTITLE" ? "{{buyer}} ordered {{title}}" : undefined)
         }
       },
       configurable: true,
@@ -405,19 +405,19 @@ describe('i18n integration', () => {
     })
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification.title': 't',
-        '@notification.subtitle': '{i18n>BOOK_ORDERED_SUBTITLE}'
+        kind: "event",
+        name: "E",
+        "@notification.title": "t",
+        "@notification.subtitle": "{i18n>BOOK_ORDERED_SUBTITLE}"
       }
     })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].Subtitle).toBe('{{buyer}} ordered {{title}}')
+    expect(type.Templates[0].Subtitle).toBe("{{buyer}} ordered {{title}}")
   })
 })
 
-describe('default channels config', () => {
-  const cds = require('@sap/cds')
+describe("default channels config", () => {
+  const cds = require("@sap/cds")
 
   afterEach(() => {
     if (cds.env.requires?.notifications) {
@@ -425,221 +425,221 @@ describe('default channels config', () => {
     }
   })
 
-  test('Add configured default channels when no channels annotated', () => {
+  test("Add configured default channels when no channels annotated", () => {
     cds.env.requires.notifications ??= {}
-    cds.env.requires.notifications.channels = ['email']
+    cds.env.requires.notifications.channels = ["email"]
 
     const model = makeModel({
-      E: { kind: 'event', name: 'E', '@notification.title': 't' }
+      E: { kind: "event", name: "E", "@notification.title": "t" }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels).toEqual([
-      { Type: 'MAIL', Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: "MAIL", Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 
-  test('Support multiple default channels', () => {
+  test("Support multiple default channels", () => {
     cds.env.requires.notifications ??= {}
-    cds.env.requires.notifications.channels = ['email', 'workzone']
+    cds.env.requires.notifications.channels = ["email", "workzone"]
 
     const model = makeModel({
-      E: { kind: 'event', name: 'E', '@notification.title': 't' }
+      E: { kind: "event", name: "E", "@notification.title": "t" }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels).toEqual([
-      { Type: 'MAIL', Enabled: true, DefaultPreference: true, EditablePreference: true },
-      { Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: "MAIL", Enabled: true, DefaultPreference: true, EditablePreference: true },
+      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 
-  test('Do not override explicit channels annotation with default channels', () => {
+  test("Do not override explicit channels annotation with default channels", () => {
     cds.env.requires.notifications ??= {}
-    cds.env.requires.notifications.channels = ['email']
+    cds.env.requires.notifications.channels = ["email"]
 
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification.title': 't',
-        '@notification.channels': ['workzone']
+        kind: "event",
+        name: "E",
+        "@notification.title": "t",
+        "@notification.channels": ["workzone"]
       }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels).toEqual([
-      { Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 
-  test('Default to workzone channel when channels config is not set', () => {
+  test("Default to workzone channel when channels config is not set", () => {
     const model = makeModel({
-      E: { kind: 'event', name: 'E', '@notification.title': 't' }
+      E: { kind: "event", name: "E", "@notification.title": "t" }
     })
 
     const [type] = notificationTypesFromModel(model)
     expect(type.DeliveryChannels).toEqual([
-      { Type: 'WEB', Enabled: true, DefaultPreference: true, EditablePreference: true }
+      { Type: "WEB", Enabled: true, DefaultPreference: true, EditablePreference: true }
     ])
   })
 })
 
-describe('HTML file resolution', () => {
-  const cds = require('@sap/cds')
+describe("HTML file resolution", () => {
+  const cds = require("@sap/cds")
   let originalI18nDescriptor
 
   beforeEach(() => {
-    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, 'i18n')
+    originalI18nDescriptor = Object.getOwnPropertyDescriptor(cds, "i18n")
     jest.clearAllMocks()
   })
 
   afterEach(() => {
-    if (originalI18nDescriptor) Object.defineProperty(cds, 'i18n', originalI18nDescriptor)
+    if (originalI18nDescriptor) Object.defineProperty(cds, "i18n", originalI18nDescriptor)
   })
 
-  test('Read html file when annotation value starts with ./', () => {
+  test("Read html file when annotation value starts with ./", () => {
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue('<p>Hello {{buyer}}</p>')
+    readFileSync.mockReturnValue("<p>Hello {{buyer}}</p>")
 
-    const model = makeModel({ E: makeEventWithHtml('./email.html') })
+    const model = makeModel({ E: makeEventWithHtml("./email.html") })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe('<p>Hello {{buyer}}</p>')
+    expect(type.Templates[0].EmailHtml).toBe("<p>Hello {{buyer}}</p>")
     expect(existsSync).toHaveBeenCalled()
     expect(readFileSync).toHaveBeenCalled()
   })
 
-  test('Read html file when annotation value starts with ../', () => {
+  test("Read html file when annotation value starts with ../", () => {
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue('<p>content</p>')
+    readFileSync.mockReturnValue("<p>content</p>")
 
-    const model = makeModel({ E: makeEventWithHtml('../templates/email.html') })
+    const model = makeModel({ E: makeEventWithHtml("../templates/email.html") })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe('<p>content</p>')
+    expect(type.Templates[0].EmailHtml).toBe("<p>content</p>")
   })
 
-  test('Pass through inline html unchanged (no file read)', () => {
-    const model = makeModel({ E: makeEventWithHtml('<p>inline</p>') })
+  test("Pass through inline html unchanged (no file read)", () => {
+    const model = makeModel({ E: makeEventWithHtml("<p>inline</p>") })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe('<p>inline</p>')
+    expect(type.Templates[0].EmailHtml).toBe("<p>inline</p>")
     expect(existsSync).not.toHaveBeenCalled()
   })
 
-  test('Return annotation value as-is when html file not found', () => {
+  test("Return annotation value as-is when html file not found", () => {
     existsSync.mockReturnValue(false)
 
-    const model = makeModel({ E: makeEventWithHtml('./missing.html') })
+    const model = makeModel({ E: makeEventWithHtml("./missing.html") })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe('./missing.html')
+    expect(type.Templates[0].EmailHtml).toBe("./missing.html")
     expect(readFileSync).not.toHaveBeenCalled()
   })
 
-  test('Resolve html file path relative to the cds source file', () => {
+  test("Resolve html file path relative to the cds source file", () => {
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue('<p>hi</p>')
+    readFileSync.mockReturnValue("<p>hi</p>")
 
-    const model = makeModel({ E: makeEventWithHtml('./email.html', 'srv/notifications.cds') })
+    const model = makeModel({ E: makeEventWithHtml("./email.html", "srv/notifications.cds") })
     notificationTypesFromModel(model)
 
     const calledPath = existsSync.mock.calls[0][0]
     expect(calledPath).toMatch(/srv[/\\]email\.html$/)
   })
 
-  test('Resolve {i18n>KEY} placeholders inside html file content', () => {
-    Object.defineProperty(cds, 'i18n', {
+  test("Resolve {i18n>KEY} placeholders inside html file content", () => {
+    Object.defineProperty(cds, "i18n", {
       value: {
         labels: {
-          all: () => ({ en: 'Book Ordered' }),
-          at: key => (key === 'BOOK_ORDERED_DESCRIPTION' ? 'Book Ordered' : undefined)
+          all: () => ({ en: "Book Ordered" }),
+          at: key => (key === "BOOK_ORDERED_DESCRIPTION" ? "Book Ordered" : undefined)
         }
       },
       configurable: true,
       writable: true
     })
     existsSync.mockReturnValue(true)
-    readFileSync.mockReturnValue('<h1>{i18n>BOOK_ORDERED_DESCRIPTION}</h1>')
+    readFileSync.mockReturnValue("<h1>{i18n>BOOK_ORDERED_DESCRIPTION}</h1>")
 
-    const model = makeModel({ E: makeEventWithHtml('./email.html') })
+    const model = makeModel({ E: makeEventWithHtml("./email.html") })
     const [type] = notificationTypesFromModel(model)
 
-    expect(type.Templates[0].EmailHtml).toBe('<h1>Book Ordered</h1>')
+    expect(type.Templates[0].EmailHtml).toBe("<h1>Book Ordered</h1>")
   })
 
-  test('Resolve {i18n>KEY} embedded within inline html string', () => {
-    Object.defineProperty(cds, 'i18n', {
+  test("Resolve {i18n>KEY} embedded within inline html string", () => {
+    Object.defineProperty(cds, "i18n", {
       value: {
         labels: {
           all: () => ({}),
-          at: key => (key === 'BOOK_ORDERED_SUBTITLE' ? '{{buyer}} ordered {{title}}' : undefined)
+          at: key => (key === "BOOK_ORDERED_SUBTITLE" ? "{{buyer}} ordered {{title}}" : undefined)
         }
       },
       configurable: true,
       writable: true
     })
     const model = makeModel({
-      E: { kind: 'event', name: 'E', '@notification.email.html': '<p>{i18n>BOOK_ORDERED_SUBTITLE}</p>' }
+      E: { kind: "event", name: "E", "@notification.email.html": "<p>{i18n>BOOK_ORDERED_SUBTITLE}</p>" }
     })
     const [type] = notificationTypesFromModel(model)
-    expect(type.Templates[0].EmailHtml).toBe('<p>{{buyer}} ordered {{title}}</p>')
+    expect(type.Templates[0].EmailHtml).toBe("<p>{{buyer}} ordered {{title}}</p>")
   })
 })
 
-describe('Element name length validation', () => {
-  test('Throw when an element name exceeds 128 characters', () => {
-    const longName = 'a'.repeat(129)
+describe("Element name length validation", () => {
+  test("Throw when an element name exceeds 128 characters", () => {
+    const longName = "a".repeat(129)
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification': {},
-        elements: { [longName]: { type: 'cds.String' } }
+        kind: "event",
+        name: "E",
+        "@notification": {},
+        elements: { [longName]: { type: "cds.String" } }
       }
     })
     expect(() => notificationTypesFromModel(model)).toThrow(longName)
     expect(() => notificationTypesFromModel(model)).toThrow("'E'")
   })
 
-  test('No error for element names at exactly 128 characters', () => {
-    const exactName = 'a'.repeat(128)
+  test("No error for element names at exactly 128 characters", () => {
+    const exactName = "a".repeat(128)
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification': {},
-        elements: { [exactName]: { type: 'cds.String' } }
+        kind: "event",
+        name: "E",
+        "@notification": {},
+        elements: { [exactName]: { type: "cds.String" } }
       }
     })
     expect(() => notificationTypesFromModel(model)).not.toThrow()
   })
 
-  test('No error when all element names are within the 128-character limit', () => {
+  test("No error when all element names are within the 128-character limit", () => {
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification': {},
-        elements: { title: { type: 'cds.String' }, buyer: { type: 'cds.String' } }
+        kind: "event",
+        name: "E",
+        "@notification": {},
+        elements: { title: { type: "cds.String" }, buyer: { type: "cds.String" } }
       }
     })
     expect(() => notificationTypesFromModel(model)).not.toThrow()
   })
 
-  test('Report all violating element names in the error message', () => {
-    const b = 'b'.repeat(129)
-    const c = 'c'.repeat(130)
+  test("Report all violating element names in the error message", () => {
+    const b = "b".repeat(129)
+    const c = "c".repeat(130)
     const model = makeModel({
       E: {
-        kind: 'event',
-        name: 'E',
-        '@notification': {},
+        kind: "event",
+        name: "E",
+        "@notification": {},
         elements: {
-          valid: { type: 'cds.String' },
-          [b]: { type: 'cds.String' },
-          [c]: { type: 'cds.String' }
+          valid: { type: "cds.String" },
+          [b]: { type: "cds.String" },
+          [c]: { type: "cds.String" }
         }
       }
     })
@@ -647,22 +647,22 @@ describe('Element name length validation', () => {
     expect(() => notificationTypesFromModel(model)).toThrow(c)
   })
 
-  test('Use stripped event name in error when event has a namespace prefix', () => {
-    const longName = 'x'.repeat(129)
+  test("Use stripped event name in error when event has a namespace prefix", () => {
+    const longName = "x".repeat(129)
     const model = makeModel({
-      'My.Namespace.OrderPlaced': {
-        kind: 'event',
-        name: 'My.Namespace.OrderPlaced',
-        '@notification': {},
-        elements: { [longName]: { type: 'cds.String' } }
+      "My.Namespace.OrderPlaced": {
+        kind: "event",
+        name: "My.Namespace.OrderPlaced",
+        "@notification": {},
+        elements: { [longName]: { type: "cds.String" } }
       }
     })
     expect(() => notificationTypesFromModel(model)).toThrow("'OrderPlaced'")
   })
 
-  test('No error when event has no elements', () => {
+  test("No error when event has no elements", () => {
     const model = makeModel({
-      E: { kind: 'event', name: 'E', '@notification': {} }
+      E: { kind: "event", name: "E", "@notification": {} }
     })
     expect(() => notificationTypesFromModel(model)).not.toThrow()
   })

--- a/tests/unit/lib/notificationTypes.test.js
+++ b/tests/unit/lib/notificationTypes.test.js
@@ -1,58 +1,58 @@
-const utils = require("../../../lib/utils")
-const httpClient = require("@sap-cloud-sdk/http-client")
-const connectivity = require("@sap-cloud-sdk/connectivity")
-const notificationTypes = require("../../../lib/notificationTypes")
+const utils = require('../../../lib/utils')
+const httpClient = require('@sap-cloud-sdk/http-client')
+const connectivity = require('@sap-cloud-sdk/connectivity')
+const notificationTypes = require('../../../lib/notificationTypes')
 
-jest.mock("../../../lib/utils")
-jest.mock("@sap-cloud-sdk/http-client")
-jest.mock("@sap-cloud-sdk/connectivity")
+jest.mock('../../../lib/utils')
+jest.mock('@sap-cloud-sdk/http-client')
+jest.mock('@sap-cloud-sdk/connectivity')
 
 const defaultNotificationType = {
-  NotificationTypeKey: "Default",
-  NotificationTypeVersion: "1",
+  NotificationTypeKey: 'Default',
+  NotificationTypeVersion: '1',
   Templates: [
     {
-      Language: "en",
-      Description: "Other Notifications",
-      TemplatePublic: "{{title}}",
-      TemplateSensitive: "{{title}}",
-      TemplateGrouped: "Other Notifications",
-      TemplateLanguage: "mustache",
-      Subtitle: "{{description}}"
+      Language: 'en',
+      Description: 'Other Notifications',
+      TemplatePublic: '{{title}}',
+      TemplateSensitive: '{{title}}',
+      TemplateGrouped: 'Other Notifications',
+      TemplateLanguage: 'mustache',
+      Subtitle: '{{description}}'
     }
   ]
 }
 
 const notificationTypeWithAllProperties = {
-  NotificationTypeKey: "notificationTypeWithAllProperties",
-  NotificationTypeVersion: "1",
+  NotificationTypeKey: 'notificationTypeWithAllProperties',
+  NotificationTypeVersion: '1',
   IsGroupable: true,
   Templates: [
     {
-      Language: "EN",
-      TemplatePublic: "TemplatePublic",
-      TemplateSensitive: "TemplateSensitive",
-      TemplateGrouped: "TemplateGrouped",
-      Description: "Description",
-      TemplateLanguage: "MUSTACHE",
-      Subtitle: "Subtitle",
-      EmailSubject: "EmailSubject",
-      EmailText: "EmailText",
-      EmailHtml: "EmailHtml"
+      Language: 'EN',
+      TemplatePublic: 'TemplatePublic',
+      TemplateSensitive: 'TemplateSensitive',
+      TemplateGrouped: 'TemplateGrouped',
+      Description: 'Description',
+      TemplateLanguage: 'MUSTACHE',
+      Subtitle: 'Subtitle',
+      EmailSubject: 'EmailSubject',
+      EmailText: 'EmailText',
+      EmailHtml: 'EmailHtml'
     }
   ],
   Actions: [
     {
-      ActionId: "Accept",
-      Language: "EN",
-      ActionText: "Accept",
-      GroupActionText: "Accept All",
-      Nature: "POSITIVE"
+      ActionId: 'Accept',
+      Language: 'EN',
+      ActionText: 'Accept',
+      GroupActionText: 'Accept All',
+      Nature: 'POSITIVE'
     }
   ],
   DeliveryChannels: [
     {
-      Type: "WEB",
+      Type: 'WEB',
       Enabled: true,
       DefaultPreference: false,
       EditablePreference: true
@@ -61,34 +61,34 @@ const notificationTypeWithAllProperties = {
 }
 
 const notificationTypeWithoutVersion = {
-  NotificationTypeKey: "notificationTypeWithoutVersion",
+  NotificationTypeKey: 'notificationTypeWithoutVersion',
   IsGroupable: true,
   Templates: [
     {
-      Language: "EN",
-      TemplatePublic: "TemplatePublic",
-      TemplateSensitive: "TemplateSensitive",
-      TemplateGrouped: "TemplateGrouped",
-      Description: "Description",
-      TemplateLanguage: "MUSTACHE",
-      Subtitle: "Subtitle",
-      EmailSubject: "EmailSubject",
-      EmailText: "EmailText",
-      EmailHtml: "EmailHtml"
+      Language: 'EN',
+      TemplatePublic: 'TemplatePublic',
+      TemplateSensitive: 'TemplateSensitive',
+      TemplateGrouped: 'TemplateGrouped',
+      Description: 'Description',
+      TemplateLanguage: 'MUSTACHE',
+      Subtitle: 'Subtitle',
+      EmailSubject: 'EmailSubject',
+      EmailText: 'EmailText',
+      EmailHtml: 'EmailHtml'
     }
   ],
   Actions: [
     {
-      ActionId: "Accept",
-      Language: "EN",
-      ActionText: "Accept",
-      GroupActionText: "Accept All",
-      Nature: "POSITIVE"
+      ActionId: 'Accept',
+      Language: 'EN',
+      ActionText: 'Accept',
+      GroupActionText: 'Accept All',
+      Nature: 'POSITIVE'
     }
   ],
   DeliveryChannels: [
     {
-      Type: "WEB",
+      Type: 'WEB',
       Enabled: true,
       DefaultPreference: false,
       EditablePreference: true
@@ -103,7 +103,7 @@ const notificationTypeWithNullTemplatesActionsAndDeliveryChannels = {
   DeliveryChannels: null
 }
 
-const testPrefix = "test-prefix"
+const testPrefix = 'test-prefix'
 
 const emptyResponseBody = { data: { d: { results: [] } } }
 
@@ -112,20 +112,20 @@ const allExistingResponseBody = {
     d: {
       results: [
         {
-          NotificationTypeId: "a6771115-42f4-4ac3-9c85-49a819927b9c",
-          NotificationTypeKey: "Default",
-          NotificationTypeVersion: "1",
+          NotificationTypeId: 'a6771115-42f4-4ac3-9c85-49a819927b9c',
+          NotificationTypeKey: 'Default',
+          NotificationTypeVersion: '1',
           IsGroupable: true,
           Templates: {
             results: [
               {
-                Language: "EN",
-                TemplatePublic: "{{title}}",
-                TemplateSensitive: "{{title}}",
-                TemplateGrouped: "Other Notifications",
-                Description: "Other Notifications",
-                TemplateLanguage: "MUSTACHE",
-                Subtitle: "{{description}}",
+                Language: 'EN',
+                TemplatePublic: '{{title}}',
+                TemplateSensitive: '{{title}}',
+                TemplateGrouped: 'Other Notifications',
+                Description: 'Other Notifications',
+                TemplateLanguage: 'MUSTACHE',
+                Subtitle: '{{description}}',
                 EmailSubject: null,
                 EmailText: null,
                 EmailHtml: null
@@ -140,41 +140,41 @@ const allExistingResponseBody = {
           }
         },
         {
-          NotificationTypeId: "26f1fad0-de4c-4869-9b4e-62f445c8a7a8",
-          NotificationTypeKey: "test-prefix/notificationTypeWithAllProperties",
-          NotificationTypeVersion: "1",
+          NotificationTypeId: '26f1fad0-de4c-4869-9b4e-62f445c8a7a8',
+          NotificationTypeKey: 'test-prefix/notificationTypeWithAllProperties',
+          NotificationTypeVersion: '1',
           IsGroupable: true,
           Templates: {
             results: [
               {
-                Language: "EN",
-                TemplatePublic: "TemplatePublic",
-                TemplateSensitive: "TemplateSensitive",
-                TemplateGrouped: "TemplateGrouped",
-                Description: "Description",
-                TemplateLanguage: "MUSTACHE",
-                Subtitle: "Subtitle",
-                EmailSubject: "EmailSubject",
-                EmailText: "EmailText",
-                EmailHtml: "EmailHtml"
+                Language: 'EN',
+                TemplatePublic: 'TemplatePublic',
+                TemplateSensitive: 'TemplateSensitive',
+                TemplateGrouped: 'TemplateGrouped',
+                Description: 'Description',
+                TemplateLanguage: 'MUSTACHE',
+                Subtitle: 'Subtitle',
+                EmailSubject: 'EmailSubject',
+                EmailText: 'EmailText',
+                EmailHtml: 'EmailHtml'
               }
             ]
           },
           Actions: {
             results: [
               {
-                ActionId: "Accept",
-                ActionText: "Accept",
-                GroupActionText: "Accept All",
-                Language: "EN",
-                Nature: "POSITIVE"
+                ActionId: 'Accept',
+                ActionText: 'Accept',
+                GroupActionText: 'Accept All',
+                Language: 'EN',
+                Nature: 'POSITIVE'
               }
             ]
           },
           DeliveryChannels: {
             results: [
               {
-                Type: "WEB",
+                Type: 'WEB',
                 Enabled: true,
                 DefaultPreference: false,
                 EditablePreference: true
@@ -183,41 +183,41 @@ const allExistingResponseBody = {
           }
         },
         {
-          NotificationTypeId: "5b641f19-7c05-404b-b9a3-f6326f8b23ad",
-          NotificationTypeKey: "test-prefix-2/notificationTypeWithAllProperties",
-          NotificationTypeVersion: "1",
+          NotificationTypeId: '5b641f19-7c05-404b-b9a3-f6326f8b23ad',
+          NotificationTypeKey: 'test-prefix-2/notificationTypeWithAllProperties',
+          NotificationTypeVersion: '1',
           IsGroupable: true,
           Templates: {
             results: [
               {
-                Language: "EN",
-                TemplatePublic: "TemplatePublic",
-                TemplateSensitive: "TemplateSensitive",
-                TemplateGrouped: "TemplateGrouped",
-                Description: "Description",
-                TemplateLanguage: "MUSTACHE",
-                Subtitle: "Subtitle",
-                EmailSubject: "EmailSubject",
-                EmailText: "EmailText",
-                EmailHtml: "EmailHtml"
+                Language: 'EN',
+                TemplatePublic: 'TemplatePublic',
+                TemplateSensitive: 'TemplateSensitive',
+                TemplateGrouped: 'TemplateGrouped',
+                Description: 'Description',
+                TemplateLanguage: 'MUSTACHE',
+                Subtitle: 'Subtitle',
+                EmailSubject: 'EmailSubject',
+                EmailText: 'EmailText',
+                EmailHtml: 'EmailHtml'
               }
             ]
           },
           Actions: {
             results: [
               {
-                ActionId: "Accept",
-                ActionText: "Accept",
-                GroupActionText: "Accept All",
-                Language: "EN",
-                Nature: "POSITIVE"
+                ActionId: 'Accept',
+                ActionText: 'Accept',
+                GroupActionText: 'Accept All',
+                Language: 'EN',
+                Nature: 'POSITIVE'
               }
             ]
           },
           DeliveryChannels: {
             results: [
               {
-                Type: "WEB",
+                Type: 'WEB',
                 Enabled: true,
                 DefaultPreference: false,
                 EditablePreference: true
@@ -226,41 +226,41 @@ const allExistingResponseBody = {
           }
         },
         {
-          NotificationTypeId: "719d8f6a-1e07-4981-b2be-07197cec7492",
-          NotificationTypeKey: "test-prefix/notificationTypeWithoutVersion",
-          NotificationTypeVersion: "1",
+          NotificationTypeId: '719d8f6a-1e07-4981-b2be-07197cec7492',
+          NotificationTypeKey: 'test-prefix/notificationTypeWithoutVersion',
+          NotificationTypeVersion: '1',
           IsGroupable: true,
           Templates: {
             results: [
               {
-                Language: "EN",
-                TemplatePublic: "TemplatePublic",
-                TemplateSensitive: "TemplateSensitive",
-                TemplateGrouped: "TemplateGrouped",
-                Description: "Description",
-                TemplateLanguage: "MUSTACHE",
-                Subtitle: "Subtitle",
-                EmailSubject: "EmailSubject",
-                EmailText: "EmailText",
-                EmailHtml: "EmailHtml"
+                Language: 'EN',
+                TemplatePublic: 'TemplatePublic',
+                TemplateSensitive: 'TemplateSensitive',
+                TemplateGrouped: 'TemplateGrouped',
+                Description: 'Description',
+                TemplateLanguage: 'MUSTACHE',
+                Subtitle: 'Subtitle',
+                EmailSubject: 'EmailSubject',
+                EmailText: 'EmailText',
+                EmailHtml: 'EmailHtml'
               }
             ]
           },
           Actions: {
             results: [
               {
-                ActionId: "Accept",
-                ActionText: "Accept",
-                GroupActionText: "Accept All",
-                Language: "EN",
-                Nature: "POSITIVE"
+                ActionId: 'Accept',
+                ActionText: 'Accept',
+                GroupActionText: 'Accept All',
+                Language: 'EN',
+                Nature: 'POSITIVE'
               }
             ]
           },
           DeliveryChannels: {
             results: [
               {
-                Type: "WEB",
+                Type: 'WEB',
                 Enabled: true,
                 DefaultPreference: false,
                 EditablePreference: true
@@ -278,21 +278,21 @@ const allExistingWithUndefinedTemplatesActionsAndDeliveryChannelsResponseBody = 
     d: {
       results: [
         {
-          NotificationTypeId: "a6771115-42f4-4ac3-9c85-49a819927b9c",
-          NotificationTypeKey: "Default",
-          NotificationTypeVersion: "1",
+          NotificationTypeId: 'a6771115-42f4-4ac3-9c85-49a819927b9c',
+          NotificationTypeKey: 'Default',
+          NotificationTypeVersion: '1',
           IsGroupable: true,
           Templates: {
             results: [
               {
-                NotificationTypeId: "a6771115-42f4-4ac3-9c85-49a819927b9c",
-                Language: "EN",
-                TemplatePublic: "{{title}}",
-                TemplateSensitive: "{{title}}",
-                TemplateGrouped: "Other Notifications",
-                Description: "Other Notifications",
-                TemplateLanguage: "MUSTACHE",
-                Subtitle: "{{description}}",
+                NotificationTypeId: 'a6771115-42f4-4ac3-9c85-49a819927b9c',
+                Language: 'EN',
+                TemplatePublic: '{{title}}',
+                TemplateSensitive: '{{title}}',
+                TemplateGrouped: 'Other Notifications',
+                Description: 'Other Notifications',
+                TemplateLanguage: 'MUSTACHE',
+                Subtitle: '{{description}}',
                 EmailSubject: null,
                 EmailText: null,
                 EmailHtml: null
@@ -305,9 +305,9 @@ const allExistingWithUndefinedTemplatesActionsAndDeliveryChannelsResponseBody = 
           DeliveryChannels: {}
         },
         {
-          NotificationTypeId: "26f1fad0-de4c-4869-9b4e-62f445c8a7a8",
-          NotificationTypeKey: "test-prefix/notificationTypeWithAllProperties",
-          NotificationTypeVersion: "1",
+          NotificationTypeId: '26f1fad0-de4c-4869-9b4e-62f445c8a7a8',
+          NotificationTypeKey: 'test-prefix/notificationTypeWithAllProperties',
+          NotificationTypeVersion: '1',
           IsGroupable: true
         }
       ]
@@ -315,37 +315,37 @@ const allExistingWithUndefinedTemplatesActionsAndDeliveryChannelsResponseBody = 
   }
 }
 
-describe("Managing of Notification Types", () => {
+describe('Managing of Notification Types', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     utils.getNotificationTypesKeyWithPrefix.mockImplementation(str => `${testPrefix}/${str}`)
   })
 
-  describe("Create Notification Types Map", () => {
-    test("Seed the Default type when isLocal is true", () => {
+  describe('Create Notification Types Map', () => {
+    test('Seed the Default type when isLocal is true', () => {
       const result = notificationTypes.createNotificationTypesMap([], true)
-      expect(result).toHaveProperty("Default")
-      expect(result["Default"]["1"]).toMatchObject(defaultNotificationType)
+      expect(result).toHaveProperty('Default')
+      expect(result['Default']['1']).toMatchObject(defaultNotificationType)
     })
 
-    test("Store multiple versions of the same type under the same key", () => {
-      const typeV1 = { NotificationTypeKey: "MyType", NotificationTypeVersion: "1", Templates: [] }
-      const typeV2 = { NotificationTypeKey: "MyType", NotificationTypeVersion: "2", Templates: [] }
+    test('Store multiple versions of the same type under the same key', () => {
+      const typeV1 = { NotificationTypeKey: 'MyType', NotificationTypeVersion: '1', Templates: [] }
+      const typeV2 = { NotificationTypeKey: 'MyType', NotificationTypeVersion: '2', Templates: [] }
       const result = notificationTypes.createNotificationTypesMap([typeV1, typeV2])
 
-      expect(Object.keys(result[`${testPrefix}/MyType`])).toEqual(["1", "2"])
+      expect(Object.keys(result[`${testPrefix}/MyType`])).toEqual(['1', '2'])
     })
   })
 
-  describe("Process Notification Types", () => {
+  describe('Process Notification Types', () => {
     beforeEach(() => {
       utils.getNotificationDestination.mockReturnValue(undefined)
       utils.getPrefix.mockReturnValue(testPrefix)
       connectivity.buildHeadersForDestination.mockReturnValue({})
     })
 
-    describe("Creating Types", () => {
-      test("Create Default and all new types when none exist in Work Zone", () => {
+    describe('Creating Types', () => {
+      test('Create Default and all new types when none exist in Work Zone', () => {
         httpClient.executeHttpRequest.mockReturnValue(emptyResponseBody)
 
         return notificationTypes
@@ -358,22 +358,22 @@ describe("Managing of Notification Types", () => {
               c => c[1]
             )
 
-            expect(createDefault.method).toBe("post")
+            expect(createDefault.method).toBe('post')
             expect(createDefault.data).toEqual(defaultNotificationType)
 
-            expect(createFirst.method).toBe("post")
+            expect(createFirst.method).toBe('post')
             expect(createFirst.data).toEqual(toNTypeWithPrefixedKey(notificationTypeWithAllProperties))
 
-            expect(createSecond.method).toBe("post")
+            expect(createSecond.method).toBe('post')
             expect(createSecond.data).toEqual(
-              toNTypeWithPrefixedKey({ ...notificationTypeWithoutVersion, NotificationTypeVersion: "1" })
+              toNTypeWithPrefixedKey({ ...notificationTypeWithoutVersion, NotificationTypeVersion: '1' })
             )
 
             expect(extra).toBeUndefined()
           })
       })
 
-      test("Do not create Default type when it already exists in Work Zone", () => {
+      test('Do not create Default type when it already exists in Work Zone', () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         return notificationTypes
@@ -382,15 +382,15 @@ describe("Managing of Notification Types", () => {
             structuredClone(notificationTypeWithoutVersion)
           ])
           .then(() => {
-            const postCalls = httpClient.executeHttpRequest.mock.calls.filter(c => c[1].method === "post")
+            const postCalls = httpClient.executeHttpRequest.mock.calls.filter(c => c[1].method === 'post')
             expect(postCalls).toHaveLength(0)
           })
       })
 
-      test("Create a missing version when another version of the same type exists", () => {
+      test('Create a missing version when another version of the same type exists', () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
         const versionTwo = structuredClone(notificationTypeWithAllProperties)
-        versionTwo.NotificationTypeVersion = "2"
+        versionTwo.NotificationTypeVersion = '2'
 
         return notificationTypes
           .processNotificationTypes([
@@ -400,30 +400,30 @@ describe("Managing of Notification Types", () => {
           ])
           .then(() => {
             const createCall = httpClient.executeHttpRequest.mock.calls[1][1]
-            expect(createCall.method).toBe("post")
-            expect(createCall.data.NotificationTypeVersion).toBe("2")
+            expect(createCall.method).toBe('post')
+            expect(createCall.data.NotificationTypeVersion).toBe('2')
             expect(httpClient.executeHttpRequest.mock.calls[2]).toBeUndefined()
           })
       })
 
-      test("Fall back gracefully when create response has no data.d", () => {
+      test('Fall back gracefully when create response has no data.d', () => {
         httpClient.executeHttpRequest.mockReturnValueOnce(emptyResponseBody).mockReturnValue({ status: 201 })
 
         return notificationTypes
           .processNotificationTypes([structuredClone(notificationTypeWithAllProperties)])
           .then(() => {
-            expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe("post")
+            expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe('post')
           })
       })
 
-      test("Create new types correctly when existing types use OData results format", () => {
+      test('Create new types correctly when existing types use OData results format', () => {
         httpClient.executeHttpRequest.mockReturnValue({
           data: {
             d: {
               results: [
                 {
-                  NotificationTypeKey: "Default",
-                  NotificationTypeVersion: "1",
+                  NotificationTypeKey: 'Default',
+                  NotificationTypeVersion: '1',
                   IsGroupable: true,
                   Templates: { results: [] },
                   Actions: { results: [] },
@@ -437,20 +437,20 @@ describe("Managing of Notification Types", () => {
         return notificationTypes
           .processNotificationTypes([structuredClone(notificationTypeWithAllProperties)])
           .then(() => {
-            expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe("post")
+            expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe('post')
             expect(httpClient.executeHttpRequest.mock.calls[2]).toBeUndefined()
           })
       })
     })
 
-    describe("Updating Types", () => {
-      test("Update all changed types", () => {
+    describe('Updating Types', () => {
+      test('Update all changed types', () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const updatedWithAll = structuredClone(notificationTypeWithAllProperties)
-        updatedWithAll.Templates[0].Description = "New Description"
+        updatedWithAll.Templates[0].Description = 'New Description'
         const updatedWithoutVersion = structuredClone(notificationTypeWithoutVersion)
-        updatedWithoutVersion.Templates[0].Description = "New Description"
+        updatedWithoutVersion.Templates[0].Description = 'New Description'
 
         return notificationTypes
           .processNotificationTypes([structuredClone(updatedWithAll), structuredClone(updatedWithoutVersion)])
@@ -460,27 +460,27 @@ describe("Managing of Notification Types", () => {
             expect(updateFirst.url).toBe(
               "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
             )
-            expect(updateFirst.method).toBe("patch")
+            expect(updateFirst.method).toBe('patch')
             expect(updateFirst.data).toEqual(toNTypeWithPrefixedKey(updatedWithAll))
 
             expect(updateSecond.url).toBe(
               "v2/NotificationType.svc/NotificationTypes(guid'719d8f6a-1e07-4981-b2be-07197cec7492')"
             )
-            expect(updateSecond.method).toBe("patch")
+            expect(updateSecond.method).toBe('patch')
             expect(updateSecond.data).toEqual(
-              toNTypeWithPrefixedKey({ ...updatedWithoutVersion, NotificationTypeVersion: "1" })
+              toNTypeWithPrefixedKey({ ...updatedWithoutVersion, NotificationTypeVersion: '1' })
             )
 
             expect(extra).toBeUndefined()
           })
       })
 
-      test("Update type when an additional Template is added", () => {
+      test('Update type when an additional Template is added', () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const updated = structuredClone(notificationTypeWithAllProperties)
         updated.Templates[1] = updated.Templates[0]
-        updated.Templates[1].Language = "DE"
+        updated.Templates[1].Language = 'DE'
 
         return notificationTypes
           .processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)])
@@ -489,18 +489,18 @@ describe("Managing of Notification Types", () => {
             expect(updateCall.url).toBe(
               "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
             )
-            expect(updateCall.method).toBe("patch")
+            expect(updateCall.method).toBe('patch')
             expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
             expect(extra).toBeUndefined()
           })
       })
 
-      test("Update type when an additional Action is added", () => {
+      test('Update type when an additional Action is added', () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const updated = structuredClone(notificationTypeWithAllProperties)
         updated.Actions[1] = updated.Actions[0]
-        updated.Actions[1].Language = "DE"
+        updated.Actions[1].Language = 'DE'
 
         return notificationTypes
           .processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)])
@@ -509,18 +509,18 @@ describe("Managing of Notification Types", () => {
             expect(updateCall.url).toBe(
               "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
             )
-            expect(updateCall.method).toBe("patch")
+            expect(updateCall.method).toBe('patch')
             expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
             expect(extra).toBeUndefined()
           })
       })
 
-      test("Update type when an additional DeliveryChannel is added", () => {
+      test('Update type when an additional DeliveryChannel is added', () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const updated = structuredClone(notificationTypeWithAllProperties)
         updated.DeliveryChannels[1] = updated.DeliveryChannels[0]
-        updated.DeliveryChannels[1].Type = "MOBILE"
+        updated.DeliveryChannels[1].Type = 'MOBILE'
 
         return notificationTypes
           .processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)])
@@ -529,19 +529,19 @@ describe("Managing of Notification Types", () => {
             expect(updateCall.url).toBe(
               "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
             )
-            expect(updateCall.method).toBe("patch")
+            expect(updateCall.method).toBe('patch')
             expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
             expect(extra).toBeUndefined()
           })
       })
 
-      test("Update type when any individual field has changed", async () => {
+      test('Update type when any individual field has changed', async () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const mutate = (target, key, value) => {
-          if (typeof value === "string") target[key] = value + " UPDATED"
-          else if (typeof value === "boolean") target[key] = !value
-          else if (typeof value === "number") target[key] = value + 1
+          if (typeof value === 'string') target[key] = value + ' UPDATED'
+          else if (typeof value === 'boolean') target[key] = !value
+          else if (typeof value === 'number') target[key] = value + 1
           else return false
           return true
         }
@@ -551,13 +551,13 @@ describe("Managing of Notification Types", () => {
           expect(updateCall.url).toBe(
             "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
           )
-          expect(updateCall.method).toBe("patch")
+          expect(updateCall.method).toBe('patch')
           expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(changed))
           expect(extra).toBeUndefined()
         }
 
         for (const [key, value] of Object.entries(notificationTypeWithAllProperties)) {
-          if (key === "NotificationTypeKey" || key === "NotificationTypeVersion") continue
+          if (key === 'NotificationTypeKey' || key === 'NotificationTypeVersion') continue
           const changed = structuredClone(notificationTypeWithAllProperties)
           if (!mutate(changed, key, value)) continue
           await notificationTypes
@@ -594,15 +594,15 @@ describe("Managing of Notification Types", () => {
         }
       })
 
-      test("Update type when existing type has null inner results", () => {
+      test('Update type when existing type has null inner results', () => {
         httpClient.executeHttpRequest.mockReturnValue({
           data: {
             d: {
               results: [
                 {
-                  NotificationTypeId: "test-guid-123",
-                  NotificationTypeKey: "test-prefix/notificationTypeWithAllProperties",
-                  NotificationTypeVersion: "1",
+                  NotificationTypeId: 'test-guid-123',
+                  NotificationTypeKey: 'test-prefix/notificationTypeWithAllProperties',
+                  NotificationTypeVersion: '1',
                   IsGroupable: true,
                   Templates: { results: null },
                   Actions: { results: null },
@@ -617,13 +617,13 @@ describe("Managing of Notification Types", () => {
           .processNotificationTypes([structuredClone(notificationTypeWithAllProperties)])
           .then(() => {
             const [, updateCall] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
-            expect(updateCall.method).toBe("patch")
+            expect(updateCall.method).toBe('patch')
           })
       })
     })
 
-    describe("No Changed Needed", () => {
-      test("Do nothing when all types match exactly", () => {
+    describe('No Changed Needed', () => {
+      test('Do nothing when all types match exactly', () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         return notificationTypes
@@ -636,7 +636,7 @@ describe("Managing of Notification Types", () => {
           })
       })
 
-      test("Do nothing when input Templates/Actions/DeliveryChannels use OData results wrapper", () => {
+      test('Do nothing when input Templates/Actions/DeliveryChannels use OData results wrapper', () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const local = structuredClone(notificationTypeWithAllProperties)
@@ -651,7 +651,7 @@ describe("Managing of Notification Types", () => {
           })
       })
 
-      test("Do nothing when IsGroupable is undefined (treated as true)", () => {
+      test('Do nothing when IsGroupable is undefined (treated as true)', () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const local = structuredClone(notificationTypeWithAllProperties)
@@ -664,7 +664,7 @@ describe("Managing of Notification Types", () => {
           })
       })
 
-      test("Do nothing when Language fields are lowercase", () => {
+      test('Do nothing when Language fields are lowercase', () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const local = structuredClone(notificationTypeWithAllProperties)
@@ -678,7 +678,7 @@ describe("Managing of Notification Types", () => {
           })
       })
 
-      test("Do nothing when TemplateLanguage is lowercase", () => {
+      test('Do nothing when TemplateLanguage is lowercase', () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const local = structuredClone(notificationTypeWithAllProperties)
@@ -692,7 +692,7 @@ describe("Managing of Notification Types", () => {
           })
       })
 
-      test("Do nothing when Templates, Actions and DeliveryChannels are null in both local and remote", () => {
+      test('Do nothing when Templates, Actions and DeliveryChannels are null in both local and remote', () => {
         httpClient.executeHttpRequest.mockReturnValue(
           allExistingWithUndefinedTemplatesActionsAndDeliveryChannelsResponseBody
         )
@@ -704,23 +704,23 @@ describe("Managing of Notification Types", () => {
           })
       })
 
-      test("Do nothing when existing type matches local type exactly", () => {
+      test('Do nothing when existing type matches local type exactly', () => {
         httpClient.executeHttpRequest.mockReturnValue({
           data: {
             d: {
               results: [
                 {
-                  NotificationTypeId: "26f1fad0-de4c-4869-9b4e-62f445c8a7a8",
-                  NotificationTypeKey: "test-prefix/notificationTypeWithAllProperties",
-                  NotificationTypeVersion: "1",
+                  NotificationTypeId: '26f1fad0-de4c-4869-9b4e-62f445c8a7a8',
+                  NotificationTypeKey: 'test-prefix/notificationTypeWithAllProperties',
+                  NotificationTypeVersion: '1',
                   IsGroupable: true,
                   Templates: structuredClone(notificationTypeWithAllProperties).Templates,
                   Actions: structuredClone(notificationTypeWithAllProperties).Actions,
                   DeliveryChannels: structuredClone(notificationTypeWithAllProperties).DeliveryChannels
                 },
                 {
-                  NotificationTypeKey: "Default",
-                  NotificationTypeVersion: "1",
+                  NotificationTypeKey: 'Default',
+                  NotificationTypeVersion: '1',
                   IsGroupable: true,
                   Templates: [],
                   Actions: [],
@@ -739,7 +739,7 @@ describe("Managing of Notification Types", () => {
       })
     })
 
-    test("Deletes a type that is no longer in the local file", () => {
+    test('Deletes a type that is no longer in the local file', () => {
       httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
       return notificationTypes
@@ -749,7 +749,7 @@ describe("Managing of Notification Types", () => {
           expect(deleteCall.url).toBe(
             "v2/NotificationType.svc/NotificationTypes(guid'719d8f6a-1e07-4981-b2be-07197cec7492')"
           )
-          expect(deleteCall.method).toBe("delete")
+          expect(deleteCall.method).toBe('delete')
           expect(extra).toBeUndefined()
         })
     })
@@ -758,6 +758,6 @@ describe("Managing of Notification Types", () => {
 
 function toNTypeWithPrefixedKey(ntype) {
   var prefixedNtype = structuredClone(ntype)
-  prefixedNtype.NotificationTypeKey = testPrefix + "/" + prefixedNtype.NotificationTypeKey
+  prefixedNtype.NotificationTypeKey = testPrefix + '/' + prefixedNtype.NotificationTypeKey
   return prefixedNtype
 }

--- a/tests/unit/lib/notificationTypes.test.js
+++ b/tests/unit/lib/notificationTypes.test.js
@@ -1,58 +1,58 @@
-const utils = require('../../../lib/utils')
-const httpClient = require('@sap-cloud-sdk/http-client')
-const connectivity = require('@sap-cloud-sdk/connectivity')
-const notificationTypes = require('../../../lib/notificationTypes')
+const utils = require("../../../lib/utils")
+const httpClient = require("@sap-cloud-sdk/http-client")
+const connectivity = require("@sap-cloud-sdk/connectivity")
+const notificationTypes = require("../../../lib/notificationTypes")
 
-jest.mock('../../../lib/utils')
-jest.mock('@sap-cloud-sdk/http-client')
-jest.mock('@sap-cloud-sdk/connectivity')
+jest.mock("../../../lib/utils")
+jest.mock("@sap-cloud-sdk/http-client")
+jest.mock("@sap-cloud-sdk/connectivity")
 
 const defaultNotificationType = {
-  NotificationTypeKey: 'Default',
-  NotificationTypeVersion: '1',
+  NotificationTypeKey: "Default",
+  NotificationTypeVersion: "1",
   Templates: [
     {
-      Language: 'en',
-      Description: 'Other Notifications',
-      TemplatePublic: '{{title}}',
-      TemplateSensitive: '{{title}}',
-      TemplateGrouped: 'Other Notifications',
-      TemplateLanguage: 'mustache',
-      Subtitle: '{{description}}'
+      Language: "en",
+      Description: "Other Notifications",
+      TemplatePublic: "{{title}}",
+      TemplateSensitive: "{{title}}",
+      TemplateGrouped: "Other Notifications",
+      TemplateLanguage: "mustache",
+      Subtitle: "{{description}}"
     }
   ]
 }
 
 const notificationTypeWithAllProperties = {
-  NotificationTypeKey: 'notificationTypeWithAllProperties',
-  NotificationTypeVersion: '1',
+  NotificationTypeKey: "notificationTypeWithAllProperties",
+  NotificationTypeVersion: "1",
   IsGroupable: true,
   Templates: [
     {
-      Language: 'EN',
-      TemplatePublic: 'TemplatePublic',
-      TemplateSensitive: 'TemplateSensitive',
-      TemplateGrouped: 'TemplateGrouped',
-      Description: 'Description',
-      TemplateLanguage: 'MUSTACHE',
-      Subtitle: 'Subtitle',
-      EmailSubject: 'EmailSubject',
-      EmailText: 'EmailText',
-      EmailHtml: 'EmailHtml'
+      Language: "EN",
+      TemplatePublic: "TemplatePublic",
+      TemplateSensitive: "TemplateSensitive",
+      TemplateGrouped: "TemplateGrouped",
+      Description: "Description",
+      TemplateLanguage: "MUSTACHE",
+      Subtitle: "Subtitle",
+      EmailSubject: "EmailSubject",
+      EmailText: "EmailText",
+      EmailHtml: "EmailHtml"
     }
   ],
   Actions: [
     {
-      ActionId: 'Accept',
-      Language: 'EN',
-      ActionText: 'Accept',
-      GroupActionText: 'Accept All',
-      Nature: 'POSITIVE'
+      ActionId: "Accept",
+      Language: "EN",
+      ActionText: "Accept",
+      GroupActionText: "Accept All",
+      Nature: "POSITIVE"
     }
   ],
   DeliveryChannels: [
     {
-      Type: 'WEB',
+      Type: "WEB",
       Enabled: true,
       DefaultPreference: false,
       EditablePreference: true
@@ -61,34 +61,34 @@ const notificationTypeWithAllProperties = {
 }
 
 const notificationTypeWithoutVersion = {
-  NotificationTypeKey: 'notificationTypeWithoutVersion',
+  NotificationTypeKey: "notificationTypeWithoutVersion",
   IsGroupable: true,
   Templates: [
     {
-      Language: 'EN',
-      TemplatePublic: 'TemplatePublic',
-      TemplateSensitive: 'TemplateSensitive',
-      TemplateGrouped: 'TemplateGrouped',
-      Description: 'Description',
-      TemplateLanguage: 'MUSTACHE',
-      Subtitle: 'Subtitle',
-      EmailSubject: 'EmailSubject',
-      EmailText: 'EmailText',
-      EmailHtml: 'EmailHtml'
+      Language: "EN",
+      TemplatePublic: "TemplatePublic",
+      TemplateSensitive: "TemplateSensitive",
+      TemplateGrouped: "TemplateGrouped",
+      Description: "Description",
+      TemplateLanguage: "MUSTACHE",
+      Subtitle: "Subtitle",
+      EmailSubject: "EmailSubject",
+      EmailText: "EmailText",
+      EmailHtml: "EmailHtml"
     }
   ],
   Actions: [
     {
-      ActionId: 'Accept',
-      Language: 'EN',
-      ActionText: 'Accept',
-      GroupActionText: 'Accept All',
-      Nature: 'POSITIVE'
+      ActionId: "Accept",
+      Language: "EN",
+      ActionText: "Accept",
+      GroupActionText: "Accept All",
+      Nature: "POSITIVE"
     }
   ],
   DeliveryChannels: [
     {
-      Type: 'WEB',
+      Type: "WEB",
       Enabled: true,
       DefaultPreference: false,
       EditablePreference: true
@@ -103,7 +103,7 @@ const notificationTypeWithNullTemplatesActionsAndDeliveryChannels = {
   DeliveryChannels: null
 }
 
-const testPrefix = 'test-prefix'
+const testPrefix = "test-prefix"
 
 const emptyResponseBody = { data: { d: { results: [] } } }
 
@@ -112,20 +112,20 @@ const allExistingResponseBody = {
     d: {
       results: [
         {
-          NotificationTypeId: 'a6771115-42f4-4ac3-9c85-49a819927b9c',
-          NotificationTypeKey: 'Default',
-          NotificationTypeVersion: '1',
+          NotificationTypeId: "a6771115-42f4-4ac3-9c85-49a819927b9c",
+          NotificationTypeKey: "Default",
+          NotificationTypeVersion: "1",
           IsGroupable: true,
           Templates: {
             results: [
               {
-                Language: 'EN',
-                TemplatePublic: '{{title}}',
-                TemplateSensitive: '{{title}}',
-                TemplateGrouped: 'Other Notifications',
-                Description: 'Other Notifications',
-                TemplateLanguage: 'MUSTACHE',
-                Subtitle: '{{description}}',
+                Language: "EN",
+                TemplatePublic: "{{title}}",
+                TemplateSensitive: "{{title}}",
+                TemplateGrouped: "Other Notifications",
+                Description: "Other Notifications",
+                TemplateLanguage: "MUSTACHE",
+                Subtitle: "{{description}}",
                 EmailSubject: null,
                 EmailText: null,
                 EmailHtml: null
@@ -140,41 +140,41 @@ const allExistingResponseBody = {
           }
         },
         {
-          NotificationTypeId: '26f1fad0-de4c-4869-9b4e-62f445c8a7a8',
-          NotificationTypeKey: 'test-prefix/notificationTypeWithAllProperties',
-          NotificationTypeVersion: '1',
+          NotificationTypeId: "26f1fad0-de4c-4869-9b4e-62f445c8a7a8",
+          NotificationTypeKey: "test-prefix/notificationTypeWithAllProperties",
+          NotificationTypeVersion: "1",
           IsGroupable: true,
           Templates: {
             results: [
               {
-                Language: 'EN',
-                TemplatePublic: 'TemplatePublic',
-                TemplateSensitive: 'TemplateSensitive',
-                TemplateGrouped: 'TemplateGrouped',
-                Description: 'Description',
-                TemplateLanguage: 'MUSTACHE',
-                Subtitle: 'Subtitle',
-                EmailSubject: 'EmailSubject',
-                EmailText: 'EmailText',
-                EmailHtml: 'EmailHtml'
+                Language: "EN",
+                TemplatePublic: "TemplatePublic",
+                TemplateSensitive: "TemplateSensitive",
+                TemplateGrouped: "TemplateGrouped",
+                Description: "Description",
+                TemplateLanguage: "MUSTACHE",
+                Subtitle: "Subtitle",
+                EmailSubject: "EmailSubject",
+                EmailText: "EmailText",
+                EmailHtml: "EmailHtml"
               }
             ]
           },
           Actions: {
             results: [
               {
-                ActionId: 'Accept',
-                ActionText: 'Accept',
-                GroupActionText: 'Accept All',
-                Language: 'EN',
-                Nature: 'POSITIVE'
+                ActionId: "Accept",
+                ActionText: "Accept",
+                GroupActionText: "Accept All",
+                Language: "EN",
+                Nature: "POSITIVE"
               }
             ]
           },
           DeliveryChannels: {
             results: [
               {
-                Type: 'WEB',
+                Type: "WEB",
                 Enabled: true,
                 DefaultPreference: false,
                 EditablePreference: true
@@ -183,41 +183,41 @@ const allExistingResponseBody = {
           }
         },
         {
-          NotificationTypeId: '5b641f19-7c05-404b-b9a3-f6326f8b23ad',
-          NotificationTypeKey: 'test-prefix-2/notificationTypeWithAllProperties',
-          NotificationTypeVersion: '1',
+          NotificationTypeId: "5b641f19-7c05-404b-b9a3-f6326f8b23ad",
+          NotificationTypeKey: "test-prefix-2/notificationTypeWithAllProperties",
+          NotificationTypeVersion: "1",
           IsGroupable: true,
           Templates: {
             results: [
               {
-                Language: 'EN',
-                TemplatePublic: 'TemplatePublic',
-                TemplateSensitive: 'TemplateSensitive',
-                TemplateGrouped: 'TemplateGrouped',
-                Description: 'Description',
-                TemplateLanguage: 'MUSTACHE',
-                Subtitle: 'Subtitle',
-                EmailSubject: 'EmailSubject',
-                EmailText: 'EmailText',
-                EmailHtml: 'EmailHtml'
+                Language: "EN",
+                TemplatePublic: "TemplatePublic",
+                TemplateSensitive: "TemplateSensitive",
+                TemplateGrouped: "TemplateGrouped",
+                Description: "Description",
+                TemplateLanguage: "MUSTACHE",
+                Subtitle: "Subtitle",
+                EmailSubject: "EmailSubject",
+                EmailText: "EmailText",
+                EmailHtml: "EmailHtml"
               }
             ]
           },
           Actions: {
             results: [
               {
-                ActionId: 'Accept',
-                ActionText: 'Accept',
-                GroupActionText: 'Accept All',
-                Language: 'EN',
-                Nature: 'POSITIVE'
+                ActionId: "Accept",
+                ActionText: "Accept",
+                GroupActionText: "Accept All",
+                Language: "EN",
+                Nature: "POSITIVE"
               }
             ]
           },
           DeliveryChannels: {
             results: [
               {
-                Type: 'WEB',
+                Type: "WEB",
                 Enabled: true,
                 DefaultPreference: false,
                 EditablePreference: true
@@ -226,41 +226,41 @@ const allExistingResponseBody = {
           }
         },
         {
-          NotificationTypeId: '719d8f6a-1e07-4981-b2be-07197cec7492',
-          NotificationTypeKey: 'test-prefix/notificationTypeWithoutVersion',
-          NotificationTypeVersion: '1',
+          NotificationTypeId: "719d8f6a-1e07-4981-b2be-07197cec7492",
+          NotificationTypeKey: "test-prefix/notificationTypeWithoutVersion",
+          NotificationTypeVersion: "1",
           IsGroupable: true,
           Templates: {
             results: [
               {
-                Language: 'EN',
-                TemplatePublic: 'TemplatePublic',
-                TemplateSensitive: 'TemplateSensitive',
-                TemplateGrouped: 'TemplateGrouped',
-                Description: 'Description',
-                TemplateLanguage: 'MUSTACHE',
-                Subtitle: 'Subtitle',
-                EmailSubject: 'EmailSubject',
-                EmailText: 'EmailText',
-                EmailHtml: 'EmailHtml'
+                Language: "EN",
+                TemplatePublic: "TemplatePublic",
+                TemplateSensitive: "TemplateSensitive",
+                TemplateGrouped: "TemplateGrouped",
+                Description: "Description",
+                TemplateLanguage: "MUSTACHE",
+                Subtitle: "Subtitle",
+                EmailSubject: "EmailSubject",
+                EmailText: "EmailText",
+                EmailHtml: "EmailHtml"
               }
             ]
           },
           Actions: {
             results: [
               {
-                ActionId: 'Accept',
-                ActionText: 'Accept',
-                GroupActionText: 'Accept All',
-                Language: 'EN',
-                Nature: 'POSITIVE'
+                ActionId: "Accept",
+                ActionText: "Accept",
+                GroupActionText: "Accept All",
+                Language: "EN",
+                Nature: "POSITIVE"
               }
             ]
           },
           DeliveryChannels: {
             results: [
               {
-                Type: 'WEB',
+                Type: "WEB",
                 Enabled: true,
                 DefaultPreference: false,
                 EditablePreference: true
@@ -278,21 +278,21 @@ const allExistingWithUndefinedTemplatesActionsAndDeliveryChannelsResponseBody = 
     d: {
       results: [
         {
-          NotificationTypeId: 'a6771115-42f4-4ac3-9c85-49a819927b9c',
-          NotificationTypeKey: 'Default',
-          NotificationTypeVersion: '1',
+          NotificationTypeId: "a6771115-42f4-4ac3-9c85-49a819927b9c",
+          NotificationTypeKey: "Default",
+          NotificationTypeVersion: "1",
           IsGroupable: true,
           Templates: {
             results: [
               {
-                NotificationTypeId: 'a6771115-42f4-4ac3-9c85-49a819927b9c',
-                Language: 'EN',
-                TemplatePublic: '{{title}}',
-                TemplateSensitive: '{{title}}',
-                TemplateGrouped: 'Other Notifications',
-                Description: 'Other Notifications',
-                TemplateLanguage: 'MUSTACHE',
-                Subtitle: '{{description}}',
+                NotificationTypeId: "a6771115-42f4-4ac3-9c85-49a819927b9c",
+                Language: "EN",
+                TemplatePublic: "{{title}}",
+                TemplateSensitive: "{{title}}",
+                TemplateGrouped: "Other Notifications",
+                Description: "Other Notifications",
+                TemplateLanguage: "MUSTACHE",
+                Subtitle: "{{description}}",
                 EmailSubject: null,
                 EmailText: null,
                 EmailHtml: null
@@ -305,9 +305,9 @@ const allExistingWithUndefinedTemplatesActionsAndDeliveryChannelsResponseBody = 
           DeliveryChannels: {}
         },
         {
-          NotificationTypeId: '26f1fad0-de4c-4869-9b4e-62f445c8a7a8',
-          NotificationTypeKey: 'test-prefix/notificationTypeWithAllProperties',
-          NotificationTypeVersion: '1',
+          NotificationTypeId: "26f1fad0-de4c-4869-9b4e-62f445c8a7a8",
+          NotificationTypeKey: "test-prefix/notificationTypeWithAllProperties",
+          NotificationTypeVersion: "1",
           IsGroupable: true
         }
       ]
@@ -315,37 +315,37 @@ const allExistingWithUndefinedTemplatesActionsAndDeliveryChannelsResponseBody = 
   }
 }
 
-describe('Managing of Notification Types', () => {
+describe("Managing of Notification Types", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     utils.getNotificationTypesKeyWithPrefix.mockImplementation(str => `${testPrefix}/${str}`)
   })
 
-  describe('Create Notification Types Map', () => {
-    test('Seed the Default type when isLocal is true', () => {
+  describe("Create Notification Types Map", () => {
+    test("Seed the Default type when isLocal is true", () => {
       const result = notificationTypes.createNotificationTypesMap([], true)
-      expect(result).toHaveProperty('Default')
-      expect(result['Default']['1']).toMatchObject(defaultNotificationType)
+      expect(result).toHaveProperty("Default")
+      expect(result["Default"]["1"]).toMatchObject(defaultNotificationType)
     })
 
-    test('Store multiple versions of the same type under the same key', () => {
-      const typeV1 = { NotificationTypeKey: 'MyType', NotificationTypeVersion: '1', Templates: [] }
-      const typeV2 = { NotificationTypeKey: 'MyType', NotificationTypeVersion: '2', Templates: [] }
+    test("Store multiple versions of the same type under the same key", () => {
+      const typeV1 = { NotificationTypeKey: "MyType", NotificationTypeVersion: "1", Templates: [] }
+      const typeV2 = { NotificationTypeKey: "MyType", NotificationTypeVersion: "2", Templates: [] }
       const result = notificationTypes.createNotificationTypesMap([typeV1, typeV2])
 
-      expect(Object.keys(result[`${testPrefix}/MyType`])).toEqual(['1', '2'])
+      expect(Object.keys(result[`${testPrefix}/MyType`])).toEqual(["1", "2"])
     })
   })
 
-  describe('Process Notification Types', () => {
+  describe("Process Notification Types", () => {
     beforeEach(() => {
       utils.getNotificationDestination.mockReturnValue(undefined)
       utils.getPrefix.mockReturnValue(testPrefix)
       connectivity.buildHeadersForDestination.mockReturnValue({})
     })
 
-    describe('Creating Types', () => {
-      test('Create Default and all new types when none exist in Work Zone', () => {
+    describe("Creating Types", () => {
+      test("Create Default and all new types when none exist in Work Zone", () => {
         httpClient.executeHttpRequest.mockReturnValue(emptyResponseBody)
 
         return notificationTypes
@@ -358,22 +358,22 @@ describe('Managing of Notification Types', () => {
               c => c[1]
             )
 
-            expect(createDefault.method).toBe('post')
+            expect(createDefault.method).toBe("post")
             expect(createDefault.data).toEqual(defaultNotificationType)
 
-            expect(createFirst.method).toBe('post')
+            expect(createFirst.method).toBe("post")
             expect(createFirst.data).toEqual(toNTypeWithPrefixedKey(notificationTypeWithAllProperties))
 
-            expect(createSecond.method).toBe('post')
+            expect(createSecond.method).toBe("post")
             expect(createSecond.data).toEqual(
-              toNTypeWithPrefixedKey({ ...notificationTypeWithoutVersion, NotificationTypeVersion: '1' })
+              toNTypeWithPrefixedKey({ ...notificationTypeWithoutVersion, NotificationTypeVersion: "1" })
             )
 
             expect(extra).toBeUndefined()
           })
       })
 
-      test('Do not create Default type when it already exists in Work Zone', () => {
+      test("Do not create Default type when it already exists in Work Zone", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         return notificationTypes
@@ -382,15 +382,15 @@ describe('Managing of Notification Types', () => {
             structuredClone(notificationTypeWithoutVersion)
           ])
           .then(() => {
-            const postCalls = httpClient.executeHttpRequest.mock.calls.filter(c => c[1].method === 'post')
+            const postCalls = httpClient.executeHttpRequest.mock.calls.filter(c => c[1].method === "post")
             expect(postCalls).toHaveLength(0)
           })
       })
 
-      test('Create a missing version when another version of the same type exists', () => {
+      test("Create a missing version when another version of the same type exists", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
         const versionTwo = structuredClone(notificationTypeWithAllProperties)
-        versionTwo.NotificationTypeVersion = '2'
+        versionTwo.NotificationTypeVersion = "2"
 
         return notificationTypes
           .processNotificationTypes([
@@ -400,30 +400,30 @@ describe('Managing of Notification Types', () => {
           ])
           .then(() => {
             const createCall = httpClient.executeHttpRequest.mock.calls[1][1]
-            expect(createCall.method).toBe('post')
-            expect(createCall.data.NotificationTypeVersion).toBe('2')
+            expect(createCall.method).toBe("post")
+            expect(createCall.data.NotificationTypeVersion).toBe("2")
             expect(httpClient.executeHttpRequest.mock.calls[2]).toBeUndefined()
           })
       })
 
-      test('Fall back gracefully when create response has no data.d', () => {
+      test("Fall back gracefully when create response has no data.d", () => {
         httpClient.executeHttpRequest.mockReturnValueOnce(emptyResponseBody).mockReturnValue({ status: 201 })
 
         return notificationTypes
           .processNotificationTypes([structuredClone(notificationTypeWithAllProperties)])
           .then(() => {
-            expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe('post')
+            expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe("post")
           })
       })
 
-      test('Create new types correctly when existing types use OData results format', () => {
+      test("Create new types correctly when existing types use OData results format", () => {
         httpClient.executeHttpRequest.mockReturnValue({
           data: {
             d: {
               results: [
                 {
-                  NotificationTypeKey: 'Default',
-                  NotificationTypeVersion: '1',
+                  NotificationTypeKey: "Default",
+                  NotificationTypeVersion: "1",
                   IsGroupable: true,
                   Templates: { results: [] },
                   Actions: { results: [] },
@@ -437,20 +437,20 @@ describe('Managing of Notification Types', () => {
         return notificationTypes
           .processNotificationTypes([structuredClone(notificationTypeWithAllProperties)])
           .then(() => {
-            expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe('post')
+            expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe("post")
             expect(httpClient.executeHttpRequest.mock.calls[2]).toBeUndefined()
           })
       })
     })
 
-    describe('Updating Types', () => {
-      test('Update all changed types', () => {
+    describe("Updating Types", () => {
+      test("Update all changed types", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const updatedWithAll = structuredClone(notificationTypeWithAllProperties)
-        updatedWithAll.Templates[0].Description = 'New Description'
+        updatedWithAll.Templates[0].Description = "New Description"
         const updatedWithoutVersion = structuredClone(notificationTypeWithoutVersion)
-        updatedWithoutVersion.Templates[0].Description = 'New Description'
+        updatedWithoutVersion.Templates[0].Description = "New Description"
 
         return notificationTypes
           .processNotificationTypes([structuredClone(updatedWithAll), structuredClone(updatedWithoutVersion)])
@@ -460,27 +460,27 @@ describe('Managing of Notification Types', () => {
             expect(updateFirst.url).toBe(
               "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
             )
-            expect(updateFirst.method).toBe('patch')
+            expect(updateFirst.method).toBe("patch")
             expect(updateFirst.data).toEqual(toNTypeWithPrefixedKey(updatedWithAll))
 
             expect(updateSecond.url).toBe(
               "v2/NotificationType.svc/NotificationTypes(guid'719d8f6a-1e07-4981-b2be-07197cec7492')"
             )
-            expect(updateSecond.method).toBe('patch')
+            expect(updateSecond.method).toBe("patch")
             expect(updateSecond.data).toEqual(
-              toNTypeWithPrefixedKey({ ...updatedWithoutVersion, NotificationTypeVersion: '1' })
+              toNTypeWithPrefixedKey({ ...updatedWithoutVersion, NotificationTypeVersion: "1" })
             )
 
             expect(extra).toBeUndefined()
           })
       })
 
-      test('Update type when an additional Template is added', () => {
+      test("Update type when an additional Template is added", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const updated = structuredClone(notificationTypeWithAllProperties)
         updated.Templates[1] = updated.Templates[0]
-        updated.Templates[1].Language = 'DE'
+        updated.Templates[1].Language = "DE"
 
         return notificationTypes
           .processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)])
@@ -489,18 +489,18 @@ describe('Managing of Notification Types', () => {
             expect(updateCall.url).toBe(
               "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
             )
-            expect(updateCall.method).toBe('patch')
+            expect(updateCall.method).toBe("patch")
             expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
             expect(extra).toBeUndefined()
           })
       })
 
-      test('Update type when an additional Action is added', () => {
+      test("Update type when an additional Action is added", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const updated = structuredClone(notificationTypeWithAllProperties)
         updated.Actions[1] = updated.Actions[0]
-        updated.Actions[1].Language = 'DE'
+        updated.Actions[1].Language = "DE"
 
         return notificationTypes
           .processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)])
@@ -509,18 +509,18 @@ describe('Managing of Notification Types', () => {
             expect(updateCall.url).toBe(
               "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
             )
-            expect(updateCall.method).toBe('patch')
+            expect(updateCall.method).toBe("patch")
             expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
             expect(extra).toBeUndefined()
           })
       })
 
-      test('Update type when an additional DeliveryChannel is added', () => {
+      test("Update type when an additional DeliveryChannel is added", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const updated = structuredClone(notificationTypeWithAllProperties)
         updated.DeliveryChannels[1] = updated.DeliveryChannels[0]
-        updated.DeliveryChannels[1].Type = 'MOBILE'
+        updated.DeliveryChannels[1].Type = "MOBILE"
 
         return notificationTypes
           .processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)])
@@ -529,19 +529,19 @@ describe('Managing of Notification Types', () => {
             expect(updateCall.url).toBe(
               "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
             )
-            expect(updateCall.method).toBe('patch')
+            expect(updateCall.method).toBe("patch")
             expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
             expect(extra).toBeUndefined()
           })
       })
 
-      test('Update type when any individual field has changed', async () => {
+      test("Update type when any individual field has changed", async () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const mutate = (target, key, value) => {
-          if (typeof value === 'string') target[key] = value + ' UPDATED'
-          else if (typeof value === 'boolean') target[key] = !value
-          else if (typeof value === 'number') target[key] = value + 1
+          if (typeof value === "string") target[key] = value + " UPDATED"
+          else if (typeof value === "boolean") target[key] = !value
+          else if (typeof value === "number") target[key] = value + 1
           else return false
           return true
         }
@@ -551,13 +551,13 @@ describe('Managing of Notification Types', () => {
           expect(updateCall.url).toBe(
             "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
           )
-          expect(updateCall.method).toBe('patch')
+          expect(updateCall.method).toBe("patch")
           expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(changed))
           expect(extra).toBeUndefined()
         }
 
         for (const [key, value] of Object.entries(notificationTypeWithAllProperties)) {
-          if (key === 'NotificationTypeKey' || key === 'NotificationTypeVersion') continue
+          if (key === "NotificationTypeKey" || key === "NotificationTypeVersion") continue
           const changed = structuredClone(notificationTypeWithAllProperties)
           if (!mutate(changed, key, value)) continue
           await notificationTypes
@@ -594,15 +594,15 @@ describe('Managing of Notification Types', () => {
         }
       })
 
-      test('Update type when existing type has null inner results', () => {
+      test("Update type when existing type has null inner results", () => {
         httpClient.executeHttpRequest.mockReturnValue({
           data: {
             d: {
               results: [
                 {
-                  NotificationTypeId: 'test-guid-123',
-                  NotificationTypeKey: 'test-prefix/notificationTypeWithAllProperties',
-                  NotificationTypeVersion: '1',
+                  NotificationTypeId: "test-guid-123",
+                  NotificationTypeKey: "test-prefix/notificationTypeWithAllProperties",
+                  NotificationTypeVersion: "1",
                   IsGroupable: true,
                   Templates: { results: null },
                   Actions: { results: null },
@@ -617,13 +617,13 @@ describe('Managing of Notification Types', () => {
           .processNotificationTypes([structuredClone(notificationTypeWithAllProperties)])
           .then(() => {
             const [, updateCall] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
-            expect(updateCall.method).toBe('patch')
+            expect(updateCall.method).toBe("patch")
           })
       })
     })
 
-    describe('No Changed Needed', () => {
-      test('Do nothing when all types match exactly', () => {
+    describe("No Changed Needed", () => {
+      test("Do nothing when all types match exactly", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         return notificationTypes
@@ -636,7 +636,7 @@ describe('Managing of Notification Types', () => {
           })
       })
 
-      test('Do nothing when input Templates/Actions/DeliveryChannels use OData results wrapper', () => {
+      test("Do nothing when input Templates/Actions/DeliveryChannels use OData results wrapper", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const local = structuredClone(notificationTypeWithAllProperties)
@@ -651,7 +651,7 @@ describe('Managing of Notification Types', () => {
           })
       })
 
-      test('Do nothing when IsGroupable is undefined (treated as true)', () => {
+      test("Do nothing when IsGroupable is undefined (treated as true)", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const local = structuredClone(notificationTypeWithAllProperties)
@@ -664,7 +664,7 @@ describe('Managing of Notification Types', () => {
           })
       })
 
-      test('Do nothing when Language fields are lowercase', () => {
+      test("Do nothing when Language fields are lowercase", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const local = structuredClone(notificationTypeWithAllProperties)
@@ -678,7 +678,7 @@ describe('Managing of Notification Types', () => {
           })
       })
 
-      test('Do nothing when TemplateLanguage is lowercase', () => {
+      test("Do nothing when TemplateLanguage is lowercase", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const local = structuredClone(notificationTypeWithAllProperties)
@@ -692,7 +692,7 @@ describe('Managing of Notification Types', () => {
           })
       })
 
-      test('Do nothing when Templates, Actions and DeliveryChannels are null in both local and remote', () => {
+      test("Do nothing when Templates, Actions and DeliveryChannels are null in both local and remote", () => {
         httpClient.executeHttpRequest.mockReturnValue(
           allExistingWithUndefinedTemplatesActionsAndDeliveryChannelsResponseBody
         )
@@ -704,23 +704,23 @@ describe('Managing of Notification Types', () => {
           })
       })
 
-      test('Do nothing when existing type matches local type exactly', () => {
+      test("Do nothing when existing type matches local type exactly", () => {
         httpClient.executeHttpRequest.mockReturnValue({
           data: {
             d: {
               results: [
                 {
-                  NotificationTypeId: '26f1fad0-de4c-4869-9b4e-62f445c8a7a8',
-                  NotificationTypeKey: 'test-prefix/notificationTypeWithAllProperties',
-                  NotificationTypeVersion: '1',
+                  NotificationTypeId: "26f1fad0-de4c-4869-9b4e-62f445c8a7a8",
+                  NotificationTypeKey: "test-prefix/notificationTypeWithAllProperties",
+                  NotificationTypeVersion: "1",
                   IsGroupable: true,
                   Templates: structuredClone(notificationTypeWithAllProperties).Templates,
                   Actions: structuredClone(notificationTypeWithAllProperties).Actions,
                   DeliveryChannels: structuredClone(notificationTypeWithAllProperties).DeliveryChannels
                 },
                 {
-                  NotificationTypeKey: 'Default',
-                  NotificationTypeVersion: '1',
+                  NotificationTypeKey: "Default",
+                  NotificationTypeVersion: "1",
                   IsGroupable: true,
                   Templates: [],
                   Actions: [],
@@ -739,7 +739,7 @@ describe('Managing of Notification Types', () => {
       })
     })
 
-    test('Deletes a type that is no longer in the local file', () => {
+    test("Deletes a type that is no longer in the local file", () => {
       httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
       return notificationTypes
@@ -749,7 +749,7 @@ describe('Managing of Notification Types', () => {
           expect(deleteCall.url).toBe(
             "v2/NotificationType.svc/NotificationTypes(guid'719d8f6a-1e07-4981-b2be-07197cec7492')"
           )
-          expect(deleteCall.method).toBe('delete')
+          expect(deleteCall.method).toBe("delete")
           expect(extra).toBeUndefined()
         })
     })
@@ -758,6 +758,6 @@ describe('Managing of Notification Types', () => {
 
 function toNTypeWithPrefixedKey(ntype) {
   var prefixedNtype = structuredClone(ntype)
-  prefixedNtype.NotificationTypeKey = testPrefix + '/' + prefixedNtype.NotificationTypeKey
+  prefixedNtype.NotificationTypeKey = testPrefix + "/" + prefixedNtype.NotificationTypeKey
   return prefixedNtype
 }

--- a/tests/unit/lib/notificationTypes.test.js
+++ b/tests/unit/lib/notificationTypes.test.js
@@ -348,29 +348,43 @@ describe("Managing of Notification Types", () => {
       test("Create Default and all new types when none exist in Work Zone", () => {
         httpClient.executeHttpRequest.mockReturnValue(emptyResponseBody)
 
-        return notificationTypes.processNotificationTypes([structuredClone(notificationTypeWithAllProperties), structuredClone(notificationTypeWithoutVersion)]).then(() => {
-          const [, createDefault, createFirst, createSecond, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
+        return notificationTypes
+          .processNotificationTypes([
+            structuredClone(notificationTypeWithAllProperties),
+            structuredClone(notificationTypeWithoutVersion)
+          ])
+          .then(() => {
+            const [, createDefault, createFirst, createSecond, extra] = httpClient.executeHttpRequest.mock.calls.map(
+              c => c[1]
+            )
 
-          expect(createDefault.method).toBe("post")
-          expect(createDefault.data).toEqual(defaultNotificationType)
+            expect(createDefault.method).toBe("post")
+            expect(createDefault.data).toEqual(defaultNotificationType)
 
-          expect(createFirst.method).toBe("post")
-          expect(createFirst.data).toEqual(toNTypeWithPrefixedKey(notificationTypeWithAllProperties))
+            expect(createFirst.method).toBe("post")
+            expect(createFirst.data).toEqual(toNTypeWithPrefixedKey(notificationTypeWithAllProperties))
 
-          expect(createSecond.method).toBe("post")
-          expect(createSecond.data).toEqual(toNTypeWithPrefixedKey({ ...notificationTypeWithoutVersion, NotificationTypeVersion: "1" }))
+            expect(createSecond.method).toBe("post")
+            expect(createSecond.data).toEqual(
+              toNTypeWithPrefixedKey({ ...notificationTypeWithoutVersion, NotificationTypeVersion: "1" })
+            )
 
-          expect(extra).toBeUndefined()
-        })
+            expect(extra).toBeUndefined()
+          })
       })
 
       test("Do not create Default type when it already exists in Work Zone", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
-        return notificationTypes.processNotificationTypes([structuredClone(notificationTypeWithAllProperties), structuredClone(notificationTypeWithoutVersion)]).then(() => {
-          const postCalls = httpClient.executeHttpRequest.mock.calls.filter(c => c[1].method === "post")
-          expect(postCalls).toHaveLength(0)
-        })
+        return notificationTypes
+          .processNotificationTypes([
+            structuredClone(notificationTypeWithAllProperties),
+            structuredClone(notificationTypeWithoutVersion)
+          ])
+          .then(() => {
+            const postCalls = httpClient.executeHttpRequest.mock.calls.filter(c => c[1].method === "post")
+            expect(postCalls).toHaveLength(0)
+          })
       })
 
       test("Create a missing version when another version of the same type exists", () => {
@@ -378,22 +392,28 @@ describe("Managing of Notification Types", () => {
         const versionTwo = structuredClone(notificationTypeWithAllProperties)
         versionTwo.NotificationTypeVersion = "2"
 
-        return notificationTypes.processNotificationTypes([structuredClone(notificationTypeWithAllProperties), versionTwo, structuredClone(notificationTypeWithoutVersion)]).then(() => {
-          const createCall = httpClient.executeHttpRequest.mock.calls[1][1]
-          expect(createCall.method).toBe("post")
-          expect(createCall.data.NotificationTypeVersion).toBe("2")
-          expect(httpClient.executeHttpRequest.mock.calls[2]).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([
+            structuredClone(notificationTypeWithAllProperties),
+            versionTwo,
+            structuredClone(notificationTypeWithoutVersion)
+          ])
+          .then(() => {
+            const createCall = httpClient.executeHttpRequest.mock.calls[1][1]
+            expect(createCall.method).toBe("post")
+            expect(createCall.data.NotificationTypeVersion).toBe("2")
+            expect(httpClient.executeHttpRequest.mock.calls[2]).toBeUndefined()
+          })
       })
 
       test("Fall back gracefully when create response has no data.d", () => {
-        httpClient.executeHttpRequest
-          .mockReturnValueOnce(emptyResponseBody)
-          .mockReturnValue({ status: 201 })
+        httpClient.executeHttpRequest.mockReturnValueOnce(emptyResponseBody).mockReturnValue({ status: 201 })
 
-        return notificationTypes.processNotificationTypes([structuredClone(notificationTypeWithAllProperties)]).then(() => {
-          expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe("post")
-        })
+        return notificationTypes
+          .processNotificationTypes([structuredClone(notificationTypeWithAllProperties)])
+          .then(() => {
+            expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe("post")
+          })
       })
 
       test("Create new types correctly when existing types use OData results format", () => {
@@ -414,10 +434,12 @@ describe("Managing of Notification Types", () => {
           }
         })
 
-        return notificationTypes.processNotificationTypes([structuredClone(notificationTypeWithAllProperties)]).then(() => {
-          expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe("post")
-          expect(httpClient.executeHttpRequest.mock.calls[2]).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([structuredClone(notificationTypeWithAllProperties)])
+          .then(() => {
+            expect(httpClient.executeHttpRequest.mock.calls[1][1].method).toBe("post")
+            expect(httpClient.executeHttpRequest.mock.calls[2]).toBeUndefined()
+          })
       })
     })
 
@@ -430,19 +452,27 @@ describe("Managing of Notification Types", () => {
         const updatedWithoutVersion = structuredClone(notificationTypeWithoutVersion)
         updatedWithoutVersion.Templates[0].Description = "New Description"
 
-        return notificationTypes.processNotificationTypes([structuredClone(updatedWithAll), structuredClone(updatedWithoutVersion)]).then(() => {
-          const [, updateFirst, updateSecond, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
+        return notificationTypes
+          .processNotificationTypes([structuredClone(updatedWithAll), structuredClone(updatedWithoutVersion)])
+          .then(() => {
+            const [, updateFirst, updateSecond, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
 
-          expect(updateFirst.url).toBe("v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')")
-          expect(updateFirst.method).toBe("patch")
-          expect(updateFirst.data).toEqual(toNTypeWithPrefixedKey(updatedWithAll))
+            expect(updateFirst.url).toBe(
+              "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
+            )
+            expect(updateFirst.method).toBe("patch")
+            expect(updateFirst.data).toEqual(toNTypeWithPrefixedKey(updatedWithAll))
 
-          expect(updateSecond.url).toBe("v2/NotificationType.svc/NotificationTypes(guid'719d8f6a-1e07-4981-b2be-07197cec7492')")
-          expect(updateSecond.method).toBe("patch")
-          expect(updateSecond.data).toEqual(toNTypeWithPrefixedKey({ ...updatedWithoutVersion, NotificationTypeVersion: "1" }))
+            expect(updateSecond.url).toBe(
+              "v2/NotificationType.svc/NotificationTypes(guid'719d8f6a-1e07-4981-b2be-07197cec7492')"
+            )
+            expect(updateSecond.method).toBe("patch")
+            expect(updateSecond.data).toEqual(
+              toNTypeWithPrefixedKey({ ...updatedWithoutVersion, NotificationTypeVersion: "1" })
+            )
 
-          expect(extra).toBeUndefined()
-        })
+            expect(extra).toBeUndefined()
+          })
       })
 
       test("Update type when an additional Template is added", () => {
@@ -452,13 +482,17 @@ describe("Managing of Notification Types", () => {
         updated.Templates[1] = updated.Templates[0]
         updated.Templates[1].Language = "DE"
 
-        return notificationTypes.processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)]).then(() => {
-          const [, updateCall, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
-          expect(updateCall.url).toBe("v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')")
-          expect(updateCall.method).toBe("patch")
-          expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
-          expect(extra).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)])
+          .then(() => {
+            const [, updateCall, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
+            expect(updateCall.url).toBe(
+              "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
+            )
+            expect(updateCall.method).toBe("patch")
+            expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
+            expect(extra).toBeUndefined()
+          })
       })
 
       test("Update type when an additional Action is added", () => {
@@ -468,13 +502,17 @@ describe("Managing of Notification Types", () => {
         updated.Actions[1] = updated.Actions[0]
         updated.Actions[1].Language = "DE"
 
-        return notificationTypes.processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)]).then(() => {
-          const [, updateCall, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
-          expect(updateCall.url).toBe("v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')")
-          expect(updateCall.method).toBe("patch")
-          expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
-          expect(extra).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)])
+          .then(() => {
+            const [, updateCall, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
+            expect(updateCall.url).toBe(
+              "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
+            )
+            expect(updateCall.method).toBe("patch")
+            expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
+            expect(extra).toBeUndefined()
+          })
       })
 
       test("Update type when an additional DeliveryChannel is added", () => {
@@ -484,29 +522,35 @@ describe("Managing of Notification Types", () => {
         updated.DeliveryChannels[1] = updated.DeliveryChannels[0]
         updated.DeliveryChannels[1].Type = "MOBILE"
 
-        return notificationTypes.processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)]).then(() => {
-          const [, updateCall, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
-          expect(updateCall.url).toBe("v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')")
-          expect(updateCall.method).toBe("patch")
-          expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
-          expect(extra).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([structuredClone(updated), structuredClone(notificationTypeWithoutVersion)])
+          .then(() => {
+            const [, updateCall, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
+            expect(updateCall.url).toBe(
+              "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
+            )
+            expect(updateCall.method).toBe("patch")
+            expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(updated))
+            expect(extra).toBeUndefined()
+          })
       })
 
       test("Update type when any individual field has changed", async () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const mutate = (target, key, value) => {
-        if (typeof value === "string") target[key] = value + " UPDATED"
+          if (typeof value === "string") target[key] = value + " UPDATED"
           else if (typeof value === "boolean") target[key] = !value
           else if (typeof value === "number") target[key] = value + 1
           else return false
           return true
         }
 
-        const assertUpdateCall = (changed) => {
+        const assertUpdateCall = changed => {
           const [, updateCall, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
-          expect(updateCall.url).toBe("v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')")
+          expect(updateCall.url).toBe(
+            "v2/NotificationType.svc/NotificationTypes(guid'26f1fad0-de4c-4869-9b4e-62f445c8a7a8')"
+          )
           expect(updateCall.method).toBe("patch")
           expect(updateCall.data).toEqual(toNTypeWithPrefixedKey(changed))
           expect(extra).toBeUndefined()
@@ -516,28 +560,36 @@ describe("Managing of Notification Types", () => {
           if (key === "NotificationTypeKey" || key === "NotificationTypeVersion") continue
           const changed = structuredClone(notificationTypeWithAllProperties)
           if (!mutate(changed, key, value)) continue
-          await notificationTypes.processNotificationTypes([structuredClone(changed), structuredClone(notificationTypeWithoutVersion)]).then(() => assertUpdateCall(changed))
+          await notificationTypes
+            .processNotificationTypes([structuredClone(changed), structuredClone(notificationTypeWithoutVersion)])
+            .then(() => assertUpdateCall(changed))
           jest.clearAllMocks()
         }
 
         for (const [key, value] of Object.entries(notificationTypeWithAllProperties.Templates[0])) {
           const changed = structuredClone(notificationTypeWithAllProperties)
           if (!mutate(changed.Templates[0], key, value)) continue
-          await notificationTypes.processNotificationTypes([structuredClone(changed), structuredClone(notificationTypeWithoutVersion)]).then(() => assertUpdateCall(changed))
+          await notificationTypes
+            .processNotificationTypes([structuredClone(changed), structuredClone(notificationTypeWithoutVersion)])
+            .then(() => assertUpdateCall(changed))
           jest.clearAllMocks()
         }
 
         for (const [key, value] of Object.entries(notificationTypeWithAllProperties.Actions[0])) {
           const changed = structuredClone(notificationTypeWithAllProperties)
           if (!mutate(changed.Actions[0], key, value)) continue
-          await notificationTypes.processNotificationTypes([structuredClone(changed), structuredClone(notificationTypeWithoutVersion)]).then(() => assertUpdateCall(changed))
+          await notificationTypes
+            .processNotificationTypes([structuredClone(changed), structuredClone(notificationTypeWithoutVersion)])
+            .then(() => assertUpdateCall(changed))
           jest.clearAllMocks()
         }
 
         for (const [key, value] of Object.entries(notificationTypeWithAllProperties.DeliveryChannels[0])) {
           const changed = structuredClone(notificationTypeWithAllProperties)
           if (!mutate(changed.DeliveryChannels[0], key, value)) continue
-          await notificationTypes.processNotificationTypes([structuredClone(changed), structuredClone(notificationTypeWithoutVersion)]).then(() => assertUpdateCall(changed))
+          await notificationTypes
+            .processNotificationTypes([structuredClone(changed), structuredClone(notificationTypeWithoutVersion)])
+            .then(() => assertUpdateCall(changed))
           jest.clearAllMocks()
         }
       })
@@ -546,23 +598,27 @@ describe("Managing of Notification Types", () => {
         httpClient.executeHttpRequest.mockReturnValue({
           data: {
             d: {
-              results: [{
-                NotificationTypeId: "test-guid-123",
-                NotificationTypeKey: "test-prefix/notificationTypeWithAllProperties",
-                NotificationTypeVersion: "1",
-                IsGroupable: true,
-                Templates: { results: null },
-                Actions: { results: null },
-                DeliveryChannels: { results: null }
-              }]
+              results: [
+                {
+                  NotificationTypeId: "test-guid-123",
+                  NotificationTypeKey: "test-prefix/notificationTypeWithAllProperties",
+                  NotificationTypeVersion: "1",
+                  IsGroupable: true,
+                  Templates: { results: null },
+                  Actions: { results: null },
+                  DeliveryChannels: { results: null }
+                }
+              ]
             }
           }
         })
 
-        return notificationTypes.processNotificationTypes([structuredClone(notificationTypeWithAllProperties)]).then(() => {
-          const [, updateCall] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
-          expect(updateCall.method).toBe("patch")
-        })
+        return notificationTypes
+          .processNotificationTypes([structuredClone(notificationTypeWithAllProperties)])
+          .then(() => {
+            const [, updateCall] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
+            expect(updateCall.method).toBe("patch")
+          })
       })
     })
 
@@ -570,9 +626,14 @@ describe("Managing of Notification Types", () => {
       test("Do nothing when all types match exactly", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
-        return notificationTypes.processNotificationTypes([structuredClone(notificationTypeWithAllProperties), structuredClone(notificationTypeWithoutVersion)]).then(() => {
-          expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([
+            structuredClone(notificationTypeWithAllProperties),
+            structuredClone(notificationTypeWithoutVersion)
+          ])
+          .then(() => {
+            expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
+          })
       })
 
       test("Do nothing when input Templates/Actions/DeliveryChannels use OData results wrapper", () => {
@@ -583,9 +644,11 @@ describe("Managing of Notification Types", () => {
         local.Actions = { results: notificationTypeWithAllProperties.Actions }
         local.DeliveryChannels = { results: notificationTypeWithAllProperties.DeliveryChannels }
 
-        return notificationTypes.processNotificationTypes([local, structuredClone(notificationTypeWithoutVersion)]).then(() => {
-          expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([local, structuredClone(notificationTypeWithoutVersion)])
+          .then(() => {
+            expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
+          })
       })
 
       test("Do nothing when IsGroupable is undefined (treated as true)", () => {
@@ -594,9 +657,11 @@ describe("Managing of Notification Types", () => {
         const local = structuredClone(notificationTypeWithAllProperties)
         local.IsGroupable = undefined
 
-        return notificationTypes.processNotificationTypes([local, structuredClone(notificationTypeWithoutVersion)]).then(() => {
-          expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([local, structuredClone(notificationTypeWithoutVersion)])
+          .then(() => {
+            expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
+          })
       })
 
       test("Do nothing when Language fields are lowercase", () => {
@@ -606,28 +671,37 @@ describe("Managing of Notification Types", () => {
         local.Templates[0].Language = notificationTypeWithAllProperties.Templates[0].Language.toLowerCase()
         local.Actions[0].Language = notificationTypeWithAllProperties.Actions[0].Language.toLowerCase()
 
-        return notificationTypes.processNotificationTypes([local, structuredClone(notificationTypeWithoutVersion)]).then(() => {
-          expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([local, structuredClone(notificationTypeWithoutVersion)])
+          .then(() => {
+            expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
+          })
       })
 
       test("Do nothing when TemplateLanguage is lowercase", () => {
         httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
         const local = structuredClone(notificationTypeWithAllProperties)
-        local.Templates[0].TemplateLanguage = notificationTypeWithAllProperties.Templates[0].TemplateLanguage.toLowerCase()
+        local.Templates[0].TemplateLanguage =
+          notificationTypeWithAllProperties.Templates[0].TemplateLanguage.toLowerCase()
 
-        return notificationTypes.processNotificationTypes([local, structuredClone(notificationTypeWithoutVersion)]).then(() => {
-          expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([local, structuredClone(notificationTypeWithoutVersion)])
+          .then(() => {
+            expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
+          })
       })
 
       test("Do nothing when Templates, Actions and DeliveryChannels are null in both local and remote", () => {
-        httpClient.executeHttpRequest.mockReturnValue(allExistingWithUndefinedTemplatesActionsAndDeliveryChannelsResponseBody)
+        httpClient.executeHttpRequest.mockReturnValue(
+          allExistingWithUndefinedTemplatesActionsAndDeliveryChannelsResponseBody
+        )
 
-        return notificationTypes.processNotificationTypes([structuredClone(notificationTypeWithNullTemplatesActionsAndDeliveryChannels)]).then(() => {
-          expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([structuredClone(notificationTypeWithNullTemplatesActionsAndDeliveryChannels)])
+          .then(() => {
+            expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
+          })
       })
 
       test("Do nothing when existing type matches local type exactly", () => {
@@ -657,21 +731,27 @@ describe("Managing of Notification Types", () => {
           }
         })
 
-        return notificationTypes.processNotificationTypes([structuredClone(notificationTypeWithAllProperties)]).then(() => {
-          expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
-        })
+        return notificationTypes
+          .processNotificationTypes([structuredClone(notificationTypeWithAllProperties)])
+          .then(() => {
+            expect(httpClient.executeHttpRequest.mock.calls[1]).toBeUndefined()
+          })
       })
     })
 
     test("Deletes a type that is no longer in the local file", () => {
       httpClient.executeHttpRequest.mockReturnValue(allExistingResponseBody)
 
-      return notificationTypes.processNotificationTypes([structuredClone(notificationTypeWithAllProperties)]).then(() => {
-        const [, deleteCall, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
-        expect(deleteCall.url).toBe("v2/NotificationType.svc/NotificationTypes(guid'719d8f6a-1e07-4981-b2be-07197cec7492')")
-        expect(deleteCall.method).toBe("delete")
-        expect(extra).toBeUndefined()
-      })
+      return notificationTypes
+        .processNotificationTypes([structuredClone(notificationTypeWithAllProperties)])
+        .then(() => {
+          const [, deleteCall, extra] = httpClient.executeHttpRequest.mock.calls.map(c => c[1])
+          expect(deleteCall.url).toBe(
+            "v2/NotificationType.svc/NotificationTypes(guid'719d8f6a-1e07-4981-b2be-07197cec7492')"
+          )
+          expect(deleteCall.method).toBe("delete")
+          expect(extra).toBeUndefined()
+        })
     })
   })
 })

--- a/tests/unit/lib/notifications.test.js
+++ b/tests/unit/lib/notifications.test.js
@@ -1,37 +1,37 @@
-const cds = require("@sap/cds")
-const { getNotificationDestination } = require("../../../lib/utils")
-const { buildHeadersForDestination } = require("@sap-cloud-sdk/connectivity")
-const NotifyToRest = require("../../../srv/notifyToRest")
-const { executeHttpRequest } = require("@sap-cloud-sdk/http-client")
+const cds = require('@sap/cds')
+const { getNotificationDestination } = require('../../../lib/utils')
+const { buildHeadersForDestination } = require('@sap-cloud-sdk/connectivity')
+const NotifyToRest = require('../../../srv/notifyToRest')
+const { executeHttpRequest } = require('@sap-cloud-sdk/http-client')
 
-jest.mock("../../../lib/utils")
-jest.mock("@sap-cloud-sdk/connectivity")
-jest.mock("@sap-cloud-sdk/http-client")
+jest.mock('../../../lib/utils')
+jest.mock('@sap-cloud-sdk/connectivity')
+jest.mock('@sap-cloud-sdk/http-client')
 
 const expectedCustomNotification = {
-  NotificationTypeKey: "Custom",
-  NotificationTypeVersion: "1",
-  Priority: "HIGH",
+  NotificationTypeKey: 'Custom',
+  NotificationTypeVersion: '1',
+  Priority: 'HIGH',
   Properties: [
     {
-      Key: "title",
+      Key: 'title',
       IsSensitive: true,
-      Language: "en",
-      Value: "Some Text Title",
-      Type: "String"
+      Language: 'en',
+      Value: 'Some Text Title',
+      Type: 'String'
     },
     {
-      Key: "description",
+      Key: 'description',
       IsSensitive: true,
-      Language: "en",
-      Value: "Some Text Description",
-      Type: "String"
+      Language: 'en',
+      Value: 'Some Text Description',
+      Type: 'String'
     }
   ],
-  Recipients: [{ RecipientId: "test.mail@mail.com" }]
+  Recipients: [{ RecipientId: 'test.mail@mail.com' }]
 }
 
-describe("Test post notification", () => {
+describe('Test post notification', () => {
   let log = cds.test.log()
   let alert
 
@@ -41,11 +41,11 @@ describe("Test post notification", () => {
     buildHeadersForDestination.mockReturnValue(undefined)
   })
 
-  test("Logs and sends when a valid notification object is posted", async () => {
+  test('Logs and sends when a valid notification object is posted', async () => {
     executeHttpRequest.mockReturnValue(expectedCustomNotification)
     await alert.postNotification(expectedCustomNotification)
 
-    expect(log.output).toContain("Sending notification of key: Custom and version: 1")
+    expect(log.output).toContain('Sending notification of key: Custom and version: 1')
     expect(executeHttpRequest).toHaveBeenCalled()
   })
 
@@ -53,10 +53,10 @@ describe("Test post notification", () => {
     [500, false],
     [404, true],
     [429, false]
-  ])("HTTP %i error - unrecoverable is %s", async (status, unrecoverable) => {
+  ])('HTTP %i error - unrecoverable is %s', async (status, unrecoverable) => {
     expect.assertions(3)
     const error = new Error()
-    error.response = { message: "mocked error", status }
+    error.response = { message: 'mocked error', status }
     executeHttpRequest.mockRejectedValue(error)
 
     try {
@@ -65,34 +65,34 @@ describe("Test post notification", () => {
       expect(!!err.unrecoverable).toBe(unrecoverable)
     }
 
-    expect(log.output).toContain("Sending notification of key: Custom and version: 1")
+    expect(log.output).toContain('Sending notification of key: Custom and version: 1')
     expect(executeHttpRequest).toHaveBeenCalled()
   })
 
-  test("Batch: resolves with empty array when no notifications are passed", async () => {
+  test('Batch: resolves with empty array when no notifications are passed', async () => {
     const results = await alert.postNotification([])
     expect(results).toEqual([])
   })
 
-  test("Batch: resolves when at least one notification succeeds", async () => {
-    const error = new Error("failed")
-    error.response = { message: "failed", status: 500 }
+  test('Batch: resolves when at least one notification succeeds', async () => {
+    const error = new Error('failed')
+    error.response = { message: 'failed', status: 500 }
     executeHttpRequest.mockRejectedValueOnce(error).mockReturnValueOnce(expectedCustomNotification)
 
     const results = await alert.postNotification([expectedCustomNotification, expectedCustomNotification])
     expect(results).toHaveLength(2)
-    expect(results[0].status).toBe("rejected")
-    expect(results[1].status).toBe("fulfilled")
-    expect(log.output).toContain("Batch notification failed:")
+    expect(results[0].status).toBe('rejected')
+    expect(results[1].status).toBe('fulfilled')
+    expect(log.output).toContain('Batch notification failed:')
   })
 
-  test("Batch: throws when all notifications fail", async () => {
-    const error = new Error("all failed")
-    error.response = { message: "all failed", status: 500 }
+  test('Batch: throws when all notifications fail', async () => {
+    const error = new Error('all failed')
+    error.response = { message: 'all failed', status: 500 }
     executeHttpRequest.mockRejectedValue(error)
 
     await expect(alert.postNotification([expectedCustomNotification, expectedCustomNotification])).rejects.toThrow(
-      "all failed"
+      'all failed'
     )
   })
 })

--- a/tests/unit/lib/notifications.test.js
+++ b/tests/unit/lib/notifications.test.js
@@ -1,4 +1,4 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 const { getNotificationDestination } = require("../../../lib/utils")
 const { buildHeadersForDestination } = require("@sap-cloud-sdk/connectivity")
 const NotifyToRest = require("../../../srv/notifyToRest")
@@ -9,92 +9,90 @@ jest.mock("@sap-cloud-sdk/connectivity")
 jest.mock("@sap-cloud-sdk/http-client")
 
 const expectedCustomNotification = {
-    NotificationTypeKey: "Custom",
-    NotificationTypeVersion: "1",
-    Priority: "HIGH",
-    Properties: [
-        {
-            Key: "title",
-            IsSensitive: true,
-            Language: "en",
-            Value: "Some Text Title",
-            Type: "String"
-        },
-        {
-            Key: "description",
-            IsSensitive: true,
-            Language: "en",
-            Value: "Some Text Description",
-            Type: "String"
-        }
-    ],
-    Recipients: [{ RecipientId: "test.mail@mail.com" }]
+  NotificationTypeKey: "Custom",
+  NotificationTypeVersion: "1",
+  Priority: "HIGH",
+  Properties: [
+    {
+      Key: "title",
+      IsSensitive: true,
+      Language: "en",
+      Value: "Some Text Title",
+      Type: "String"
+    },
+    {
+      Key: "description",
+      IsSensitive: true,
+      Language: "en",
+      Value: "Some Text Description",
+      Type: "String"
+    }
+  ],
+  Recipients: [{ RecipientId: "test.mail@mail.com" }]
 }
 
 describe("Test post notification", () => {
-    let log = cds.test.log()
-    let alert
+  let log = cds.test.log()
+  let alert
 
-    beforeEach(() => {
-        alert = new NotifyToRest
-        getNotificationDestination.mockReturnValue(undefined)
-        buildHeadersForDestination.mockReturnValue(undefined)
-    })
+  beforeEach(() => {
+    alert = new NotifyToRest()
+    getNotificationDestination.mockReturnValue(undefined)
+    buildHeadersForDestination.mockReturnValue(undefined)
+  })
 
-    test("Logs and sends when a valid notification object is posted", async () => {
-        executeHttpRequest.mockReturnValue(expectedCustomNotification)
-        await alert.postNotification(expectedCustomNotification)
+  test("Logs and sends when a valid notification object is posted", async () => {
+    executeHttpRequest.mockReturnValue(expectedCustomNotification)
+    await alert.postNotification(expectedCustomNotification)
 
-        expect(log.output).toContain("Sending notification of key: Custom and version: 1")
-        expect(executeHttpRequest).toHaveBeenCalled()
-    })
+    expect(log.output).toContain("Sending notification of key: Custom and version: 1")
+    expect(executeHttpRequest).toHaveBeenCalled()
+  })
 
-    test.each([
-        [500, false],
-        [404, true],
-        [429, false],
-    ])("HTTP %i error - unrecoverable is %s", async (status, unrecoverable) => {
-        expect.assertions(3)
-        const error = new Error()
-        error.response = { message: "mocked error", status }
-        executeHttpRequest.mockRejectedValue(error)
+  test.each([
+    [500, false],
+    [404, true],
+    [429, false]
+  ])("HTTP %i error - unrecoverable is %s", async (status, unrecoverable) => {
+    expect.assertions(3)
+    const error = new Error()
+    error.response = { message: "mocked error", status }
+    executeHttpRequest.mockRejectedValue(error)
 
-        try {
-            await alert.postNotification(expectedCustomNotification)
-        } catch (err) {
-            expect(!!err.unrecoverable).toBe(unrecoverable)
-        }
+    try {
+      await alert.postNotification(expectedCustomNotification)
+    } catch (err) {
+      expect(!!err.unrecoverable).toBe(unrecoverable)
+    }
 
-        expect(log.output).toContain("Sending notification of key: Custom and version: 1")
-        expect(executeHttpRequest).toHaveBeenCalled()
-    })
+    expect(log.output).toContain("Sending notification of key: Custom and version: 1")
+    expect(executeHttpRequest).toHaveBeenCalled()
+  })
 
-    test("Batch: resolves with empty array when no notifications are passed", async () => {
-        const results = await alert.postNotification([])
-        expect(results).toEqual([])
-    })
+  test("Batch: resolves with empty array when no notifications are passed", async () => {
+    const results = await alert.postNotification([])
+    expect(results).toEqual([])
+  })
 
-    test("Batch: resolves when at least one notification succeeds", async () => {
-        const error = new Error('failed')
-        error.response = { message: 'failed', status: 500 }
-        executeHttpRequest
-            .mockRejectedValueOnce(error)
-            .mockReturnValueOnce(expectedCustomNotification)
+  test("Batch: resolves when at least one notification succeeds", async () => {
+    const error = new Error("failed")
+    error.response = { message: "failed", status: 500 }
+    executeHttpRequest.mockRejectedValueOnce(error).mockReturnValueOnce(expectedCustomNotification)
 
-        const results = await alert.postNotification([expectedCustomNotification, expectedCustomNotification])
-        expect(results).toHaveLength(2)
-        expect(results[0].status).toBe('rejected')
-        expect(results[1].status).toBe('fulfilled')
-        expect(log.output).toContain('Batch notification failed:')
-    })
+    const results = await alert.postNotification([expectedCustomNotification, expectedCustomNotification])
+    expect(results).toHaveLength(2)
+    expect(results[0].status).toBe("rejected")
+    expect(results[1].status).toBe("fulfilled")
+    expect(log.output).toContain("Batch notification failed:")
+  })
 
-    test("Batch: throws when all notifications fail", async () => {
-        const error = new Error('all failed')
-        error.response = { message: 'all failed', status: 500 }
-        executeHttpRequest.mockRejectedValue(error)
+  test("Batch: throws when all notifications fail", async () => {
+    const error = new Error("all failed")
+    error.response = { message: "all failed", status: 500 }
+    executeHttpRequest.mockRejectedValue(error)
 
-        await expect(
-            alert.postNotification([expectedCustomNotification, expectedCustomNotification])
-        ).rejects.toThrow('all failed')
-    })
+    await expect(alert.postNotification([expectedCustomNotification, expectedCustomNotification])).rejects.toThrow(
+      "all failed"
+    )
+  })
 })

--- a/tests/unit/lib/notifications.test.js
+++ b/tests/unit/lib/notifications.test.js
@@ -1,37 +1,37 @@
-const cds = require('@sap/cds')
-const { getNotificationDestination } = require('../../../lib/utils')
-const { buildHeadersForDestination } = require('@sap-cloud-sdk/connectivity')
-const NotifyToRest = require('../../../srv/notifyToRest')
-const { executeHttpRequest } = require('@sap-cloud-sdk/http-client')
+const cds = require("@sap/cds")
+const { getNotificationDestination } = require("../../../lib/utils")
+const { buildHeadersForDestination } = require("@sap-cloud-sdk/connectivity")
+const NotifyToRest = require("../../../srv/notifyToRest")
+const { executeHttpRequest } = require("@sap-cloud-sdk/http-client")
 
-jest.mock('../../../lib/utils')
-jest.mock('@sap-cloud-sdk/connectivity')
-jest.mock('@sap-cloud-sdk/http-client')
+jest.mock("../../../lib/utils")
+jest.mock("@sap-cloud-sdk/connectivity")
+jest.mock("@sap-cloud-sdk/http-client")
 
 const expectedCustomNotification = {
-  NotificationTypeKey: 'Custom',
-  NotificationTypeVersion: '1',
-  Priority: 'HIGH',
+  NotificationTypeKey: "Custom",
+  NotificationTypeVersion: "1",
+  Priority: "HIGH",
   Properties: [
     {
-      Key: 'title',
+      Key: "title",
       IsSensitive: true,
-      Language: 'en',
-      Value: 'Some Text Title',
-      Type: 'String'
+      Language: "en",
+      Value: "Some Text Title",
+      Type: "String"
     },
     {
-      Key: 'description',
+      Key: "description",
       IsSensitive: true,
-      Language: 'en',
-      Value: 'Some Text Description',
-      Type: 'String'
+      Language: "en",
+      Value: "Some Text Description",
+      Type: "String"
     }
   ],
-  Recipients: [{ RecipientId: 'test.mail@mail.com' }]
+  Recipients: [{ RecipientId: "test.mail@mail.com" }]
 }
 
-describe('Test post notification', () => {
+describe("Test post notification", () => {
   let log = cds.test.log()
   let alert
 
@@ -41,11 +41,11 @@ describe('Test post notification', () => {
     buildHeadersForDestination.mockReturnValue(undefined)
   })
 
-  test('Logs and sends when a valid notification object is posted', async () => {
+  test("Logs and sends when a valid notification object is posted", async () => {
     executeHttpRequest.mockReturnValue(expectedCustomNotification)
     await alert.postNotification(expectedCustomNotification)
 
-    expect(log.output).toContain('Sending notification of key: Custom and version: 1')
+    expect(log.output).toContain("Sending notification of key: Custom and version: 1")
     expect(executeHttpRequest).toHaveBeenCalled()
   })
 
@@ -53,10 +53,10 @@ describe('Test post notification', () => {
     [500, false],
     [404, true],
     [429, false]
-  ])('HTTP %i error - unrecoverable is %s', async (status, unrecoverable) => {
+  ])("HTTP %i error - unrecoverable is %s", async (status, unrecoverable) => {
     expect.assertions(3)
     const error = new Error()
-    error.response = { message: 'mocked error', status }
+    error.response = { message: "mocked error", status }
     executeHttpRequest.mockRejectedValue(error)
 
     try {
@@ -65,34 +65,34 @@ describe('Test post notification', () => {
       expect(!!err.unrecoverable).toBe(unrecoverable)
     }
 
-    expect(log.output).toContain('Sending notification of key: Custom and version: 1')
+    expect(log.output).toContain("Sending notification of key: Custom and version: 1")
     expect(executeHttpRequest).toHaveBeenCalled()
   })
 
-  test('Batch: resolves with empty array when no notifications are passed', async () => {
+  test("Batch: resolves with empty array when no notifications are passed", async () => {
     const results = await alert.postNotification([])
     expect(results).toEqual([])
   })
 
-  test('Batch: resolves when at least one notification succeeds', async () => {
-    const error = new Error('failed')
-    error.response = { message: 'failed', status: 500 }
+  test("Batch: resolves when at least one notification succeeds", async () => {
+    const error = new Error("failed")
+    error.response = { message: "failed", status: 500 }
     executeHttpRequest.mockRejectedValueOnce(error).mockReturnValueOnce(expectedCustomNotification)
 
     const results = await alert.postNotification([expectedCustomNotification, expectedCustomNotification])
     expect(results).toHaveLength(2)
-    expect(results[0].status).toBe('rejected')
-    expect(results[1].status).toBe('fulfilled')
-    expect(log.output).toContain('Batch notification failed:')
+    expect(results[0].status).toBe("rejected")
+    expect(results[1].status).toBe("fulfilled")
+    expect(log.output).toContain("Batch notification failed:")
   })
 
-  test('Batch: throws when all notifications fail', async () => {
-    const error = new Error('all failed')
-    error.response = { message: 'all failed', status: 500 }
+  test("Batch: throws when all notifications fail", async () => {
+    const error = new Error("all failed")
+    error.response = { message: "all failed", status: 500 }
     executeHttpRequest.mockRejectedValue(error)
 
     await expect(alert.postNotification([expectedCustomNotification, expectedCustomNotification])).rejects.toThrow(
-      'all failed'
+      "all failed"
     )
   })
 })

--- a/tests/unit/lib/plugin.test.js
+++ b/tests/unit/lib/plugin.test.js
@@ -1,146 +1,146 @@
-const cds = require('@sap/cds')
-require('../../../cds-plugin')
+const cds = require("@sap/cds")
+require("../../../cds-plugin")
 
 function makeModel(defs) {
   return { definitions: defs }
 }
 
-describe('Loaded hook - recipients injection', () => {
-  test('Inject recipients into a notification event that has none', () => {
+describe("Loaded hook - recipients injection", () => {
+  test("Inject recipients into a notification event that has none", () => {
     const model = makeModel({
       MyEvent: {
-        kind: 'event',
-        '@notification.template.title': 'Test',
+        kind: "event",
+        "@notification.template.title": "Test",
         elements: {}
       }
     })
-    cds.emit('loaded', model)
-    expect(model.definitions.MyEvent.elements.recipients).toEqual({ items: { type: 'cds.String' } })
+    cds.emit("loaded", model)
+    expect(model.definitions.MyEvent.elements.recipients).toEqual({ items: { type: "cds.String" } })
   })
 
-  test('Do not overwrite recipients already defined on the event', () => {
-    const existing = { items: { type: 'cds.String' } }
+  test("Do not overwrite recipients already defined on the event", () => {
+    const existing = { items: { type: "cds.String" } }
     const model = makeModel({
       MyEvent: {
-        kind: 'event',
-        '@notification.template.title': 'Test',
+        kind: "event",
+        "@notification.template.title": "Test",
         elements: { recipients: existing }
       }
     })
-    cds.emit('loaded', model)
+    cds.emit("loaded", model)
     expect(model.definitions.MyEvent.elements.recipients).toBe(existing)
   })
 
-  test('Do not inject recipients on events without @notification', () => {
+  test("Do not inject recipients on events without @notification", () => {
     const model = makeModel({
-      PlainEvent: { kind: 'event', elements: {} }
+      PlainEvent: { kind: "event", elements: {} }
     })
-    cds.emit('loaded', model)
+    cds.emit("loaded", model)
     expect(model.definitions.PlainEvent.elements.recipients).toBeUndefined()
   })
 
-  test('Create elements object if missing before injecting', () => {
+  test("Create elements object if missing before injecting", () => {
     const model = makeModel({
       MyEvent: {
-        kind: 'event',
-        '@notification': true
+        kind: "event",
+        "@notification": true
       }
     })
-    cds.emit('loaded', model)
-    expect(model.definitions.MyEvent.elements.recipients).toEqual({ items: { type: 'cds.String' } })
+    cds.emit("loaded", model)
+    expect(model.definitions.MyEvent.elements.recipients).toEqual({ items: { type: "cds.String" } })
   })
 })
 
-describe('Serving hook - notification handler registration', () => {
+describe("Serving hook - notification handler registration", () => {
   let notifySpy, registeredHandler, service
 
   beforeEach(async () => {
     notifySpy = jest.fn()
-    jest.spyOn(cds.connect, 'to').mockResolvedValue({ notify: notifySpy })
+    jest.spyOn(cds.connect, "to").mockResolvedValue({ notify: notifySpy })
 
     registeredHandler = undefined
     service = new cds.Service()
-    service.name = 'LazyService'
+    service.name = "LazyService"
     service.events = {}
-    jest.spyOn(service, 'on').mockImplementation((event, handler) => {
-      if (event === '*') registeredHandler = handler
+    jest.spyOn(service, "on").mockImplementation((event, handler) => {
+      if (event === "*") registeredHandler = handler
     })
 
-    await cds.emit('serving', service)
+    await cds.emit("serving", service)
   })
 
   afterEach(() => jest.restoreAllMocks())
 
-  test('Does not attach a handler to the notifications service itself', async () => {
+  test("Does not attach a handler to the notifications service itself", async () => {
     const service = new cds.Service()
-    service.name = 'notifications'
-    const onSpy = jest.spyOn(service, 'on')
-    await cds.emit('serving', service)
+    service.name = "notifications"
+    const onSpy = jest.spyOn(service, "on")
+    await cds.emit("serving", service)
     expect(onSpy).not.toHaveBeenCalled()
   })
 
-  test('Registers a handler on lazily connected services', () => {
+  test("Registers a handler on lazily connected services", () => {
     expect(registeredHandler).toBeDefined()
   })
 
-  test('Calls notify for @notification events', async () => {
+  test("Calls notify for @notification events", async () => {
     const eventDef = {
-      kind: 'event',
-      name: 'LazyService.OrderPlaced',
-      '@notification': true,
-      '@notification.priority': { '#': 'High' },
-      '@Common.SemanticObject': 'Orders',
-      '@Common.SemanticObjectAction': 'manage',
+      kind: "event",
+      name: "LazyService.OrderPlaced",
+      "@notification": true,
+      "@notification.priority": { "#": "High" },
+      "@Common.SemanticObject": "Orders",
+      "@Common.SemanticObjectAction": "manage",
       elements: {
-        ID: { type: 'cds.String', key: true },
-        title: { type: 'cds.String' },
-        recipients: { items: { type: 'cds.String' } }
+        ID: { type: "cds.String", key: true },
+        title: { type: "cds.String" },
+        recipients: { items: { type: "cds.String" } }
       }
     }
-    service.events['OrderPlaced'] = eventDef
+    service.events["OrderPlaced"] = eventDef
     await registeredHandler(
-      { event: 'OrderPlaced', data: { ID: '123', title: 'Moby Dick', recipients: ['buyer@example.com'] } },
+      { event: "OrderPlaced", data: { ID: "123", title: "Moby Dick", recipients: ["buyer@example.com"] } },
       jest.fn()
     )
 
     expect(notifySpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        NotificationTypeKey: 'OrderPlaced',
-        NotificationTypeVersion: '1',
-        Priority: 'HIGH',
-        NavigationTargetObject: 'Orders',
-        NavigationTargetAction: 'manage',
-        Recipients: [{ RecipientId: 'buyer@example.com' }],
+        NotificationTypeKey: "OrderPlaced",
+        NotificationTypeVersion: "1",
+        Priority: "HIGH",
+        NavigationTargetObject: "Orders",
+        NavigationTargetAction: "manage",
+        Recipients: [{ RecipientId: "buyer@example.com" }],
         Properties: expect.arrayContaining([
-          expect.objectContaining({ Key: 'title', Value: 'Moby Dick', IsSensitive: true })
+          expect.objectContaining({ Key: "title", Value: "Moby Dick", IsSensitive: true })
         ]),
-        TargetParameters: [{ Key: 'ID', Value: '123' }]
+        TargetParameters: [{ Key: "ID", Value: "123" }]
       })
     )
   })
 
-  test('Skips plain events without @notification', async () => {
-    await registeredHandler({ event: 'PlainEvent', data: {} }, jest.fn())
+  test("Skips plain events without @notification", async () => {
+    await registeredHandler({ event: "PlainEvent", data: {} }, jest.fn())
 
     expect(notifySpy).not.toHaveBeenCalled()
   })
 
-  test('Logs error when notify fails', async () => {
-    notifySpy.mockRejectedValue(new Error('Network error'))
+  test("Logs error when notify fails", async () => {
+    notifySpy.mockRejectedValue(new Error("Network error"))
     const errorSpy = jest.fn()
-    jest.spyOn(cds, 'log').mockReturnValue({ _error: true, error: errorSpy })
+    jest.spyOn(cds, "log").mockReturnValue({ _error: true, error: errorSpy })
 
     const eventDef = {
-      kind: 'event',
-      name: 'LazyService.OrderPlaced',
-      '@notification': true,
-      elements: { recipients: { items: { type: 'cds.String' } } }
+      kind: "event",
+      name: "LazyService.OrderPlaced",
+      "@notification": true,
+      elements: { recipients: { items: { type: "cds.String" } } }
     }
-    service.events['OrderPlaced'] = eventDef
-    await registeredHandler({ event: 'OrderPlaced', data: { recipients: ['buyer@example.com'] } }, jest.fn())
+    service.events["OrderPlaced"] = eventDef
+    await registeredHandler({ event: "OrderPlaced", data: { recipients: ["buyer@example.com"] } }, jest.fn())
 
     expect(errorSpy).toHaveBeenCalledWith(
-      'Failed to send notification for event',
+      "Failed to send notification for event",
       expect.any(String),
       expect.any(Error)
     )

--- a/tests/unit/lib/plugin.test.js
+++ b/tests/unit/lib/plugin.test.js
@@ -1,146 +1,146 @@
-const cds = require("@sap/cds")
-require("../../../cds-plugin")
+const cds = require('@sap/cds')
+require('../../../cds-plugin')
 
 function makeModel(defs) {
   return { definitions: defs }
 }
 
-describe("Loaded hook - recipients injection", () => {
-  test("Inject recipients into a notification event that has none", () => {
+describe('Loaded hook - recipients injection', () => {
+  test('Inject recipients into a notification event that has none', () => {
     const model = makeModel({
       MyEvent: {
-        kind: "event",
-        "@notification.template.title": "Test",
+        kind: 'event',
+        '@notification.template.title': 'Test',
         elements: {}
       }
     })
-    cds.emit("loaded", model)
-    expect(model.definitions.MyEvent.elements.recipients).toEqual({ items: { type: "cds.String" } })
+    cds.emit('loaded', model)
+    expect(model.definitions.MyEvent.elements.recipients).toEqual({ items: { type: 'cds.String' } })
   })
 
-  test("Do not overwrite recipients already defined on the event", () => {
-    const existing = { items: { type: "cds.String" } }
+  test('Do not overwrite recipients already defined on the event', () => {
+    const existing = { items: { type: 'cds.String' } }
     const model = makeModel({
       MyEvent: {
-        kind: "event",
-        "@notification.template.title": "Test",
+        kind: 'event',
+        '@notification.template.title': 'Test',
         elements: { recipients: existing }
       }
     })
-    cds.emit("loaded", model)
+    cds.emit('loaded', model)
     expect(model.definitions.MyEvent.elements.recipients).toBe(existing)
   })
 
-  test("Do not inject recipients on events without @notification", () => {
+  test('Do not inject recipients on events without @notification', () => {
     const model = makeModel({
-      PlainEvent: { kind: "event", elements: {} }
+      PlainEvent: { kind: 'event', elements: {} }
     })
-    cds.emit("loaded", model)
+    cds.emit('loaded', model)
     expect(model.definitions.PlainEvent.elements.recipients).toBeUndefined()
   })
 
-  test("Create elements object if missing before injecting", () => {
+  test('Create elements object if missing before injecting', () => {
     const model = makeModel({
       MyEvent: {
-        kind: "event",
-        "@notification": true
+        kind: 'event',
+        '@notification': true
       }
     })
-    cds.emit("loaded", model)
-    expect(model.definitions.MyEvent.elements.recipients).toEqual({ items: { type: "cds.String" } })
+    cds.emit('loaded', model)
+    expect(model.definitions.MyEvent.elements.recipients).toEqual({ items: { type: 'cds.String' } })
   })
 })
 
-describe("Serving hook - notification handler registration", () => {
+describe('Serving hook - notification handler registration', () => {
   let notifySpy, registeredHandler, service
 
   beforeEach(async () => {
     notifySpy = jest.fn()
-    jest.spyOn(cds.connect, "to").mockResolvedValue({ notify: notifySpy })
+    jest.spyOn(cds.connect, 'to').mockResolvedValue({ notify: notifySpy })
 
     registeredHandler = undefined
     service = new cds.Service()
-    service.name = "LazyService"
+    service.name = 'LazyService'
     service.events = {}
-    jest.spyOn(service, "on").mockImplementation((event, handler) => {
-      if (event === "*") registeredHandler = handler
+    jest.spyOn(service, 'on').mockImplementation((event, handler) => {
+      if (event === '*') registeredHandler = handler
     })
 
-    await cds.emit("serving", service)
+    await cds.emit('serving', service)
   })
 
   afterEach(() => jest.restoreAllMocks())
 
-  test("Does not attach a handler to the notifications service itself", async () => {
+  test('Does not attach a handler to the notifications service itself', async () => {
     const service = new cds.Service()
-    service.name = "notifications"
-    const onSpy = jest.spyOn(service, "on")
-    await cds.emit("serving", service)
+    service.name = 'notifications'
+    const onSpy = jest.spyOn(service, 'on')
+    await cds.emit('serving', service)
     expect(onSpy).not.toHaveBeenCalled()
   })
 
-  test("Registers a handler on lazily connected services", () => {
+  test('Registers a handler on lazily connected services', () => {
     expect(registeredHandler).toBeDefined()
   })
 
-  test("Calls notify for @notification events", async () => {
+  test('Calls notify for @notification events', async () => {
     const eventDef = {
-      kind: "event",
-      name: "LazyService.OrderPlaced",
-      "@notification": true,
-      "@notification.priority": { "#": "High" },
-      "@Common.SemanticObject": "Orders",
-      "@Common.SemanticObjectAction": "manage",
+      kind: 'event',
+      name: 'LazyService.OrderPlaced',
+      '@notification': true,
+      '@notification.priority': { '#': 'High' },
+      '@Common.SemanticObject': 'Orders',
+      '@Common.SemanticObjectAction': 'manage',
       elements: {
-        ID: { type: "cds.String", key: true },
-        title: { type: "cds.String" },
-        recipients: { items: { type: "cds.String" } }
+        ID: { type: 'cds.String', key: true },
+        title: { type: 'cds.String' },
+        recipients: { items: { type: 'cds.String' } }
       }
     }
-    service.events["OrderPlaced"] = eventDef
+    service.events['OrderPlaced'] = eventDef
     await registeredHandler(
-      { event: "OrderPlaced", data: { ID: "123", title: "Moby Dick", recipients: ["buyer@example.com"] } },
+      { event: 'OrderPlaced', data: { ID: '123', title: 'Moby Dick', recipients: ['buyer@example.com'] } },
       jest.fn()
     )
 
     expect(notifySpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        NotificationTypeKey: "OrderPlaced",
-        NotificationTypeVersion: "1",
-        Priority: "HIGH",
-        NavigationTargetObject: "Orders",
-        NavigationTargetAction: "manage",
-        Recipients: [{ RecipientId: "buyer@example.com" }],
+        NotificationTypeKey: 'OrderPlaced',
+        NotificationTypeVersion: '1',
+        Priority: 'HIGH',
+        NavigationTargetObject: 'Orders',
+        NavigationTargetAction: 'manage',
+        Recipients: [{ RecipientId: 'buyer@example.com' }],
         Properties: expect.arrayContaining([
-          expect.objectContaining({ Key: "title", Value: "Moby Dick", IsSensitive: true })
+          expect.objectContaining({ Key: 'title', Value: 'Moby Dick', IsSensitive: true })
         ]),
-        TargetParameters: [{ Key: "ID", Value: "123" }]
+        TargetParameters: [{ Key: 'ID', Value: '123' }]
       })
     )
   })
 
-  test("Skips plain events without @notification", async () => {
-    await registeredHandler({ event: "PlainEvent", data: {} }, jest.fn())
+  test('Skips plain events without @notification', async () => {
+    await registeredHandler({ event: 'PlainEvent', data: {} }, jest.fn())
 
     expect(notifySpy).not.toHaveBeenCalled()
   })
 
-  test("Logs error when notify fails", async () => {
-    notifySpy.mockRejectedValue(new Error("Network error"))
+  test('Logs error when notify fails', async () => {
+    notifySpy.mockRejectedValue(new Error('Network error'))
     const errorSpy = jest.fn()
-    jest.spyOn(cds, "log").mockReturnValue({ _error: true, error: errorSpy })
+    jest.spyOn(cds, 'log').mockReturnValue({ _error: true, error: errorSpy })
 
     const eventDef = {
-      kind: "event",
-      name: "LazyService.OrderPlaced",
-      "@notification": true,
-      elements: { recipients: { items: { type: "cds.String" } } }
+      kind: 'event',
+      name: 'LazyService.OrderPlaced',
+      '@notification': true,
+      elements: { recipients: { items: { type: 'cds.String' } } }
     }
-    service.events["OrderPlaced"] = eventDef
-    await registeredHandler({ event: "OrderPlaced", data: { recipients: ["buyer@example.com"] } }, jest.fn())
+    service.events['OrderPlaced'] = eventDef
+    await registeredHandler({ event: 'OrderPlaced', data: { recipients: ['buyer@example.com'] } }, jest.fn())
 
     expect(errorSpy).toHaveBeenCalledWith(
-      "Failed to send notification for event",
+      'Failed to send notification for event',
       expect.any(String),
       expect.any(Error)
     )

--- a/tests/unit/lib/plugin.test.js
+++ b/tests/unit/lib/plugin.test.js
@@ -6,10 +6,9 @@ function makeModel(defs) {
 }
 
 describe("Loaded hook - recipients injection", () => {
-
   test("Inject recipients into a notification event that has none", () => {
     const model = makeModel({
-      "MyEvent": {
+      MyEvent: {
         kind: "event",
         "@notification.template.title": "Test",
         elements: {}
@@ -22,7 +21,7 @@ describe("Loaded hook - recipients injection", () => {
   test("Do not overwrite recipients already defined on the event", () => {
     const existing = { items: { type: "cds.String" } }
     const model = makeModel({
-      "MyEvent": {
+      MyEvent: {
         kind: "event",
         "@notification.template.title": "Test",
         elements: { recipients: existing }
@@ -34,7 +33,7 @@ describe("Loaded hook - recipients injection", () => {
 
   test("Do not inject recipients on events without @notification", () => {
     const model = makeModel({
-      "PlainEvent": { kind: "event", elements: {} }
+      PlainEvent: { kind: "event", elements: {} }
     })
     cds.emit("loaded", model)
     expect(model.definitions.PlainEvent.elements.recipients).toBeUndefined()
@@ -42,7 +41,7 @@ describe("Loaded hook - recipients injection", () => {
 
   test("Create elements object if missing before injecting", () => {
     const model = makeModel({
-      "MyEvent": {
+      MyEvent: {
         kind: "event",
         "@notification": true
       }
@@ -50,35 +49,33 @@ describe("Loaded hook - recipients injection", () => {
     cds.emit("loaded", model)
     expect(model.definitions.MyEvent.elements.recipients).toEqual({ items: { type: "cds.String" } })
   })
-
 })
 
 describe("Serving hook - notification handler registration", () => {
-
   let notifySpy, registeredHandler, service
 
   beforeEach(async () => {
     notifySpy = jest.fn()
-    jest.spyOn(cds.connect, 'to').mockResolvedValue({ notify: notifySpy })
+    jest.spyOn(cds.connect, "to").mockResolvedValue({ notify: notifySpy })
 
     registeredHandler = undefined
     service = new cds.Service()
-    service.name = 'LazyService'
+    service.name = "LazyService"
     service.events = {}
-    jest.spyOn(service, 'on').mockImplementation((event, handler) => {
-      if (event === '*') registeredHandler = handler
+    jest.spyOn(service, "on").mockImplementation((event, handler) => {
+      if (event === "*") registeredHandler = handler
     })
 
-    await cds.emit('serving', service)
+    await cds.emit("serving", service)
   })
 
   afterEach(() => jest.restoreAllMocks())
 
   test("Does not attach a handler to the notifications service itself", async () => {
     const service = new cds.Service()
-    service.name = 'notifications'
-    const onSpy = jest.spyOn(service, 'on')
-    await cds.emit('serving', service)
+    service.name = "notifications"
+    const onSpy = jest.spyOn(service, "on")
+    await cds.emit("serving", service)
     expect(onSpy).not.toHaveBeenCalled()
   })
 
@@ -88,52 +85,64 @@ describe("Serving hook - notification handler registration", () => {
 
   test("Calls notify for @notification events", async () => {
     const eventDef = {
-      kind: 'event',
-      name: 'LazyService.OrderPlaced',
-      '@notification': true,
-      '@notification.priority': { '#': 'High' },
-      '@Common.SemanticObject': 'Orders',
-      '@Common.SemanticObjectAction': 'manage',
-      elements: { ID: { type: 'cds.String', key: true }, title: { type: 'cds.String' }, recipients: { items: { type: 'cds.String' } } }
+      kind: "event",
+      name: "LazyService.OrderPlaced",
+      "@notification": true,
+      "@notification.priority": { "#": "High" },
+      "@Common.SemanticObject": "Orders",
+      "@Common.SemanticObjectAction": "manage",
+      elements: {
+        ID: { type: "cds.String", key: true },
+        title: { type: "cds.String" },
+        recipients: { items: { type: "cds.String" } }
+      }
     }
-    service.events['OrderPlaced'] = eventDef
-    await registeredHandler({ event: 'OrderPlaced', data: { ID: '123', title: 'Moby Dick', recipients: ['buyer@example.com'] } }, jest.fn())
+    service.events["OrderPlaced"] = eventDef
+    await registeredHandler(
+      { event: "OrderPlaced", data: { ID: "123", title: "Moby Dick", recipients: ["buyer@example.com"] } },
+      jest.fn()
+    )
 
-    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
-      NotificationTypeKey: 'OrderPlaced',
-      NotificationTypeVersion: '1',
-      Priority: 'HIGH',
-      NavigationTargetObject: 'Orders',
-      NavigationTargetAction: 'manage',
-      Recipients: [{ RecipientId: 'buyer@example.com' }],
-      Properties: expect.arrayContaining([
-        expect.objectContaining({ Key: 'title', Value: 'Moby Dick', IsSensitive: true }),
-      ]),
-      TargetParameters: [{ Key: 'ID', Value: '123' }],
-    }))
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        NotificationTypeKey: "OrderPlaced",
+        NotificationTypeVersion: "1",
+        Priority: "HIGH",
+        NavigationTargetObject: "Orders",
+        NavigationTargetAction: "manage",
+        Recipients: [{ RecipientId: "buyer@example.com" }],
+        Properties: expect.arrayContaining([
+          expect.objectContaining({ Key: "title", Value: "Moby Dick", IsSensitive: true })
+        ]),
+        TargetParameters: [{ Key: "ID", Value: "123" }]
+      })
+    )
   })
 
   test("Skips plain events without @notification", async () => {
-    await registeredHandler({ event: 'PlainEvent', data: {} }, jest.fn())
+    await registeredHandler({ event: "PlainEvent", data: {} }, jest.fn())
 
     expect(notifySpy).not.toHaveBeenCalled()
   })
 
   test("Logs error when notify fails", async () => {
-    notifySpy.mockRejectedValue(new Error('Network error'))
+    notifySpy.mockRejectedValue(new Error("Network error"))
     const errorSpy = jest.fn()
-    jest.spyOn(cds, 'log').mockReturnValue({ _error: true, error: errorSpy })
+    jest.spyOn(cds, "log").mockReturnValue({ _error: true, error: errorSpy })
 
     const eventDef = {
-      kind: 'event',
-      name: 'LazyService.OrderPlaced',
-      '@notification': true,
-      elements: { recipients: { items: { type: 'cds.String' } } }
+      kind: "event",
+      name: "LazyService.OrderPlaced",
+      "@notification": true,
+      elements: { recipients: { items: { type: "cds.String" } } }
     }
-    service.events['OrderPlaced'] = eventDef
-    await registeredHandler({ event: 'OrderPlaced', data: { recipients: ['buyer@example.com'] } }, jest.fn())
+    service.events["OrderPlaced"] = eventDef
+    await registeredHandler({ event: "OrderPlaced", data: { recipients: ["buyer@example.com"] } }, jest.fn())
 
-    expect(errorSpy).toHaveBeenCalledWith('Failed to send notification for event', expect.any(String), expect.any(Error))
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Failed to send notification for event",
+      expect.any(String),
+      expect.any(Error)
+    )
   })
-
 })

--- a/tests/unit/lib/utils.test.js
+++ b/tests/unit/lib/utils.test.js
@@ -1,4 +1,4 @@
-const cds = require("@sap/cds")
+const cds = require('@sap/cds')
 const {
   buildNotification,
   validateNotificationTypes,
@@ -10,679 +10,679 @@ const {
   applyValueLengthConstraints,
   MAX_PROPERTY_VALUE_LENGTH,
   MAX_TARGET_PARAM_VALUE_LENGTH
-} = require("../../../lib/utils")
-const { existsSync, readFileSync } = require("fs")
-const { getDestination } = require("@sap-cloud-sdk/connectivity")
+} = require('../../../lib/utils')
+const { existsSync, readFileSync } = require('fs')
+const { getDestination } = require('@sap-cloud-sdk/connectivity')
 
-jest.mock("fs")
-jest.mock("@sap-cloud-sdk/connectivity")
+jest.mock('fs')
+jest.mock('@sap-cloud-sdk/connectivity')
 
-describe("Test utils", () => {
-  describe("Build notifications", () => {
-    describe("Default notifications", () => {
+describe('Test utils', () => {
+  describe('Build notifications', () => {
+    describe('Default notifications', () => {
       const expectedWithoutDescription = {
-        NotificationTypeKey: "Default",
-        NotificationTypeVersion: "1",
-        Priority: "NEUTRAL",
+        NotificationTypeKey: 'Default',
+        NotificationTypeVersion: '1',
+        Priority: 'NEUTRAL',
         Properties: [
           {
-            Key: "title",
+            Key: 'title',
             IsSensitive: true,
-            Language: "en",
-            Value: "Some Test Title",
-            Type: "String"
+            Language: 'en',
+            Value: 'Some Test Title',
+            Type: 'String'
           },
           {
-            Key: "description",
+            Key: 'description',
             IsSensitive: true,
-            Language: "en",
-            Value: "",
-            Type: "String"
+            Language: 'en',
+            Value: '',
+            Type: 'String'
           }
         ],
-        Recipients: [{ RecipientId: "test.mail@mail.com" }]
+        Recipients: [{ RecipientId: 'test.mail@mail.com' }]
       }
 
       const expectedWithDescription = {
         ...expectedWithoutDescription,
         Properties: [
           {
-            Key: "title",
+            Key: 'title',
             IsSensitive: true,
-            Language: "en",
-            Value: "Some Test Title",
-            Type: "String"
+            Language: 'en',
+            Value: 'Some Test Title',
+            Type: 'String'
           },
           {
-            Key: "description",
+            Key: 'description',
             IsSensitive: true,
-            Language: "en",
-            Value: "Some Test Description",
-            Type: "String"
+            Language: 'en',
+            Value: 'Some Test Description',
+            Type: 'String'
           }
         ]
       }
 
-      test("Build a default notification with priority", () => {
+      test('Build a default notification with priority', () => {
         expect(
           buildNotification({
-            recipients: ["test.mail@mail.com"],
-            title: "Some Test Title",
-            priority: "NEUTRAL"
+            recipients: ['test.mail@mail.com'],
+            title: 'Some Test Title',
+            priority: 'NEUTRAL'
           })
         ).toMatchObject(expectedWithoutDescription)
       })
 
-      test("Build a default notification without priority", () => {
+      test('Build a default notification without priority', () => {
         expect(
           buildNotification({
-            recipients: ["test.mail@mail.com"],
-            title: "Some Test Title"
+            recipients: ['test.mail@mail.com'],
+            title: 'Some Test Title'
           })
         ).toMatchObject(expectedWithoutDescription)
       })
 
-      test("Build a default notification with description and priority", () => {
+      test('Build a default notification with description and priority', () => {
         expect(
           buildNotification({
-            recipients: ["test.mail@mail.com"],
-            title: "Some Test Title",
-            priority: "NEUTRAL",
-            description: "Some Test Description"
+            recipients: ['test.mail@mail.com'],
+            title: 'Some Test Title',
+            priority: 'NEUTRAL',
+            description: 'Some Test Description'
           })
         ).toMatchObject(expectedWithDescription)
       })
 
-      test("Build a default notification with description", () => {
+      test('Build a default notification with description', () => {
         expect(
           buildNotification({
-            recipients: ["test.mail@mail.com"],
-            title: "Some Test Title",
-            description: "Some Test Description"
+            recipients: ['test.mail@mail.com'],
+            title: 'Some Test Title',
+            description: 'Some Test Description'
           })
         ).toMatchObject(expectedWithDescription)
       })
 
-      test("Default notification uses locale from cds.context when set", () => {
+      test('Default notification uses locale from cds.context when set', () => {
         const prev = cds.context
-        cds.context = { locale: "de" }
+        cds.context = { locale: 'de' }
         const result = buildNotification({
-          recipients: ["test@mail.com"],
-          title: "Hallo"
+          recipients: ['test@mail.com'],
+          title: 'Hallo'
         })
         cds.context = prev
-        expect(result.Properties[0].Language).toBe("de")
-        expect(result.Properties[1].Language).toBe("de")
+        expect(result.Properties[0].Language).toBe('de')
+        expect(result.Properties[1].Language).toBe('de')
       })
     })
 
-    describe("Custom notifications", () => {
+    describe('Custom notifications', () => {
       const properties = [
         {
-          Key: "title",
+          Key: 'title',
           IsSensitive: true,
-          Language: "en",
-          Value: "Some Test Title",
-          Type: "String"
+          Language: 'en',
+          Value: 'Some Test Title',
+          Type: 'String'
         }
       ]
 
       const baseInput = {
-        recipients: ["test.mail@mail.com"],
-        type: "TestNotificationType",
+        recipients: ['test.mail@mail.com'],
+        type: 'TestNotificationType',
         Properties: properties
       }
 
       const baseExpected = {
-        NotificationTypeKey: "notifications/TestNotificationType",
-        NotificationTypeVersion: "1",
-        Priority: "NEUTRAL",
+        NotificationTypeKey: 'notifications/TestNotificationType',
+        NotificationTypeVersion: '1',
+        Priority: 'NEUTRAL',
         Properties: properties,
-        Recipients: [{ RecipientId: "test.mail@mail.com" }]
+        Recipients: [{ RecipientId: 'test.mail@mail.com' }]
       }
 
-      test("Build a custom notification with properties", () => {
+      test('Build a custom notification with properties', () => {
         expect(buildNotification(baseInput)).toMatchObject(baseExpected)
       })
 
-      test("Build a custom notification with navigation targets", () => {
+      test('Build a custom notification with navigation targets', () => {
         expect(
           buildNotification({
             ...baseInput,
-            NavigationTargetAction: "TestTargetAction",
-            NavigationTargetObject: "TestTargetObject"
+            NavigationTargetAction: 'TestTargetAction',
+            NavigationTargetObject: 'TestTargetObject'
           })
         ).toMatchObject({
           ...baseExpected,
-          NavigationTargetAction: "TestTargetAction",
-          NavigationTargetObject: "TestTargetObject"
+          NavigationTargetAction: 'TestTargetAction',
+          NavigationTargetObject: 'TestTargetObject'
         })
       })
 
-      test("Build a custom notification with a non-default priority", () => {
+      test('Build a custom notification with a non-default priority', () => {
         expect(
           buildNotification({
             ...baseInput,
-            priority: "HIGH"
+            priority: 'HIGH'
           })
         ).toMatchObject({
           ...baseExpected,
-          Priority: "HIGH"
+          Priority: 'HIGH'
         })
       })
 
-      test("Build a custom notification with a non-default priority and navigation targets", () => {
+      test('Build a custom notification with a non-default priority and navigation targets', () => {
         expect(
           buildNotification({
             ...baseInput,
-            NavigationTargetAction: "TestTargetAction",
-            NavigationTargetObject: "TestTargetObject",
-            priority: "HIGH"
+            NavigationTargetAction: 'TestTargetAction',
+            NavigationTargetObject: 'TestTargetObject',
+            priority: 'HIGH'
           })
         ).toMatchObject({
           ...baseExpected,
-          NavigationTargetAction: "TestTargetAction",
-          NavigationTargetObject: "TestTargetObject",
-          Priority: "HIGH"
+          NavigationTargetAction: 'TestTargetAction',
+          NavigationTargetObject: 'TestTargetObject',
+          Priority: 'HIGH'
         })
       })
 
-      test("Maps data object to Properties array", () => {
+      test('Maps data object to Properties array', () => {
         expect(
           buildNotification({
-            recipients: ["test.mail@mail.com"],
-            type: "TestNotificationType",
-            data: { title: "Some Test Title" }
+            recipients: ['test.mail@mail.com'],
+            type: 'TestNotificationType',
+            data: { title: 'Some Test Title' }
           })
         ).toMatchObject({
           ...baseExpected,
           Properties: [
             {
-              Key: "title",
-              Value: "Some Test Title",
-              Language: "en",
-              Type: "string"
+              Key: 'title',
+              Value: 'Some Test Title',
+              Language: 'en',
+              Type: 'string'
             }
           ]
         })
       })
 
-      test("Pass all low-level API fields through to the notification", () => {
+      test('Pass all low-level API fields through to the notification', () => {
         const lowLevelFields = {
-          OriginId: "01234567-89ab-cdef-0123-456789abcdef",
-          NotificationTypeId: "01234567-89ab-cdef-0123-456789abcdef",
-          NavigationTargetAction: "TestTargetAction",
-          NavigationTargetObject: "TestTargetObject",
-          ProviderId: "SAMPLEPROVIDER",
-          ActorId: "BACKENDACTORID",
-          ActorDisplayText: "ActorName",
-          ActorImageURL: "https://some-url",
-          NotificationTypeTimestamp: "2022-03-15T09:58:42.807Z",
-          TargetParameters: [{ Key: "string", Value: "string" }]
+          OriginId: '01234567-89ab-cdef-0123-456789abcdef',
+          NotificationTypeId: '01234567-89ab-cdef-0123-456789abcdef',
+          NavigationTargetAction: 'TestTargetAction',
+          NavigationTargetObject: 'TestTargetObject',
+          ProviderId: 'SAMPLEPROVIDER',
+          ActorId: 'BACKENDACTORID',
+          ActorDisplayText: 'ActorName',
+          ActorImageURL: 'https://some-url',
+          NotificationTypeTimestamp: '2022-03-15T09:58:42.807Z',
+          TargetParameters: [{ Key: 'string', Value: 'string' }]
         }
 
         expect(
           buildNotification({
             ...baseInput,
             ...lowLevelFields,
-            priority: "HIGH"
+            priority: 'HIGH'
           })
         ).toMatchObject({
           ...baseExpected,
           ...lowLevelFields,
-          Priority: "HIGH"
+          Priority: 'HIGH'
         })
       })
 
-      test("Pass partial low-level API fields through to the notification", () => {
+      test('Pass partial low-level API fields through to the notification', () => {
         const partialLowLevelFields = {
-          NotificationTypeId: "01234567-89ab-cdef-0123-456789abcdef",
-          NavigationTargetAction: "TestTargetAction",
-          NavigationTargetObject: "TestTargetObject",
-          ProviderId: "SAMPLEPROVIDER",
-          ActorId: "BACKENDACTORID",
-          ActorDisplayText: "ActorName",
-          ActorImageURL: "https://some-url",
-          NotificationTypeTimestamp: "2022-03-15T09:58:42.807Z",
-          TargetParameters: [{ Key: "string", Value: "string" }]
+          NotificationTypeId: '01234567-89ab-cdef-0123-456789abcdef',
+          NavigationTargetAction: 'TestTargetAction',
+          NavigationTargetObject: 'TestTargetObject',
+          ProviderId: 'SAMPLEPROVIDER',
+          ActorId: 'BACKENDACTORID',
+          ActorDisplayText: 'ActorName',
+          ActorImageURL: 'https://some-url',
+          NotificationTypeTimestamp: '2022-03-15T09:58:42.807Z',
+          TargetParameters: [{ Key: 'string', Value: 'string' }]
         }
 
         expect(
           buildNotification({
             ...baseInput,
             ...partialLowLevelFields,
-            priority: "HIGH"
+            priority: 'HIGH'
           })
         ).toMatchObject({
           ...baseExpected,
           ...partialLowLevelFields,
-          Priority: "HIGH"
+          Priority: 'HIGH'
         })
       })
 
-      test("Custom notification data mapping uses locale from cds.context when set", () => {
+      test('Custom notification data mapping uses locale from cds.context when set', () => {
         const prev = cds.context
-        cds.context = { locale: "de" }
+        cds.context = { locale: 'de' }
         const result = buildNotification({
-          recipients: ["test@mail.com"],
-          type: "TestType",
-          data: { title: "Hallo" }
+          recipients: ['test@mail.com'],
+          type: 'TestType',
+          data: { title: 'Hallo' }
         })
         cds.context = prev
-        expect(result.Properties[0].Language).toBe("de")
+        expect(result.Properties[0].Language).toBe('de')
       })
     })
 
-    describe("Invalid inputs", () => {
-      test("Return falsy when an empty object is passed", () => {
+    describe('Invalid inputs', () => {
+      test('Return falsy when an empty object is passed', () => {
         expect(buildNotification({})).toBeFalsy()
       })
 
-      describe("Default notification", () => {
-        test("Return falsy when title is missing", () => {
+      describe('Default notification', () => {
+        test('Return falsy when title is missing', () => {
           expect(
             buildNotification({
-              recipients: ["test.mail@mail.com"],
-              priority: "NEUTRAL"
+              recipients: ['test.mail@mail.com'],
+              priority: 'NEUTRAL'
             })
           ).toBeFalsy()
         })
 
-        test("Return falsy when recipients is empty", () => {
+        test('Return falsy when recipients is empty', () => {
           expect(
             buildNotification({
               recipients: [],
-              title: "Some Test Title",
-              priority: "NEUTRAL"
+              title: 'Some Test Title',
+              priority: 'NEUTRAL'
             })
           ).toBeFalsy()
         })
 
-        test("Return falsy when recipients is not an array", () => {
+        test('Return falsy when recipients is not an array', () => {
           expect(
             buildNotification({
-              recipients: "invalid",
-              title: "Some Test Title",
-              priority: "NEUTRAL"
+              recipients: 'invalid',
+              title: 'Some Test Title',
+              priority: 'NEUTRAL'
             })
           ).toBeFalsy()
         })
 
-        test("Return falsy when priority is not a valid value", () => {
+        test('Return falsy when priority is not a valid value', () => {
           expect(
             buildNotification({
-              recipients: ["test.mail@mail.com"],
-              title: "Some Test Title",
-              priority: "INVALID"
+              recipients: ['test.mail@mail.com'],
+              title: 'Some Test Title',
+              priority: 'INVALID'
             })
           ).toBeFalsy()
         })
 
-        test("Return falsy when description is not a string", () => {
+        test('Return falsy when description is not a string', () => {
           expect(
             buildNotification({
-              recipients: ["test.mail@mail.com"],
-              title: "Some Test Title",
-              priority: "NEUTRAL",
-              description: { invalid: "invalid" }
+              recipients: ['test.mail@mail.com'],
+              title: 'Some Test Title',
+              priority: 'NEUTRAL',
+              description: { invalid: 'invalid' }
             })
           ).toBeFalsy()
         })
 
-        test("Return falsy when title is not a string", () => {
+        test('Return falsy when title is not a string', () => {
           expect(
             buildNotification({
-              recipients: ["test.mail@mail.com"],
-              title: { invalid: "invalid" },
-              priority: "NEUTRAL"
+              recipients: ['test.mail@mail.com'],
+              title: { invalid: 'invalid' },
+              priority: 'NEUTRAL'
             })
           ).toBeFalsy()
         })
       })
 
-      describe("Custom notification", () => {
-        test("Return falsy when recipients is missing", () => {
+      describe('Custom notification', () => {
+        test('Return falsy when recipients is missing', () => {
           expect(
             buildNotification({
-              type: "TestNotificationType"
+              type: 'TestNotificationType'
             })
           ).toBeFalsy()
         })
 
-        test("Return falsy when recipients is empty", () => {
+        test('Return falsy when recipients is empty', () => {
           expect(
             buildNotification({
               recipients: [],
-              type: "TestNotificationType"
+              type: 'TestNotificationType'
             })
           ).toBeFalsy()
         })
 
-        test("Return falsy when recipients is not an array", () => {
+        test('Return falsy when recipients is not an array', () => {
           expect(
             buildNotification({
-              recipients: "invalid",
-              type: "TestNotificationType"
+              recipients: 'invalid',
+              type: 'TestNotificationType'
             })
           ).toBeFalsy()
         })
 
-        test("Return falsy when priority is not a valid value", () => {
+        test('Return falsy when priority is not a valid value', () => {
           expect(
             buildNotification({
-              recipients: ["test.mail@mail.com"],
-              type: "TestNotificationType",
-              priority: "invalid"
+              recipients: ['test.mail@mail.com'],
+              type: 'TestNotificationType',
+              priority: 'invalid'
             })
           ).toBeFalsy()
         })
 
-        test("Return falsy when properties is not an array", () => {
+        test('Return falsy when properties is not an array', () => {
           expect(
             buildNotification({
-              recipients: ["test.mail@mail.com"],
-              type: "TestNotificationType",
-              priority: "NEUTRAL",
-              properties: "invalid"
+              recipients: ['test.mail@mail.com'],
+              type: 'TestNotificationType',
+              priority: 'NEUTRAL',
+              properties: 'invalid'
             })
           ).toBeFalsy()
         })
 
-        test("Return falsy when navigation is not an object", () => {
+        test('Return falsy when navigation is not an object', () => {
           expect(
             buildNotification({
-              recipients: ["test.mail@mail.com"],
-              type: "TestNotificationType",
-              priority: "NEUTRAL",
-              navigation: "invalid"
+              recipients: ['test.mail@mail.com'],
+              type: 'TestNotificationType',
+              priority: 'NEUTRAL',
+              navigation: 'invalid'
             })
           ).toBeFalsy()
         })
 
-        test("Return falsy when payload is not an object", () => {
+        test('Return falsy when payload is not an object', () => {
           expect(
             buildNotification({
-              recipients: ["test.mail@mail.com"],
-              type: "TestNotificationType",
-              priority: "NEUTRAL",
-              payload: "invalid"
+              recipients: ['test.mail@mail.com'],
+              type: 'TestNotificationType',
+              priority: 'NEUTRAL',
+              payload: 'invalid'
             })
           ).toBeFalsy()
         })
       })
     })
 
-    test("Pass a raw notification object through with the prefix applied to the type key", () => {
+    test('Pass a raw notification object through with the prefix applied to the type key', () => {
       const rawNotification = {
-        NotificationTypeKey: "TestNotificationType",
-        NotificationTypeVersion: "1",
-        Priority: "NEUTRAL",
+        NotificationTypeKey: 'TestNotificationType',
+        NotificationTypeVersion: '1',
+        Priority: 'NEUTRAL',
         Properties: [
           {
-            Key: "title",
+            Key: 'title',
             IsSensitive: true,
-            Language: "en",
-            Value: "Some Test Title",
-            Type: "String"
+            Language: 'en',
+            Value: 'Some Test Title',
+            Type: 'String'
           },
           {
-            Key: "description",
+            Key: 'description',
             IsSensitive: true,
-            Language: "en",
-            Value: "Some Test Description",
-            Type: "String"
+            Language: 'en',
+            Value: 'Some Test Description',
+            Type: 'String'
           }
         ],
-        Recipients: [{ RecipientId: "test.mail@mail.com" }]
+        Recipients: [{ RecipientId: 'test.mail@mail.com' }]
       }
 
       expect(buildNotification({ ...rawNotification })).toMatchObject({
         ...rawNotification,
-        NotificationTypeKey: "notifications/TestNotificationType"
+        NotificationTypeKey: 'notifications/TestNotificationType'
       })
     })
   })
 
-  describe("Notification types validation", () => {
-    test("Return false when an entry is missing NotificationTypeKey", () => {
-      expect(validateNotificationTypes([{ NotificationTypeKey: "Test" }, { blabla: "Test2" }])).toEqual(false)
+  describe('Notification types validation', () => {
+    test('Return false when an entry is missing NotificationTypeKey', () => {
+      expect(validateNotificationTypes([{ NotificationTypeKey: 'Test' }, { blabla: 'Test2' }])).toEqual(false)
     })
 
-    test("Return true for an empty array", () => {
+    test('Return true for an empty array', () => {
       expect(validateNotificationTypes([])).toBe(true)
     })
 
-    test("Return true when all entries have NotificationTypeKey", () => {
-      expect(validateNotificationTypes([{ NotificationTypeKey: "Test" }, { NotificationTypeKey: "Test2" }])).toEqual(
+    test('Return true when all entries have NotificationTypeKey', () => {
+      expect(validateNotificationTypes([{ NotificationTypeKey: 'Test' }, { NotificationTypeKey: 'Test2' }])).toEqual(
         true
       )
     })
   })
 
-  describe("Read file", () => {
-    test("Return an empty array when the file does not exist", () => {
+  describe('Read file', () => {
+    test('Return an empty array when the file does not exist', () => {
       existsSync.mockReturnValue(false)
-      expect(readFile("test.json")).toMatchObject([])
+      expect(readFile('test.json')).toMatchObject([])
     })
 
-    test("Return the parsed file contents when the file exists", () => {
+    test('Return the parsed file contents when the file exists', () => {
       existsSync.mockReturnValue(true)
       readFileSync.mockReturnValue('[{ "test": "test" }]')
-      expect(readFile("test.json")).toMatchObject([{ test: "test" }])
+      expect(readFile('test.json')).toMatchObject([{ test: 'test' }])
     })
   })
 
-  describe("Get notification destination", () => {
-    test("Return the destination when it exists", async () => {
-      getDestination.mockReturnValue({ "mock-destination": "mock-destination" })
-      expect(await getNotificationDestination()).toMatchObject({ "mock-destination": "mock-destination" })
+  describe('Get notification destination', () => {
+    test('Return the destination when it exists', async () => {
+      getDestination.mockReturnValue({ 'mock-destination': 'mock-destination' })
+      expect(await getNotificationDestination()).toMatchObject({ 'mock-destination': 'mock-destination' })
     })
 
-    test("Throw an error when the destination is not found", async () => {
+    test('Throw an error when the destination is not found', async () => {
       getDestination.mockReturnValue(undefined)
-      await expect(() => getNotificationDestination()).rejects.toThrow("Failed to get destination: SAP_Notifications")
+      await expect(() => getNotificationDestination()).rejects.toThrow('Failed to get destination: SAP_Notifications')
     })
   })
 
-  describe("Build notification from event", () => {
+  describe('Build notification from event', () => {
     const baseEventDef = {
-      name: "CatalogService.NewOrder",
-      kind: "event",
-      "@notification": true,
+      name: 'CatalogService.NewOrder',
+      kind: 'event',
+      '@notification': true,
       elements: {
-        book: { type: "cds.String" },
-        quantity: { type: "cds.Integer" },
-        orderedAt: { type: "cds.Date" },
-        ID: { type: "cds.UUID", key: true },
-        recipients: { items: { type: "cds.String" } }
+        book: { type: 'cds.String' },
+        quantity: { type: 'cds.Integer' },
+        orderedAt: { type: 'cds.Date' },
+        ID: { type: 'cds.UUID', key: true },
+        recipients: { items: { type: 'cds.String' } }
       }
     }
 
     const baseData = {
-      book: "Moby Dick",
+      book: 'Moby Dick',
       quantity: 2,
-      orderedAt: "2024-01-15",
-      ID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-      recipients: ["buyer@example.com"]
+      orderedAt: '2024-01-15',
+      ID: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      recipients: ['buyer@example.com']
     }
 
-    test("Sets NotificationTypeKey to the unqualified event name", async () => {
+    test('Sets NotificationTypeKey to the unqualified event name', async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.NotificationTypeKey).toBe("NewOrder")
+      expect(result.NotificationTypeKey).toBe('NewOrder')
     })
 
     test("Sets NotificationTypeVersion to '1'", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.NotificationTypeVersion).toBe("1")
+      expect(result.NotificationTypeVersion).toBe('1')
     })
 
-    test("Maps event data fields to Properties with IsSensitive true", async () => {
+    test('Maps event data fields to Properties with IsSensitive true', async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
       expect(result.Properties).toContainEqual({
-        Key: "book",
-        Language: "en",
-        Value: "Moby Dick",
-        Type: "String",
+        Key: 'book',
+        Language: 'en',
+        Value: 'Moby Dick',
+        Type: 'String',
         IsSensitive: true
       })
     })
 
-    test("Does not include recipients in Properties", async () => {
+    test('Does not include recipients in Properties', async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.Properties.map(p => p.Key)).not.toContain("recipients")
+      expect(result.Properties.map(p => p.Key)).not.toContain('recipients')
     })
 
-    test("Maps key elements to TargetParameters", async () => {
+    test('Maps key elements to TargetParameters', async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.TargetParameters).toEqual([{ Key: "ID", Value: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }])
+      expect(result.TargetParameters).toEqual([{ Key: 'ID', Value: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }])
     })
 
-    test("Omits TargetParameters when no key elements exist", async () => {
-      const defNoKeys = { ...baseEventDef, elements: { book: { type: "cds.String" } } }
-      const result = await buildNotificationFromEvent(defNoKeys, { book: "Test", recipients: [] })
+    test('Omits TargetParameters when no key elements exist', async () => {
+      const defNoKeys = { ...baseEventDef, elements: { book: { type: 'cds.String' } } }
+      const result = await buildNotificationFromEvent(defNoKeys, { book: 'Test', recipients: [] })
       expect(result.TargetParameters).toBeUndefined()
     })
 
-    test("Uses RecipientId for email-style recipients", async () => {
+    test('Uses RecipientId for email-style recipients', async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.Recipients).toEqual([{ RecipientId: "buyer@example.com" }])
+      expect(result.Recipients).toEqual([{ RecipientId: 'buyer@example.com' }])
     })
 
-    test("Uses GlobalUserId for GUID recipients", async () => {
-      const data = { ...baseData, recipients: ["123e4567-e89b-12d3-a456-426614174000"] }
+    test('Uses GlobalUserId for GUID recipients', async () => {
+      const data = { ...baseData, recipients: ['123e4567-e89b-12d3-a456-426614174000'] }
       const result = await buildNotificationFromEvent(baseEventDef, data)
-      expect(result.Recipients).toEqual([{ GlobalUserId: "123e4567-e89b-12d3-a456-426614174000" }])
+      expect(result.Recipients).toEqual([{ GlobalUserId: '123e4567-e89b-12d3-a456-426614174000' }])
     })
 
-    test("Handles mixed GUID and email recipients", async () => {
-      const data = { ...baseData, recipients: ["123e4567-e89b-12d3-a456-426614174000", "email@example.com"] }
+    test('Handles mixed GUID and email recipients', async () => {
+      const data = { ...baseData, recipients: ['123e4567-e89b-12d3-a456-426614174000', 'email@example.com'] }
       const result = await buildNotificationFromEvent(baseEventDef, data)
       expect(result.Recipients).toEqual([
-        { GlobalUserId: "123e4567-e89b-12d3-a456-426614174000" },
-        { RecipientId: "email@example.com" }
+        { GlobalUserId: '123e4567-e89b-12d3-a456-426614174000' },
+        { RecipientId: 'email@example.com' }
       ])
     })
 
-    test("Defaults Priority to NEUTRAL when annotation is absent", async () => {
+    test('Defaults Priority to NEUTRAL when annotation is absent', async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.Priority).toBe("NEUTRAL")
+      expect(result.Priority).toBe('NEUTRAL')
     })
 
-    test("Resolves enum priority annotation (#High -> HIGH)", async () => {
-      const def = { ...baseEventDef, "@notification.priority": { "#": "High" } }
+    test('Resolves enum priority annotation (#High -> HIGH)', async () => {
+      const def = { ...baseEventDef, '@notification.priority': { '#': 'High' } }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.Priority).toBe("HIGH")
+      expect(result.Priority).toBe('HIGH')
     })
 
-    test("Accepts plain string priority annotation", async () => {
-      const def = { ...baseEventDef, "@notification.priority": "LOW" }
+    test('Accepts plain string priority annotation', async () => {
+      const def = { ...baseEventDef, '@notification.priority': 'LOW' }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.Priority).toBe("LOW")
+      expect(result.Priority).toBe('LOW')
     })
 
-    describe("Invalid static priority annotation", () => {
+    describe('Invalid static priority annotation', () => {
       const log = cds.test.log()
       beforeEach(() => log.clear())
 
-      test("Falls back to NEUTRAL and warns when plain string priority is invalid", async () => {
-        const def = { ...baseEventDef, "@notification.priority": "CRITICAL" }
+      test('Falls back to NEUTRAL and warns when plain string priority is invalid', async () => {
+        const def = { ...baseEventDef, '@notification.priority': 'CRITICAL' }
         const result = await buildNotificationFromEvent(def, baseData)
-        expect(result.Priority).toBe("NEUTRAL")
+        expect(result.Priority).toBe('NEUTRAL')
         expect(log.output).toMatch(/invalid|CRITICAL/i)
       })
 
-      test("Falls back to NEUTRAL and warns when enum priority annotation resolves to invalid value", async () => {
-        const def = { ...baseEventDef, "@notification.priority": { "#": "CRITICAL" } }
+      test('Falls back to NEUTRAL and warns when enum priority annotation resolves to invalid value', async () => {
+        const def = { ...baseEventDef, '@notification.priority': { '#': 'CRITICAL' } }
         const result = await buildNotificationFromEvent(def, baseData)
-        expect(result.Priority).toBe("NEUTRAL")
+        expect(result.Priority).toBe('NEUTRAL')
         expect(log.output).toMatch(/invalid|CRITICAL/i)
       })
     })
 
-    test("Maps @Common.SemanticObject to NavigationTargetObject", async () => {
-      const def = { ...baseEventDef, "@Common.SemanticObject": "Orders" }
+    test('Maps @Common.SemanticObject to NavigationTargetObject', async () => {
+      const def = { ...baseEventDef, '@Common.SemanticObject': 'Orders' }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.NavigationTargetObject).toBe("Orders")
+      expect(result.NavigationTargetObject).toBe('Orders')
     })
 
-    test("Maps @Common.SemanticObjectAction to NavigationTargetAction", async () => {
-      const def = { ...baseEventDef, "@Common.SemanticObjectAction": "manage" }
+    test('Maps @Common.SemanticObjectAction to NavigationTargetAction', async () => {
+      const def = { ...baseEventDef, '@Common.SemanticObjectAction': 'manage' }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.NavigationTargetAction).toBe("manage")
+      expect(result.NavigationTargetAction).toBe('manage')
     })
 
-    test("Works with empty data and no recipients", async () => {
+    test('Works with empty data and no recipients', async () => {
       const result = await buildNotificationFromEvent(baseEventDef, {})
       expect(result.Recipients).toEqual([])
       expect(result.Properties).toEqual([])
     })
   })
 
-  describe("replaceRefsInExpr", () => {
-    test("Passes through val nodes unchanged", () => {
+  describe('replaceRefsInExpr', () => {
+    test('Passes through val nodes unchanged', () => {
       expect(replaceRefsInExpr({ val: 42 }, {})).toEqual({ val: 42 })
     })
 
-    test("Passes through string operators unchanged", () => {
-      expect(replaceRefsInExpr(">", {})).toBe(">")
+    test('Passes through string operators unchanged', () => {
+      expect(replaceRefsInExpr('>', {})).toBe('>')
     })
 
-    test("Replaces {ref} with {val} when key exists in data", () => {
-      expect(replaceRefsInExpr({ ref: ["quantity"] }, { quantity: 10 })).toEqual({ val: 10, param: false })
+    test('Replaces {ref} with {val} when key exists in data', () => {
+      expect(replaceRefsInExpr({ ref: ['quantity'] }, { quantity: 10 })).toEqual({ val: 10, param: false })
     })
 
-    test("Substitutes null when key is not in data", () => {
-      expect(replaceRefsInExpr({ ref: ["unknown"] }, { quantity: 10 })).toEqual({ val: null, param: false })
+    test('Substitutes null when key is not in data', () => {
+      expect(replaceRefsInExpr({ ref: ['unknown'] }, { quantity: 10 })).toEqual({ val: null, param: false })
     })
 
-    test("Does not replace binding parameters ({ref, param: true})", () => {
-      const param = { ref: ["?"], param: true }
-      expect(replaceRefsInExpr(param, { "?": "something" })).toEqual(param)
+    test('Does not replace binding parameters ({ref, param: true})', () => {
+      const param = { ref: ['?'], param: true }
+      expect(replaceRefsInExpr(param, { '?': 'something' })).toEqual(param)
     })
 
-    test("Recursively replaces refs in flat xpr array", () => {
-      const xpr = [{ ref: ["quantity"] }, ">", { val: 5 }]
-      expect(replaceRefsInExpr(xpr, { quantity: 10 })).toEqual([{ val: 10, param: false }, ">", { val: 5 }])
+    test('Recursively replaces refs in flat xpr array', () => {
+      const xpr = [{ ref: ['quantity'] }, '>', { val: 5 }]
+      expect(replaceRefsInExpr(xpr, { quantity: 10 })).toEqual([{ val: 10, param: false }, '>', { val: 5 }])
     })
 
-    test("Recursively replaces refs in nested xpr object", () => {
-      const expr = { xpr: [{ ref: ["quantity"] }, ">", { val: 5 }] }
-      expect(replaceRefsInExpr(expr, { quantity: 10 })).toEqual({ xpr: [{ val: 10, param: false }, ">", { val: 5 }] })
+    test('Recursively replaces refs in nested xpr object', () => {
+      const expr = { xpr: [{ ref: ['quantity'] }, '>', { val: 5 }] }
+      expect(replaceRefsInExpr(expr, { quantity: 10 })).toEqual({ xpr: [{ val: 10, param: false }, '>', { val: 5 }] })
     })
 
     test("Converts enum symbol {'#': value} to {val: value}", () => {
-      expect(replaceRefsInExpr({ "#": "High" }, {})).toEqual({ val: "High", param: false })
+      expect(replaceRefsInExpr({ '#': 'High' }, {})).toEqual({ val: 'High', param: false })
     })
 
-    test("Replaces refs in function call args", () => {
-      const func = { func: "days_between", args: [{ ref: ["startDate"] }, { ref: ["endDate"] }] }
-      expect(replaceRefsInExpr(func, { startDate: "2024-01-01", endDate: "2024-06-01" })).toEqual({
-        func: "days_between",
+    test('Replaces refs in function call args', () => {
+      const func = { func: 'days_between', args: [{ ref: ['startDate'] }, { ref: ['endDate'] }] }
+      expect(replaceRefsInExpr(func, { startDate: '2024-01-01', endDate: '2024-06-01' })).toEqual({
+        func: 'days_between',
         args: [
-          { val: "2024-01-01", param: false },
-          { val: "2024-06-01", param: false }
+          { val: '2024-01-01', param: false },
+          { val: '2024-06-01', param: false }
         ]
       })
     })
 
-    test("Handles deep nesting: xpr containing xpr containing refs", () => {
+    test('Handles deep nesting: xpr containing xpr containing refs', () => {
       const expr = {
-        xpr: ["case", "when", { xpr: [{ ref: ["a"] }, "<", { val: 1 }] }, "then", { ref: ["b"] }, "end"]
+        xpr: ['case', 'when', { xpr: [{ ref: ['a'] }, '<', { val: 1 }] }, 'then', { ref: ['b'] }, 'end']
       }
-      expect(replaceRefsInExpr(expr, { a: 0, b: "High" })).toEqual({
+      expect(replaceRefsInExpr(expr, { a: 0, b: 'High' })).toEqual({
         xpr: [
-          "case",
-          "when",
-          { xpr: [{ val: 0, param: false }, "<", { val: 1 }] },
-          "then",
-          { val: "High", param: false },
-          "end"
+          'case',
+          'when',
+          { xpr: [{ val: 0, param: false }, '<', { val: 1 }] },
+          'then',
+          { val: 'High', param: false },
+          'end'
         ]
       })
     })
 
-    test("Replaces refs inside list nodes", () => {
-      const expr = { list: [{ ref: ["a"] }, { ref: ["b"] }] }
+    test('Replaces refs inside list nodes', () => {
+      const expr = { list: [{ ref: ['a'] }, { ref: ['b'] }] }
       expect(replaceRefsInExpr(expr, { a: 1, b: 2 })).toEqual({
         list: [
           { val: 1, param: false },
@@ -691,198 +691,198 @@ describe("Test utils", () => {
       })
     })
 
-    test("Replaces refs in named function args", () => {
-      const func = { func: "foo", args: { p: { ref: ["x"] } } }
-      expect(replaceRefsInExpr(func, { x: 42 })).toEqual({ func: "foo", args: { p: { val: 42, param: false } } })
+    test('Replaces refs in named function args', () => {
+      const func = { func: 'foo', args: { p: { ref: ['x'] } } }
+      expect(replaceRefsInExpr(func, { x: 42 })).toEqual({ func: 'foo', args: { p: { val: 42, param: false } } })
     })
 
-    test("Leaves multi-segment refs unchanged — path traversal is not supported", () => {
-      const expr = { ref: ["assoc", "field"] }
-      expect(replaceRefsInExpr(expr, { assoc: "something" })).toEqual({ ref: ["assoc", "field"] })
-    })
-  })
-
-  describe("mapCdsTypeToANSType", () => {
-    test.each([
-      ["cds.String", "String"],
-      ["cds.UUID", "String"],
-      ["cds.Boolean", "String"],
-      ["String", "String"]
-    ])("%s -> %s", (cdsType, expected) => {
-      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
-    })
-
-    test.each([
-      ["cds.Integer", "Integer"],
-      ["cds.Integer64", "Integer"],
-      ["cds.Int16", "Integer"],
-      ["cds.Int32", "Integer"],
-      ["cds.Int64", "Integer"],
-      ["cds.UInt8", "Integer"],
-      ["cds.Decimal", "String"],
-      ["cds.Double", "String"],
-      ["cds.Float", "String"]
-    ])("%s -> %s", (cdsType, expected) => {
-      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
-    })
-
-    test.each([
-      ["cds.Date", "Date"],
-      ["cds.DateTime", "Date"],
-      ["cds.Timestamp", "Date"],
-      ["cds.Time", "Date"]
-    ])("%s -> %s", (cdsType, expected) => {
-      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
-    })
-
-    test("Returns String for undefined type", () => {
-      expect(mapCdsTypeToANSType(undefined)).toBe("String")
+    test('Leaves multi-segment refs unchanged — path traversal is not supported', () => {
+      const expr = { ref: ['assoc', 'field'] }
+      expect(replaceRefsInExpr(expr, { assoc: 'something' })).toEqual({ ref: ['assoc', 'field'] })
     })
   })
 
-  describe("Configuration", () => {
+  describe('mapCdsTypeToANSType', () => {
+    test.each([
+      ['cds.String', 'String'],
+      ['cds.UUID', 'String'],
+      ['cds.Boolean', 'String'],
+      ['String', 'String']
+    ])('%s -> %s', (cdsType, expected) => {
+      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
+    })
+
+    test.each([
+      ['cds.Integer', 'Integer'],
+      ['cds.Integer64', 'Integer'],
+      ['cds.Int16', 'Integer'],
+      ['cds.Int32', 'Integer'],
+      ['cds.Int64', 'Integer'],
+      ['cds.UInt8', 'Integer'],
+      ['cds.Decimal', 'String'],
+      ['cds.Double', 'String'],
+      ['cds.Float', 'String']
+    ])('%s -> %s', (cdsType, expected) => {
+      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
+    })
+
+    test.each([
+      ['cds.Date', 'Date'],
+      ['cds.DateTime', 'Date'],
+      ['cds.Timestamp', 'Date'],
+      ['cds.Time', 'Date']
+    ])('%s -> %s', (cdsType, expected) => {
+      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
+    })
+
+    test('Returns String for undefined type', () => {
+      expect(mapCdsTypeToANSType(undefined)).toBe('String')
+    })
+  })
+
+  describe('Configuration', () => {
     const log = cds.test.log()
     afterEach(() => {
       delete cds.env.requires.notifications?.authenticationIdentifier
     })
 
-    it("Use GlobalUserId as the recipient key when authenticationIdentifier is set to UserUUID", () => {
+    it('Use GlobalUserId as the recipient key when authenticationIdentifier is set to UserUUID', () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = "UserUUID"
+      cds.env.requires.notifications.authenticationIdentifier = 'UserUUID'
 
       const result = buildNotification({
-        recipients: ["user-uuid-123"],
-        title: "Test Title"
+        recipients: ['user-uuid-123'],
+        title: 'Test Title'
       })
 
-      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: "user-uuid-123" })
+      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: 'user-uuid-123' })
     })
 
-    it("Auto mode picks GlobalUserId for UUID recipients", () => {
+    it('Auto mode picks GlobalUserId for UUID recipients', () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = "auto"
+      cds.env.requires.notifications.authenticationIdentifier = 'auto'
 
       const result = buildNotification({
-        recipients: ["550e8400-e29b-41d4-a716-446655440000"],
-        title: "Test Title"
+        recipients: ['550e8400-e29b-41d4-a716-446655440000'],
+        title: 'Test Title'
       })
 
-      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: "550e8400-e29b-41d4-a716-446655440000" })
+      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: '550e8400-e29b-41d4-a716-446655440000' })
     })
 
-    it("Auto mode picks RecipientId for email recipients", () => {
+    it('Auto mode picks RecipientId for email recipients', () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = "auto"
+      cds.env.requires.notifications.authenticationIdentifier = 'auto'
 
       const result = buildNotification({
-        recipients: ["test.mail@mail.com"],
-        title: "Test Title"
+        recipients: ['test.mail@mail.com'],
+        title: 'Test Title'
       })
 
-      expect(result.Recipients[0]).toMatchObject({ RecipientId: "test.mail@mail.com" })
+      expect(result.Recipients[0]).toMatchObject({ RecipientId: 'test.mail@mail.com' })
     })
 
-    it("Auto mode supports mixed UUID and email recipients in one notification", () => {
+    it('Auto mode supports mixed UUID and email recipients in one notification', () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = "auto"
+      cds.env.requires.notifications.authenticationIdentifier = 'auto'
 
       const result = buildNotification({
-        recipients: ["550e8400-e29b-41d4-a716-446655440000", "test.mail@mail.com"],
-        title: "Test Title"
+        recipients: ['550e8400-e29b-41d4-a716-446655440000', 'test.mail@mail.com'],
+        title: 'Test Title'
       })
 
       expect(result.Recipients).toEqual([
-        { GlobalUserId: "550e8400-e29b-41d4-a716-446655440000" },
-        { RecipientId: "test.mail@mail.com" }
+        { GlobalUserId: '550e8400-e29b-41d4-a716-446655440000' },
+        { RecipientId: 'test.mail@mail.com' }
       ])
     })
 
-    it("Auto mode warns and falls back to RecipientId when value is neither UUID nor email", () => {
+    it('Auto mode warns and falls back to RecipientId when value is neither UUID nor email', () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = "auto"
+      cds.env.requires.notifications.authenticationIdentifier = 'auto'
       log.clear()
 
       const result = buildNotification({
-        recipients: ["not-a-uuid-or-email"],
-        title: "Test Title"
+        recipients: ['not-a-uuid-or-email'],
+        title: 'Test Title'
       })
 
-      expect(result.Recipients[0]).toMatchObject({ RecipientId: "not-a-uuid-or-email" })
-      expect(log.output).toContain("neither a UUID nor an email")
+      expect(result.Recipients[0]).toMatchObject({ RecipientId: 'not-a-uuid-or-email' })
+      expect(log.output).toContain('neither a UUID nor an email')
     })
 
-    it("Auto is the default when authenticationIdentifier is not configured", () => {
+    it('Auto is the default when authenticationIdentifier is not configured', () => {
       cds.env.requires.notifications ??= {}
       delete cds.env.requires.notifications.authenticationIdentifier
 
       const result = buildNotification({
-        recipients: ["550e8400-e29b-41d4-a716-446655440000"],
-        title: "Test Title"
+        recipients: ['550e8400-e29b-41d4-a716-446655440000'],
+        title: 'Test Title'
       })
 
-      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: "550e8400-e29b-41d4-a716-446655440000" })
+      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: '550e8400-e29b-41d4-a716-446655440000' })
     })
 
-    it("Explicit RecipientId mode never resolves to GlobalUserId even for UUID values", () => {
+    it('Explicit RecipientId mode never resolves to GlobalUserId even for UUID values', () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = "RecipientId"
+      cds.env.requires.notifications.authenticationIdentifier = 'RecipientId'
 
       const result = buildNotification({
-        recipients: ["550e8400-e29b-41d4-a716-446655440000"],
-        title: "Test Title"
+        recipients: ['550e8400-e29b-41d4-a716-446655440000'],
+        title: 'Test Title'
       })
 
-      expect(result.Recipients[0]).toMatchObject({ RecipientId: "550e8400-e29b-41d4-a716-446655440000" })
+      expect(result.Recipients[0]).toMatchObject({ RecipientId: '550e8400-e29b-41d4-a716-446655440000' })
     })
 
-    it("Fall back to basename of cds.root as prefix when package.json cannot be read", () => {
+    it('Fall back to basename of cds.root as prefix when package.json cannot be read', () => {
       let result
       jest.isolateModules(() => {
-        const cds = require("@sap/cds")
+        const cds = require('@sap/cds')
         const originalRoot = cds.root
         cds.env.requires.notifications ??= {}
-        cds.env.requires.notifications.prefix = "$app-name"
-        cds.root = "/nonexistent-path-for-testing"
+        cds.env.requires.notifications.prefix = '$app-name'
+        cds.root = '/nonexistent-path-for-testing'
         try {
-          const { getNotificationTypesKeyWithPrefix } = require("../../../lib/utils")
-          result = getNotificationTypesKeyWithPrefix("TestType")
+          const { getNotificationTypesKeyWithPrefix } = require('../../../lib/utils')
+          result = getNotificationTypesKeyWithPrefix('TestType')
         } finally {
           cds.root = originalRoot
           delete cds.env.requires.notifications.prefix
         }
       })
-      expect(result).toBe("nonexistent-path-for-testing/TestType")
+      expect(result).toBe('nonexistent-path-for-testing/TestType')
     })
   })
 
-  describe("applyValueLengthConstraints", () => {
-    const longValue251 = "a".repeat(MAX_TARGET_PARAM_VALUE_LENGTH + 1)
-    const longValue256 = "a".repeat(MAX_PROPERTY_VALUE_LENGTH + 1)
-    const value255 = "a".repeat(MAX_PROPERTY_VALUE_LENGTH)
-    const value250 = "a".repeat(MAX_TARGET_PARAM_VALUE_LENGTH)
+  describe('applyValueLengthConstraints', () => {
+    const longValue251 = 'a'.repeat(MAX_TARGET_PARAM_VALUE_LENGTH + 1)
+    const longValue256 = 'a'.repeat(MAX_PROPERTY_VALUE_LENGTH + 1)
+    const value255 = 'a'.repeat(MAX_PROPERTY_VALUE_LENGTH)
+    const value250 = 'a'.repeat(MAX_TARGET_PARAM_VALUE_LENGTH)
 
-    test("Returns notification unchanged when all values are within limits", () => {
+    test('Returns notification unchanged when all values are within limits', () => {
       const notification = {
-        Properties: [{ Key: "k", Value: value255 }],
-        TargetParameters: [{ Key: "k", Value: value250 }]
+        Properties: [{ Key: 'k', Value: value255 }],
+        TargetParameters: [{ Key: 'k', Value: value250 }]
       }
       expect(applyValueLengthConstraints(notification)).toStrictEqual(notification)
     })
 
-    test("Throws when a Property value exceeds 255 characters", () => {
+    test('Throws when a Property value exceeds 255 characters', () => {
       const notification = {
-        Properties: [{ Key: "k", Value: longValue256 }]
+        Properties: [{ Key: 'k', Value: longValue256 }]
       }
       expect(() => applyValueLengthConstraints(notification)).toThrow(
         `Property value exceeds the maximum length of ${MAX_PROPERTY_VALUE_LENGTH} characters.`
       )
     })
 
-    test("Throws on the first Property value over 255 even when others are valid", () => {
+    test('Throws on the first Property value over 255 even when others are valid', () => {
       const notification = {
         Properties: [
-          { Key: "ok", Value: "short" },
-          { Key: "bad", Value: longValue256 }
+          { Key: 'ok', Value: 'short' },
+          { Key: 'bad', Value: longValue256 }
         ]
       }
       expect(() => applyValueLengthConstraints(notification)).toThrow(
@@ -890,32 +890,32 @@ describe("Test utils", () => {
       )
     })
 
-    test("Removes TargetParameter entries whose value exceeds 250 characters", () => {
+    test('Removes TargetParameter entries whose value exceeds 250 characters', () => {
       const notification = {
         TargetParameters: [
-          { Key: "short", Value: value250 },
-          { Key: "long", Value: longValue251 }
+          { Key: 'short', Value: value250 },
+          { Key: 'long', Value: longValue251 }
         ]
       }
       const result = applyValueLengthConstraints(notification)
-      expect(result.TargetParameters).toEqual([{ Key: "short", Value: value250 }])
+      expect(result.TargetParameters).toEqual([{ Key: 'short', Value: value250 }])
     })
 
-    test("Removes all TargetParameters when all values exceed 250 characters", () => {
+    test('Removes all TargetParameters when all values exceed 250 characters', () => {
       const notification = {
-        TargetParameters: [{ Key: "k", Value: longValue251 }]
+        TargetParameters: [{ Key: 'k', Value: longValue251 }]
       }
       const result = applyValueLengthConstraints(notification)
       expect(result.TargetParameters).toEqual([])
     })
 
-    test("Returns null/undefined unchanged", () => {
+    test('Returns null/undefined unchanged', () => {
       expect(applyValueLengthConstraints(null)).toBeNull()
       expect(applyValueLengthConstraints(undefined)).toBeUndefined()
     })
 
-    test("Handles notification with no Properties or TargetParameters", () => {
-      const notification = { NotificationTypeKey: "Test" }
+    test('Handles notification with no Properties or TargetParameters', () => {
+      const notification = { NotificationTypeKey: 'Test' }
       expect(applyValueLengthConstraints(notification)).toBe(notification)
     })
   })

--- a/tests/unit/lib/utils.test.js
+++ b/tests/unit/lib/utils.test.js
@@ -1,5 +1,16 @@
 const cds = require("@sap/cds")
-const { buildNotification, validateNotificationTypes, readFile, getNotificationDestination, buildNotificationFromEvent, mapCdsTypeToANSType, replaceRefsInExpr, applyValueLengthConstraints, MAX_PROPERTY_VALUE_LENGTH, MAX_TARGET_PARAM_VALUE_LENGTH } = require("../../../lib/utils")
+const {
+  buildNotification,
+  validateNotificationTypes,
+  readFile,
+  getNotificationDestination,
+  buildNotificationFromEvent,
+  mapCdsTypeToANSType,
+  replaceRefsInExpr,
+  applyValueLengthConstraints,
+  MAX_PROPERTY_VALUE_LENGTH,
+  MAX_TARGET_PARAM_VALUE_LENGTH
+} = require("../../../lib/utils")
 const { existsSync, readFileSync } = require("fs")
 const { getDestination } = require("@sap-cloud-sdk/connectivity")
 
@@ -7,7 +18,6 @@ jest.mock("fs")
 jest.mock("@sap-cloud-sdk/connectivity")
 
 describe("Test utils", () => {
-
   describe("Build notifications", () => {
     describe("Default notifications", () => {
       const expectedWithoutDescription = {
@@ -107,13 +117,15 @@ describe("Test utils", () => {
     })
 
     describe("Custom notifications", () => {
-      const properties = [{
-        Key: "title",
-        IsSensitive: true,
-        Language: "en",
-        Value: "Some Test Title",
-        Type: "String"
-      }]
+      const properties = [
+        {
+          Key: "title",
+          IsSensitive: true,
+          Language: "en",
+          Value: "Some Test Title",
+          Type: "String"
+        }
+      ]
 
       const baseInput = {
         recipients: ["test.mail@mail.com"],
@@ -134,24 +146,28 @@ describe("Test utils", () => {
       })
 
       test("Build a custom notification with navigation targets", () => {
-        expect(buildNotification({ 
-          ...baseInput, 
-          NavigationTargetAction: "TestTargetAction", 
-          NavigationTargetObject: "TestTargetObject" 
-        })).toMatchObject({ 
-          ...baseExpected, 
-          NavigationTargetAction: "TestTargetAction", 
-          NavigationTargetObject: "TestTargetObject" 
+        expect(
+          buildNotification({
+            ...baseInput,
+            NavigationTargetAction: "TestTargetAction",
+            NavigationTargetObject: "TestTargetObject"
+          })
+        ).toMatchObject({
+          ...baseExpected,
+          NavigationTargetAction: "TestTargetAction",
+          NavigationTargetObject: "TestTargetObject"
         })
       })
 
       test("Build a custom notification with a non-default priority", () => {
-        expect(buildNotification({ 
-          ...baseInput, 
-          priority: "HIGH" 
-        })).toMatchObject({ 
-          ...baseExpected, 
-          Priority: "HIGH" 
+        expect(
+          buildNotification({
+            ...baseInput,
+            priority: "HIGH"
+          })
+        ).toMatchObject({
+          ...baseExpected,
+          Priority: "HIGH"
         })
       })
 
@@ -164,7 +180,7 @@ describe("Test utils", () => {
             priority: "HIGH"
           })
         ).toMatchObject({
-          ...baseExpected, 
+          ...baseExpected,
           NavigationTargetAction: "TestTargetAction",
           NavigationTargetObject: "TestTargetObject",
           Priority: "HIGH"
@@ -180,12 +196,14 @@ describe("Test utils", () => {
           })
         ).toMatchObject({
           ...baseExpected,
-          Properties: [{ 
-            Key: "title", 
-            Value: "Some Test Title", 
-            Language: "en", 
-            Type: "string" 
-          }]
+          Properties: [
+            {
+              Key: "title",
+              Value: "Some Test Title",
+              Language: "en",
+              Type: "string"
+            }
+          ]
         })
       })
 
@@ -203,11 +221,13 @@ describe("Test utils", () => {
           TargetParameters: [{ Key: "string", Value: "string" }]
         }
 
-        expect(buildNotification({
+        expect(
+          buildNotification({
             ...baseInput,
-            ...lowLevelFields, 
+            ...lowLevelFields,
             priority: "HIGH"
-        })).toMatchObject({
+          })
+        ).toMatchObject({
           ...baseExpected,
           ...lowLevelFields,
           Priority: "HIGH"
@@ -398,27 +418,25 @@ describe("Test utils", () => {
         NotificationTypeVersion: "1",
         Priority: "NEUTRAL",
         Properties: [
-          { 
+          {
             Key: "title",
             IsSensitive: true,
             Language: "en",
             Value: "Some Test Title",
-            Type: "String" 
+            Type: "String"
           },
-          { 
+          {
             Key: "description",
             IsSensitive: true,
             Language: "en",
             Value: "Some Test Description",
-            Type: "String" 
+            Type: "String"
           }
         ],
         Recipients: [{ RecipientId: "test.mail@mail.com" }]
       }
 
-      expect(
-        buildNotification({ ...rawNotification }))
-        .toMatchObject({
+      expect(buildNotification({ ...rawNotification })).toMatchObject({
         ...rawNotification,
         NotificationTypeKey: "notifications/TestNotificationType"
       })
@@ -435,7 +453,9 @@ describe("Test utils", () => {
     })
 
     test("Return true when all entries have NotificationTypeKey", () => {
-      expect(validateNotificationTypes([{ NotificationTypeKey: "Test" }, { NotificationTypeKey: "Test2" }])).toEqual(true)
+      expect(validateNotificationTypes([{ NotificationTypeKey: "Test" }, { NotificationTypeKey: "Test2" }])).toEqual(
+        true
+      )
     })
   })
 
@@ -466,92 +486,98 @@ describe("Test utils", () => {
 
   describe("Build notification from event", () => {
     const baseEventDef = {
-      name: 'CatalogService.NewOrder',
-      kind: 'event',
-      '@notification': true,
+      name: "CatalogService.NewOrder",
+      kind: "event",
+      "@notification": true,
       elements: {
-        book:      { type: 'cds.String' },
-        quantity:  { type: 'cds.Integer' },
-        orderedAt: { type: 'cds.Date' },
-        ID:        { type: 'cds.UUID', key: true },
-        recipients: { items: { type: 'cds.String' } },
+        book: { type: "cds.String" },
+        quantity: { type: "cds.Integer" },
+        orderedAt: { type: "cds.Date" },
+        ID: { type: "cds.UUID", key: true },
+        recipients: { items: { type: "cds.String" } }
       }
     }
 
     const baseData = {
-      book: 'Moby Dick',
+      book: "Moby Dick",
       quantity: 2,
-      orderedAt: '2024-01-15',
-      ID: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
-      recipients: ['buyer@example.com'],
+      orderedAt: "2024-01-15",
+      ID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      recipients: ["buyer@example.com"]
     }
 
     test("Sets NotificationTypeKey to the unqualified event name", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.NotificationTypeKey).toBe('NewOrder')
+      expect(result.NotificationTypeKey).toBe("NewOrder")
     })
 
     test("Sets NotificationTypeVersion to '1'", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.NotificationTypeVersion).toBe('1')
+      expect(result.NotificationTypeVersion).toBe("1")
     })
 
     test("Maps event data fields to Properties with IsSensitive true", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.Properties).toContainEqual({ Key: 'book', Language: 'en', Value: 'Moby Dick', Type: 'String', IsSensitive: true })
+      expect(result.Properties).toContainEqual({
+        Key: "book",
+        Language: "en",
+        Value: "Moby Dick",
+        Type: "String",
+        IsSensitive: true
+      })
     })
 
     test("Does not include recipients in Properties", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.Properties.map(p => p.Key)).not.toContain('recipients')
+      expect(result.Properties.map(p => p.Key)).not.toContain("recipients")
     })
 
     test("Maps key elements to TargetParameters", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.TargetParameters).toEqual([{ Key: 'ID', Value: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }])
+      expect(result.TargetParameters).toEqual([{ Key: "ID", Value: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }])
     })
 
     test("Omits TargetParameters when no key elements exist", async () => {
-      const defNoKeys = { ...baseEventDef, elements: { book: { type: 'cds.String' } } }
-      const result = await buildNotificationFromEvent(defNoKeys, { book: 'Test', recipients: [] })
+      const defNoKeys = { ...baseEventDef, elements: { book: { type: "cds.String" } } }
+      const result = await buildNotificationFromEvent(defNoKeys, { book: "Test", recipients: [] })
       expect(result.TargetParameters).toBeUndefined()
     })
 
     test("Uses RecipientId for email-style recipients", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.Recipients).toEqual([{ RecipientId: 'buyer@example.com' }])
+      expect(result.Recipients).toEqual([{ RecipientId: "buyer@example.com" }])
     })
 
     test("Uses GlobalUserId for GUID recipients", async () => {
-      const data = { ...baseData, recipients: ['123e4567-e89b-12d3-a456-426614174000'] }
+      const data = { ...baseData, recipients: ["123e4567-e89b-12d3-a456-426614174000"] }
       const result = await buildNotificationFromEvent(baseEventDef, data)
-      expect(result.Recipients).toEqual([{ GlobalUserId: '123e4567-e89b-12d3-a456-426614174000' }])
+      expect(result.Recipients).toEqual([{ GlobalUserId: "123e4567-e89b-12d3-a456-426614174000" }])
     })
 
     test("Handles mixed GUID and email recipients", async () => {
-      const data = { ...baseData, recipients: ['123e4567-e89b-12d3-a456-426614174000', 'email@example.com'] }
+      const data = { ...baseData, recipients: ["123e4567-e89b-12d3-a456-426614174000", "email@example.com"] }
       const result = await buildNotificationFromEvent(baseEventDef, data)
       expect(result.Recipients).toEqual([
-        { GlobalUserId: '123e4567-e89b-12d3-a456-426614174000' },
-        { RecipientId: 'email@example.com' },
+        { GlobalUserId: "123e4567-e89b-12d3-a456-426614174000" },
+        { RecipientId: "email@example.com" }
       ])
     })
 
     test("Defaults Priority to NEUTRAL when annotation is absent", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.Priority).toBe('NEUTRAL')
+      expect(result.Priority).toBe("NEUTRAL")
     })
 
     test("Resolves enum priority annotation (#High -> HIGH)", async () => {
-      const def = { ...baseEventDef, '@notification.priority': { '#': 'High' } }
+      const def = { ...baseEventDef, "@notification.priority": { "#": "High" } }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.Priority).toBe('HIGH')
+      expect(result.Priority).toBe("HIGH")
     })
 
     test("Accepts plain string priority annotation", async () => {
-      const def = { ...baseEventDef, '@notification.priority': 'LOW' }
+      const def = { ...baseEventDef, "@notification.priority": "LOW" }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.Priority).toBe('LOW')
+      expect(result.Priority).toBe("LOW")
     })
 
     describe("Invalid static priority annotation", () => {
@@ -559,30 +585,30 @@ describe("Test utils", () => {
       beforeEach(() => log.clear())
 
       test("Falls back to NEUTRAL and warns when plain string priority is invalid", async () => {
-        const def = { ...baseEventDef, '@notification.priority': 'CRITICAL' }
+        const def = { ...baseEventDef, "@notification.priority": "CRITICAL" }
         const result = await buildNotificationFromEvent(def, baseData)
-        expect(result.Priority).toBe('NEUTRAL')
+        expect(result.Priority).toBe("NEUTRAL")
         expect(log.output).toMatch(/invalid|CRITICAL/i)
       })
 
       test("Falls back to NEUTRAL and warns when enum priority annotation resolves to invalid value", async () => {
-        const def = { ...baseEventDef, '@notification.priority': { '#': 'CRITICAL' } }
+        const def = { ...baseEventDef, "@notification.priority": { "#": "CRITICAL" } }
         const result = await buildNotificationFromEvent(def, baseData)
-        expect(result.Priority).toBe('NEUTRAL')
+        expect(result.Priority).toBe("NEUTRAL")
         expect(log.output).toMatch(/invalid|CRITICAL/i)
       })
     })
 
     test("Maps @Common.SemanticObject to NavigationTargetObject", async () => {
-      const def = { ...baseEventDef, '@Common.SemanticObject': 'Orders' }
+      const def = { ...baseEventDef, "@Common.SemanticObject": "Orders" }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.NavigationTargetObject).toBe('Orders')
+      expect(result.NavigationTargetObject).toBe("Orders")
     })
 
     test("Maps @Common.SemanticObjectAction to NavigationTargetAction", async () => {
-      const def = { ...baseEventDef, '@Common.SemanticObjectAction': 'manage' }
+      const def = { ...baseEventDef, "@Common.SemanticObjectAction": "manage" }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.NavigationTargetAction).toBe('manage')
+      expect(result.NavigationTargetAction).toBe("manage")
     })
 
     test("Works with empty data and no recipients", async () => {
@@ -598,114 +624,127 @@ describe("Test utils", () => {
     })
 
     test("Passes through string operators unchanged", () => {
-      expect(replaceRefsInExpr('>', {})).toBe('>')
+      expect(replaceRefsInExpr(">", {})).toBe(">")
     })
 
     test("Replaces {ref} with {val} when key exists in data", () => {
-      expect(replaceRefsInExpr({ ref: ['quantity'] }, { quantity: 10 })).toEqual({ val: 10, param: false })
+      expect(replaceRefsInExpr({ ref: ["quantity"] }, { quantity: 10 })).toEqual({ val: 10, param: false })
     })
 
     test("Substitutes null when key is not in data", () => {
-      expect(replaceRefsInExpr({ ref: ['unknown'] }, { quantity: 10 })).toEqual({ val: null, param: false })
+      expect(replaceRefsInExpr({ ref: ["unknown"] }, { quantity: 10 })).toEqual({ val: null, param: false })
     })
 
     test("Does not replace binding parameters ({ref, param: true})", () => {
-      const param = { ref: ['?'], param: true }
-      expect(replaceRefsInExpr(param, { '?': 'something' })).toEqual(param)
+      const param = { ref: ["?"], param: true }
+      expect(replaceRefsInExpr(param, { "?": "something" })).toEqual(param)
     })
 
     test("Recursively replaces refs in flat xpr array", () => {
-      const xpr = [{ ref: ['quantity'] }, '>', { val: 5 }]
-      expect(replaceRefsInExpr(xpr, { quantity: 10 }))
-        .toEqual([{ val: 10, param: false }, '>', { val: 5 }])
+      const xpr = [{ ref: ["quantity"] }, ">", { val: 5 }]
+      expect(replaceRefsInExpr(xpr, { quantity: 10 })).toEqual([{ val: 10, param: false }, ">", { val: 5 }])
     })
 
     test("Recursively replaces refs in nested xpr object", () => {
-      const expr = { xpr: [{ ref: ['quantity'] }, '>', { val: 5 }] }
-      expect(replaceRefsInExpr(expr, { quantity: 10 }))
-        .toEqual({ xpr: [{ val: 10, param: false }, '>', { val: 5 }] })
+      const expr = { xpr: [{ ref: ["quantity"] }, ">", { val: 5 }] }
+      expect(replaceRefsInExpr(expr, { quantity: 10 })).toEqual({ xpr: [{ val: 10, param: false }, ">", { val: 5 }] })
     })
 
     test("Converts enum symbol {'#': value} to {val: value}", () => {
-      expect(replaceRefsInExpr({ '#': 'High' }, {})).toEqual({ val: 'High', param: false })
+      expect(replaceRefsInExpr({ "#": "High" }, {})).toEqual({ val: "High", param: false })
     })
 
     test("Replaces refs in function call args", () => {
-      const func = { func: 'days_between', args: [{ ref: ['startDate'] }, { ref: ['endDate'] }] }
-      expect(replaceRefsInExpr(func, { startDate: '2024-01-01', endDate: '2024-06-01' }))
-        .toEqual({ func: 'days_between', args: [{ val: '2024-01-01', param: false }, { val: '2024-06-01', param: false }] })
+      const func = { func: "days_between", args: [{ ref: ["startDate"] }, { ref: ["endDate"] }] }
+      expect(replaceRefsInExpr(func, { startDate: "2024-01-01", endDate: "2024-06-01" })).toEqual({
+        func: "days_between",
+        args: [
+          { val: "2024-01-01", param: false },
+          { val: "2024-06-01", param: false }
+        ]
+      })
     })
 
     test("Handles deep nesting: xpr containing xpr containing refs", () => {
       const expr = {
-        xpr: ['case', 'when', { xpr: [{ ref: ['a'] }, '<', { val: 1 }] }, 'then', { ref: ['b'] }, 'end']
+        xpr: ["case", "when", { xpr: [{ ref: ["a"] }, "<", { val: 1 }] }, "then", { ref: ["b"] }, "end"]
       }
-      expect(replaceRefsInExpr(expr, { a: 0, b: 'High' }))
-        .toEqual({
-          xpr: ['case', 'when', { xpr: [{ val: 0, param: false }, '<', { val: 1 }] }, 'then', { val: 'High', param: false }, 'end']
-        })
+      expect(replaceRefsInExpr(expr, { a: 0, b: "High" })).toEqual({
+        xpr: [
+          "case",
+          "when",
+          { xpr: [{ val: 0, param: false }, "<", { val: 1 }] },
+          "then",
+          { val: "High", param: false },
+          "end"
+        ]
+      })
     })
 
     test("Replaces refs inside list nodes", () => {
-      const expr = { list: [{ ref: ['a'] }, { ref: ['b'] }] }
-      expect(replaceRefsInExpr(expr, { a: 1, b: 2 }))
-        .toEqual({ list: [{ val: 1, param: false }, { val: 2, param: false }] })
+      const expr = { list: [{ ref: ["a"] }, { ref: ["b"] }] }
+      expect(replaceRefsInExpr(expr, { a: 1, b: 2 })).toEqual({
+        list: [
+          { val: 1, param: false },
+          { val: 2, param: false }
+        ]
+      })
     })
 
     test("Replaces refs in named function args", () => {
-      const func = { func: 'foo', args: { p: { ref: ['x'] } } }
-      expect(replaceRefsInExpr(func, { x: 42 }))
-        .toEqual({ func: 'foo', args: { p: { val: 42, param: false } } })
+      const func = { func: "foo", args: { p: { ref: ["x"] } } }
+      expect(replaceRefsInExpr(func, { x: 42 })).toEqual({ func: "foo", args: { p: { val: 42, param: false } } })
     })
 
     test("Leaves multi-segment refs unchanged — path traversal is not supported", () => {
-      const expr = { ref: ['assoc', 'field'] }
-      expect(replaceRefsInExpr(expr, { assoc: 'something' }))
-        .toEqual({ ref: ['assoc', 'field'] })
+      const expr = { ref: ["assoc", "field"] }
+      expect(replaceRefsInExpr(expr, { assoc: "something" })).toEqual({ ref: ["assoc", "field"] })
     })
   })
 
   describe("mapCdsTypeToANSType", () => {
     test.each([
-      ['cds.String',    'String'],
-      ['cds.UUID',      'String'],
-      ['cds.Boolean',   'String'],
-      ['String',        'String'],
+      ["cds.String", "String"],
+      ["cds.UUID", "String"],
+      ["cds.Boolean", "String"],
+      ["String", "String"]
     ])("%s -> %s", (cdsType, expected) => {
       expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
     })
 
     test.each([
-      ['cds.Integer',   'Integer'],
-      ['cds.Integer64', 'Integer'],
-      ['cds.Int16',     'Integer'],
-      ['cds.Int32',     'Integer'],
-      ['cds.Int64',     'Integer'],
-      ['cds.UInt8',     'Integer'],
-      ['cds.Decimal',   'String'],
-      ['cds.Double',    'String'],
-      ['cds.Float',     'String'],
+      ["cds.Integer", "Integer"],
+      ["cds.Integer64", "Integer"],
+      ["cds.Int16", "Integer"],
+      ["cds.Int32", "Integer"],
+      ["cds.Int64", "Integer"],
+      ["cds.UInt8", "Integer"],
+      ["cds.Decimal", "String"],
+      ["cds.Double", "String"],
+      ["cds.Float", "String"]
     ])("%s -> %s", (cdsType, expected) => {
       expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
     })
 
     test.each([
-      ['cds.Date',      'Date'],
-      ['cds.DateTime',  'Date'],
-      ['cds.Timestamp', 'Date'],
-      ['cds.Time',      'Date'],
+      ["cds.Date", "Date"],
+      ["cds.DateTime", "Date"],
+      ["cds.Timestamp", "Date"],
+      ["cds.Time", "Date"]
     ])("%s -> %s", (cdsType, expected) => {
       expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
     })
 
     test("Returns String for undefined type", () => {
-      expect(mapCdsTypeToANSType(undefined)).toBe('String')
+      expect(mapCdsTypeToANSType(undefined)).toBe("String")
     })
   })
 
   describe("Configuration", () => {
     const log = cds.test.log()
-    afterEach(() => { delete cds.env.requires.notifications?.authenticationIdentifier })
+    afterEach(() => {
+      delete cds.env.requires.notifications?.authenticationIdentifier
+    })
 
     it("Use GlobalUserId as the recipient key when authenticationIdentifier is set to UserUUID", () => {
       cds.env.requires.notifications ??= {}
@@ -726,7 +765,7 @@ describe("Test utils", () => {
       const result = buildNotification({
         recipients: ["550e8400-e29b-41d4-a716-446655440000"],
         title: "Test Title"
-      });
+      })
 
       expect(result.Recipients[0]).toMatchObject({ GlobalUserId: "550e8400-e29b-41d4-a716-446655440000" })
     })
@@ -825,34 +864,38 @@ describe("Test utils", () => {
     test("Returns notification unchanged when all values are within limits", () => {
       const notification = {
         Properties: [{ Key: "k", Value: value255 }],
-        TargetParameters: [{ Key: "k", Value: value250 }],
+        TargetParameters: [{ Key: "k", Value: value250 }]
       }
       expect(applyValueLengthConstraints(notification)).toStrictEqual(notification)
     })
 
     test("Throws when a Property value exceeds 255 characters", () => {
       const notification = {
-        Properties: [{ Key: "k", Value: longValue256 }],
+        Properties: [{ Key: "k", Value: longValue256 }]
       }
-      expect(() => applyValueLengthConstraints(notification)).toThrow(`Property value exceeds the maximum length of ${MAX_PROPERTY_VALUE_LENGTH} characters.`)
+      expect(() => applyValueLengthConstraints(notification)).toThrow(
+        `Property value exceeds the maximum length of ${MAX_PROPERTY_VALUE_LENGTH} characters.`
+      )
     })
 
     test("Throws on the first Property value over 255 even when others are valid", () => {
       const notification = {
         Properties: [
           { Key: "ok", Value: "short" },
-          { Key: "bad", Value: longValue256 },
-        ],
+          { Key: "bad", Value: longValue256 }
+        ]
       }
-      expect(() => applyValueLengthConstraints(notification)).toThrow(`Property value exceeds the maximum length of ${MAX_PROPERTY_VALUE_LENGTH} characters.`)
+      expect(() => applyValueLengthConstraints(notification)).toThrow(
+        `Property value exceeds the maximum length of ${MAX_PROPERTY_VALUE_LENGTH} characters.`
+      )
     })
 
     test("Removes TargetParameter entries whose value exceeds 250 characters", () => {
       const notification = {
         TargetParameters: [
           { Key: "short", Value: value250 },
-          { Key: "long", Value: longValue251 },
-        ],
+          { Key: "long", Value: longValue251 }
+        ]
       }
       const result = applyValueLengthConstraints(notification)
       expect(result.TargetParameters).toEqual([{ Key: "short", Value: value250 }])
@@ -860,7 +903,7 @@ describe("Test utils", () => {
 
     test("Removes all TargetParameters when all values exceed 250 characters", () => {
       const notification = {
-        TargetParameters: [{ Key: "k", Value: longValue251 }],
+        TargetParameters: [{ Key: "k", Value: longValue251 }]
       }
       const result = applyValueLengthConstraints(notification)
       expect(result.TargetParameters).toEqual([])

--- a/tests/unit/lib/utils.test.js
+++ b/tests/unit/lib/utils.test.js
@@ -1,4 +1,4 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 const {
   buildNotification,
   validateNotificationTypes,
@@ -10,679 +10,679 @@ const {
   applyValueLengthConstraints,
   MAX_PROPERTY_VALUE_LENGTH,
   MAX_TARGET_PARAM_VALUE_LENGTH
-} = require('../../../lib/utils')
-const { existsSync, readFileSync } = require('fs')
-const { getDestination } = require('@sap-cloud-sdk/connectivity')
+} = require("../../../lib/utils")
+const { existsSync, readFileSync } = require("fs")
+const { getDestination } = require("@sap-cloud-sdk/connectivity")
 
-jest.mock('fs')
-jest.mock('@sap-cloud-sdk/connectivity')
+jest.mock("fs")
+jest.mock("@sap-cloud-sdk/connectivity")
 
-describe('Test utils', () => {
-  describe('Build notifications', () => {
-    describe('Default notifications', () => {
+describe("Test utils", () => {
+  describe("Build notifications", () => {
+    describe("Default notifications", () => {
       const expectedWithoutDescription = {
-        NotificationTypeKey: 'Default',
-        NotificationTypeVersion: '1',
-        Priority: 'NEUTRAL',
+        NotificationTypeKey: "Default",
+        NotificationTypeVersion: "1",
+        Priority: "NEUTRAL",
         Properties: [
           {
-            Key: 'title',
+            Key: "title",
             IsSensitive: true,
-            Language: 'en',
-            Value: 'Some Test Title',
-            Type: 'String'
+            Language: "en",
+            Value: "Some Test Title",
+            Type: "String"
           },
           {
-            Key: 'description',
+            Key: "description",
             IsSensitive: true,
-            Language: 'en',
-            Value: '',
-            Type: 'String'
+            Language: "en",
+            Value: "",
+            Type: "String"
           }
         ],
-        Recipients: [{ RecipientId: 'test.mail@mail.com' }]
+        Recipients: [{ RecipientId: "test.mail@mail.com" }]
       }
 
       const expectedWithDescription = {
         ...expectedWithoutDescription,
         Properties: [
           {
-            Key: 'title',
+            Key: "title",
             IsSensitive: true,
-            Language: 'en',
-            Value: 'Some Test Title',
-            Type: 'String'
+            Language: "en",
+            Value: "Some Test Title",
+            Type: "String"
           },
           {
-            Key: 'description',
+            Key: "description",
             IsSensitive: true,
-            Language: 'en',
-            Value: 'Some Test Description',
-            Type: 'String'
+            Language: "en",
+            Value: "Some Test Description",
+            Type: "String"
           }
         ]
       }
 
-      test('Build a default notification with priority', () => {
+      test("Build a default notification with priority", () => {
         expect(
           buildNotification({
-            recipients: ['test.mail@mail.com'],
-            title: 'Some Test Title',
-            priority: 'NEUTRAL'
+            recipients: ["test.mail@mail.com"],
+            title: "Some Test Title",
+            priority: "NEUTRAL"
           })
         ).toMatchObject(expectedWithoutDescription)
       })
 
-      test('Build a default notification without priority', () => {
+      test("Build a default notification without priority", () => {
         expect(
           buildNotification({
-            recipients: ['test.mail@mail.com'],
-            title: 'Some Test Title'
+            recipients: ["test.mail@mail.com"],
+            title: "Some Test Title"
           })
         ).toMatchObject(expectedWithoutDescription)
       })
 
-      test('Build a default notification with description and priority', () => {
+      test("Build a default notification with description and priority", () => {
         expect(
           buildNotification({
-            recipients: ['test.mail@mail.com'],
-            title: 'Some Test Title',
-            priority: 'NEUTRAL',
-            description: 'Some Test Description'
+            recipients: ["test.mail@mail.com"],
+            title: "Some Test Title",
+            priority: "NEUTRAL",
+            description: "Some Test Description"
           })
         ).toMatchObject(expectedWithDescription)
       })
 
-      test('Build a default notification with description', () => {
+      test("Build a default notification with description", () => {
         expect(
           buildNotification({
-            recipients: ['test.mail@mail.com'],
-            title: 'Some Test Title',
-            description: 'Some Test Description'
+            recipients: ["test.mail@mail.com"],
+            title: "Some Test Title",
+            description: "Some Test Description"
           })
         ).toMatchObject(expectedWithDescription)
       })
 
-      test('Default notification uses locale from cds.context when set', () => {
+      test("Default notification uses locale from cds.context when set", () => {
         const prev = cds.context
-        cds.context = { locale: 'de' }
+        cds.context = { locale: "de" }
         const result = buildNotification({
-          recipients: ['test@mail.com'],
-          title: 'Hallo'
+          recipients: ["test@mail.com"],
+          title: "Hallo"
         })
         cds.context = prev
-        expect(result.Properties[0].Language).toBe('de')
-        expect(result.Properties[1].Language).toBe('de')
+        expect(result.Properties[0].Language).toBe("de")
+        expect(result.Properties[1].Language).toBe("de")
       })
     })
 
-    describe('Custom notifications', () => {
+    describe("Custom notifications", () => {
       const properties = [
         {
-          Key: 'title',
+          Key: "title",
           IsSensitive: true,
-          Language: 'en',
-          Value: 'Some Test Title',
-          Type: 'String'
+          Language: "en",
+          Value: "Some Test Title",
+          Type: "String"
         }
       ]
 
       const baseInput = {
-        recipients: ['test.mail@mail.com'],
-        type: 'TestNotificationType',
+        recipients: ["test.mail@mail.com"],
+        type: "TestNotificationType",
         Properties: properties
       }
 
       const baseExpected = {
-        NotificationTypeKey: 'notifications/TestNotificationType',
-        NotificationTypeVersion: '1',
-        Priority: 'NEUTRAL',
+        NotificationTypeKey: "notifications/TestNotificationType",
+        NotificationTypeVersion: "1",
+        Priority: "NEUTRAL",
         Properties: properties,
-        Recipients: [{ RecipientId: 'test.mail@mail.com' }]
+        Recipients: [{ RecipientId: "test.mail@mail.com" }]
       }
 
-      test('Build a custom notification with properties', () => {
+      test("Build a custom notification with properties", () => {
         expect(buildNotification(baseInput)).toMatchObject(baseExpected)
       })
 
-      test('Build a custom notification with navigation targets', () => {
+      test("Build a custom notification with navigation targets", () => {
         expect(
           buildNotification({
             ...baseInput,
-            NavigationTargetAction: 'TestTargetAction',
-            NavigationTargetObject: 'TestTargetObject'
+            NavigationTargetAction: "TestTargetAction",
+            NavigationTargetObject: "TestTargetObject"
           })
         ).toMatchObject({
           ...baseExpected,
-          NavigationTargetAction: 'TestTargetAction',
-          NavigationTargetObject: 'TestTargetObject'
+          NavigationTargetAction: "TestTargetAction",
+          NavigationTargetObject: "TestTargetObject"
         })
       })
 
-      test('Build a custom notification with a non-default priority', () => {
+      test("Build a custom notification with a non-default priority", () => {
         expect(
           buildNotification({
             ...baseInput,
-            priority: 'HIGH'
+            priority: "HIGH"
           })
         ).toMatchObject({
           ...baseExpected,
-          Priority: 'HIGH'
+          Priority: "HIGH"
         })
       })
 
-      test('Build a custom notification with a non-default priority and navigation targets', () => {
+      test("Build a custom notification with a non-default priority and navigation targets", () => {
         expect(
           buildNotification({
             ...baseInput,
-            NavigationTargetAction: 'TestTargetAction',
-            NavigationTargetObject: 'TestTargetObject',
-            priority: 'HIGH'
+            NavigationTargetAction: "TestTargetAction",
+            NavigationTargetObject: "TestTargetObject",
+            priority: "HIGH"
           })
         ).toMatchObject({
           ...baseExpected,
-          NavigationTargetAction: 'TestTargetAction',
-          NavigationTargetObject: 'TestTargetObject',
-          Priority: 'HIGH'
+          NavigationTargetAction: "TestTargetAction",
+          NavigationTargetObject: "TestTargetObject",
+          Priority: "HIGH"
         })
       })
 
-      test('Maps data object to Properties array', () => {
+      test("Maps data object to Properties array", () => {
         expect(
           buildNotification({
-            recipients: ['test.mail@mail.com'],
-            type: 'TestNotificationType',
-            data: { title: 'Some Test Title' }
+            recipients: ["test.mail@mail.com"],
+            type: "TestNotificationType",
+            data: { title: "Some Test Title" }
           })
         ).toMatchObject({
           ...baseExpected,
           Properties: [
             {
-              Key: 'title',
-              Value: 'Some Test Title',
-              Language: 'en',
-              Type: 'string'
+              Key: "title",
+              Value: "Some Test Title",
+              Language: "en",
+              Type: "string"
             }
           ]
         })
       })
 
-      test('Pass all low-level API fields through to the notification', () => {
+      test("Pass all low-level API fields through to the notification", () => {
         const lowLevelFields = {
-          OriginId: '01234567-89ab-cdef-0123-456789abcdef',
-          NotificationTypeId: '01234567-89ab-cdef-0123-456789abcdef',
-          NavigationTargetAction: 'TestTargetAction',
-          NavigationTargetObject: 'TestTargetObject',
-          ProviderId: 'SAMPLEPROVIDER',
-          ActorId: 'BACKENDACTORID',
-          ActorDisplayText: 'ActorName',
-          ActorImageURL: 'https://some-url',
-          NotificationTypeTimestamp: '2022-03-15T09:58:42.807Z',
-          TargetParameters: [{ Key: 'string', Value: 'string' }]
+          OriginId: "01234567-89ab-cdef-0123-456789abcdef",
+          NotificationTypeId: "01234567-89ab-cdef-0123-456789abcdef",
+          NavigationTargetAction: "TestTargetAction",
+          NavigationTargetObject: "TestTargetObject",
+          ProviderId: "SAMPLEPROVIDER",
+          ActorId: "BACKENDACTORID",
+          ActorDisplayText: "ActorName",
+          ActorImageURL: "https://some-url",
+          NotificationTypeTimestamp: "2022-03-15T09:58:42.807Z",
+          TargetParameters: [{ Key: "string", Value: "string" }]
         }
 
         expect(
           buildNotification({
             ...baseInput,
             ...lowLevelFields,
-            priority: 'HIGH'
+            priority: "HIGH"
           })
         ).toMatchObject({
           ...baseExpected,
           ...lowLevelFields,
-          Priority: 'HIGH'
+          Priority: "HIGH"
         })
       })
 
-      test('Pass partial low-level API fields through to the notification', () => {
+      test("Pass partial low-level API fields through to the notification", () => {
         const partialLowLevelFields = {
-          NotificationTypeId: '01234567-89ab-cdef-0123-456789abcdef',
-          NavigationTargetAction: 'TestTargetAction',
-          NavigationTargetObject: 'TestTargetObject',
-          ProviderId: 'SAMPLEPROVIDER',
-          ActorId: 'BACKENDACTORID',
-          ActorDisplayText: 'ActorName',
-          ActorImageURL: 'https://some-url',
-          NotificationTypeTimestamp: '2022-03-15T09:58:42.807Z',
-          TargetParameters: [{ Key: 'string', Value: 'string' }]
+          NotificationTypeId: "01234567-89ab-cdef-0123-456789abcdef",
+          NavigationTargetAction: "TestTargetAction",
+          NavigationTargetObject: "TestTargetObject",
+          ProviderId: "SAMPLEPROVIDER",
+          ActorId: "BACKENDACTORID",
+          ActorDisplayText: "ActorName",
+          ActorImageURL: "https://some-url",
+          NotificationTypeTimestamp: "2022-03-15T09:58:42.807Z",
+          TargetParameters: [{ Key: "string", Value: "string" }]
         }
 
         expect(
           buildNotification({
             ...baseInput,
             ...partialLowLevelFields,
-            priority: 'HIGH'
+            priority: "HIGH"
           })
         ).toMatchObject({
           ...baseExpected,
           ...partialLowLevelFields,
-          Priority: 'HIGH'
+          Priority: "HIGH"
         })
       })
 
-      test('Custom notification data mapping uses locale from cds.context when set', () => {
+      test("Custom notification data mapping uses locale from cds.context when set", () => {
         const prev = cds.context
-        cds.context = { locale: 'de' }
+        cds.context = { locale: "de" }
         const result = buildNotification({
-          recipients: ['test@mail.com'],
-          type: 'TestType',
-          data: { title: 'Hallo' }
+          recipients: ["test@mail.com"],
+          type: "TestType",
+          data: { title: "Hallo" }
         })
         cds.context = prev
-        expect(result.Properties[0].Language).toBe('de')
+        expect(result.Properties[0].Language).toBe("de")
       })
     })
 
-    describe('Invalid inputs', () => {
-      test('Return falsy when an empty object is passed', () => {
+    describe("Invalid inputs", () => {
+      test("Return falsy when an empty object is passed", () => {
         expect(buildNotification({})).toBeFalsy()
       })
 
-      describe('Default notification', () => {
-        test('Return falsy when title is missing', () => {
+      describe("Default notification", () => {
+        test("Return falsy when title is missing", () => {
           expect(
             buildNotification({
-              recipients: ['test.mail@mail.com'],
-              priority: 'NEUTRAL'
+              recipients: ["test.mail@mail.com"],
+              priority: "NEUTRAL"
             })
           ).toBeFalsy()
         })
 
-        test('Return falsy when recipients is empty', () => {
+        test("Return falsy when recipients is empty", () => {
           expect(
             buildNotification({
               recipients: [],
-              title: 'Some Test Title',
-              priority: 'NEUTRAL'
+              title: "Some Test Title",
+              priority: "NEUTRAL"
             })
           ).toBeFalsy()
         })
 
-        test('Return falsy when recipients is not an array', () => {
+        test("Return falsy when recipients is not an array", () => {
           expect(
             buildNotification({
-              recipients: 'invalid',
-              title: 'Some Test Title',
-              priority: 'NEUTRAL'
+              recipients: "invalid",
+              title: "Some Test Title",
+              priority: "NEUTRAL"
             })
           ).toBeFalsy()
         })
 
-        test('Return falsy when priority is not a valid value', () => {
+        test("Return falsy when priority is not a valid value", () => {
           expect(
             buildNotification({
-              recipients: ['test.mail@mail.com'],
-              title: 'Some Test Title',
-              priority: 'INVALID'
+              recipients: ["test.mail@mail.com"],
+              title: "Some Test Title",
+              priority: "INVALID"
             })
           ).toBeFalsy()
         })
 
-        test('Return falsy when description is not a string', () => {
+        test("Return falsy when description is not a string", () => {
           expect(
             buildNotification({
-              recipients: ['test.mail@mail.com'],
-              title: 'Some Test Title',
-              priority: 'NEUTRAL',
-              description: { invalid: 'invalid' }
+              recipients: ["test.mail@mail.com"],
+              title: "Some Test Title",
+              priority: "NEUTRAL",
+              description: { invalid: "invalid" }
             })
           ).toBeFalsy()
         })
 
-        test('Return falsy when title is not a string', () => {
+        test("Return falsy when title is not a string", () => {
           expect(
             buildNotification({
-              recipients: ['test.mail@mail.com'],
-              title: { invalid: 'invalid' },
-              priority: 'NEUTRAL'
+              recipients: ["test.mail@mail.com"],
+              title: { invalid: "invalid" },
+              priority: "NEUTRAL"
             })
           ).toBeFalsy()
         })
       })
 
-      describe('Custom notification', () => {
-        test('Return falsy when recipients is missing', () => {
+      describe("Custom notification", () => {
+        test("Return falsy when recipients is missing", () => {
           expect(
             buildNotification({
-              type: 'TestNotificationType'
+              type: "TestNotificationType"
             })
           ).toBeFalsy()
         })
 
-        test('Return falsy when recipients is empty', () => {
+        test("Return falsy when recipients is empty", () => {
           expect(
             buildNotification({
               recipients: [],
-              type: 'TestNotificationType'
+              type: "TestNotificationType"
             })
           ).toBeFalsy()
         })
 
-        test('Return falsy when recipients is not an array', () => {
+        test("Return falsy when recipients is not an array", () => {
           expect(
             buildNotification({
-              recipients: 'invalid',
-              type: 'TestNotificationType'
+              recipients: "invalid",
+              type: "TestNotificationType"
             })
           ).toBeFalsy()
         })
 
-        test('Return falsy when priority is not a valid value', () => {
+        test("Return falsy when priority is not a valid value", () => {
           expect(
             buildNotification({
-              recipients: ['test.mail@mail.com'],
-              type: 'TestNotificationType',
-              priority: 'invalid'
+              recipients: ["test.mail@mail.com"],
+              type: "TestNotificationType",
+              priority: "invalid"
             })
           ).toBeFalsy()
         })
 
-        test('Return falsy when properties is not an array', () => {
+        test("Return falsy when properties is not an array", () => {
           expect(
             buildNotification({
-              recipients: ['test.mail@mail.com'],
-              type: 'TestNotificationType',
-              priority: 'NEUTRAL',
-              properties: 'invalid'
+              recipients: ["test.mail@mail.com"],
+              type: "TestNotificationType",
+              priority: "NEUTRAL",
+              properties: "invalid"
             })
           ).toBeFalsy()
         })
 
-        test('Return falsy when navigation is not an object', () => {
+        test("Return falsy when navigation is not an object", () => {
           expect(
             buildNotification({
-              recipients: ['test.mail@mail.com'],
-              type: 'TestNotificationType',
-              priority: 'NEUTRAL',
-              navigation: 'invalid'
+              recipients: ["test.mail@mail.com"],
+              type: "TestNotificationType",
+              priority: "NEUTRAL",
+              navigation: "invalid"
             })
           ).toBeFalsy()
         })
 
-        test('Return falsy when payload is not an object', () => {
+        test("Return falsy when payload is not an object", () => {
           expect(
             buildNotification({
-              recipients: ['test.mail@mail.com'],
-              type: 'TestNotificationType',
-              priority: 'NEUTRAL',
-              payload: 'invalid'
+              recipients: ["test.mail@mail.com"],
+              type: "TestNotificationType",
+              priority: "NEUTRAL",
+              payload: "invalid"
             })
           ).toBeFalsy()
         })
       })
     })
 
-    test('Pass a raw notification object through with the prefix applied to the type key', () => {
+    test("Pass a raw notification object through with the prefix applied to the type key", () => {
       const rawNotification = {
-        NotificationTypeKey: 'TestNotificationType',
-        NotificationTypeVersion: '1',
-        Priority: 'NEUTRAL',
+        NotificationTypeKey: "TestNotificationType",
+        NotificationTypeVersion: "1",
+        Priority: "NEUTRAL",
         Properties: [
           {
-            Key: 'title',
+            Key: "title",
             IsSensitive: true,
-            Language: 'en',
-            Value: 'Some Test Title',
-            Type: 'String'
+            Language: "en",
+            Value: "Some Test Title",
+            Type: "String"
           },
           {
-            Key: 'description',
+            Key: "description",
             IsSensitive: true,
-            Language: 'en',
-            Value: 'Some Test Description',
-            Type: 'String'
+            Language: "en",
+            Value: "Some Test Description",
+            Type: "String"
           }
         ],
-        Recipients: [{ RecipientId: 'test.mail@mail.com' }]
+        Recipients: [{ RecipientId: "test.mail@mail.com" }]
       }
 
       expect(buildNotification({ ...rawNotification })).toMatchObject({
         ...rawNotification,
-        NotificationTypeKey: 'notifications/TestNotificationType'
+        NotificationTypeKey: "notifications/TestNotificationType"
       })
     })
   })
 
-  describe('Notification types validation', () => {
-    test('Return false when an entry is missing NotificationTypeKey', () => {
-      expect(validateNotificationTypes([{ NotificationTypeKey: 'Test' }, { blabla: 'Test2' }])).toEqual(false)
+  describe("Notification types validation", () => {
+    test("Return false when an entry is missing NotificationTypeKey", () => {
+      expect(validateNotificationTypes([{ NotificationTypeKey: "Test" }, { blabla: "Test2" }])).toEqual(false)
     })
 
-    test('Return true for an empty array', () => {
+    test("Return true for an empty array", () => {
       expect(validateNotificationTypes([])).toBe(true)
     })
 
-    test('Return true when all entries have NotificationTypeKey', () => {
-      expect(validateNotificationTypes([{ NotificationTypeKey: 'Test' }, { NotificationTypeKey: 'Test2' }])).toEqual(
+    test("Return true when all entries have NotificationTypeKey", () => {
+      expect(validateNotificationTypes([{ NotificationTypeKey: "Test" }, { NotificationTypeKey: "Test2" }])).toEqual(
         true
       )
     })
   })
 
-  describe('Read file', () => {
-    test('Return an empty array when the file does not exist', () => {
+  describe("Read file", () => {
+    test("Return an empty array when the file does not exist", () => {
       existsSync.mockReturnValue(false)
-      expect(readFile('test.json')).toMatchObject([])
+      expect(readFile("test.json")).toMatchObject([])
     })
 
-    test('Return the parsed file contents when the file exists', () => {
+    test("Return the parsed file contents when the file exists", () => {
       existsSync.mockReturnValue(true)
       readFileSync.mockReturnValue('[{ "test": "test" }]')
-      expect(readFile('test.json')).toMatchObject([{ test: 'test' }])
+      expect(readFile("test.json")).toMatchObject([{ test: "test" }])
     })
   })
 
-  describe('Get notification destination', () => {
-    test('Return the destination when it exists', async () => {
-      getDestination.mockReturnValue({ 'mock-destination': 'mock-destination' })
-      expect(await getNotificationDestination()).toMatchObject({ 'mock-destination': 'mock-destination' })
+  describe("Get notification destination", () => {
+    test("Return the destination when it exists", async () => {
+      getDestination.mockReturnValue({ "mock-destination": "mock-destination" })
+      expect(await getNotificationDestination()).toMatchObject({ "mock-destination": "mock-destination" })
     })
 
-    test('Throw an error when the destination is not found', async () => {
+    test("Throw an error when the destination is not found", async () => {
       getDestination.mockReturnValue(undefined)
-      await expect(() => getNotificationDestination()).rejects.toThrow('Failed to get destination: SAP_Notifications')
+      await expect(() => getNotificationDestination()).rejects.toThrow("Failed to get destination: SAP_Notifications")
     })
   })
 
-  describe('Build notification from event', () => {
+  describe("Build notification from event", () => {
     const baseEventDef = {
-      name: 'CatalogService.NewOrder',
-      kind: 'event',
-      '@notification': true,
+      name: "CatalogService.NewOrder",
+      kind: "event",
+      "@notification": true,
       elements: {
-        book: { type: 'cds.String' },
-        quantity: { type: 'cds.Integer' },
-        orderedAt: { type: 'cds.Date' },
-        ID: { type: 'cds.UUID', key: true },
-        recipients: { items: { type: 'cds.String' } }
+        book: { type: "cds.String" },
+        quantity: { type: "cds.Integer" },
+        orderedAt: { type: "cds.Date" },
+        ID: { type: "cds.UUID", key: true },
+        recipients: { items: { type: "cds.String" } }
       }
     }
 
     const baseData = {
-      book: 'Moby Dick',
+      book: "Moby Dick",
       quantity: 2,
-      orderedAt: '2024-01-15',
-      ID: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
-      recipients: ['buyer@example.com']
+      orderedAt: "2024-01-15",
+      ID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      recipients: ["buyer@example.com"]
     }
 
-    test('Sets NotificationTypeKey to the unqualified event name', async () => {
+    test("Sets NotificationTypeKey to the unqualified event name", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.NotificationTypeKey).toBe('NewOrder')
+      expect(result.NotificationTypeKey).toBe("NewOrder")
     })
 
     test("Sets NotificationTypeVersion to '1'", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.NotificationTypeVersion).toBe('1')
+      expect(result.NotificationTypeVersion).toBe("1")
     })
 
-    test('Maps event data fields to Properties with IsSensitive true', async () => {
+    test("Maps event data fields to Properties with IsSensitive true", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
       expect(result.Properties).toContainEqual({
-        Key: 'book',
-        Language: 'en',
-        Value: 'Moby Dick',
-        Type: 'String',
+        Key: "book",
+        Language: "en",
+        Value: "Moby Dick",
+        Type: "String",
         IsSensitive: true
       })
     })
 
-    test('Does not include recipients in Properties', async () => {
+    test("Does not include recipients in Properties", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.Properties.map(p => p.Key)).not.toContain('recipients')
+      expect(result.Properties.map(p => p.Key)).not.toContain("recipients")
     })
 
-    test('Maps key elements to TargetParameters', async () => {
+    test("Maps key elements to TargetParameters", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.TargetParameters).toEqual([{ Key: 'ID', Value: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }])
+      expect(result.TargetParameters).toEqual([{ Key: "ID", Value: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }])
     })
 
-    test('Omits TargetParameters when no key elements exist', async () => {
-      const defNoKeys = { ...baseEventDef, elements: { book: { type: 'cds.String' } } }
-      const result = await buildNotificationFromEvent(defNoKeys, { book: 'Test', recipients: [] })
+    test("Omits TargetParameters when no key elements exist", async () => {
+      const defNoKeys = { ...baseEventDef, elements: { book: { type: "cds.String" } } }
+      const result = await buildNotificationFromEvent(defNoKeys, { book: "Test", recipients: [] })
       expect(result.TargetParameters).toBeUndefined()
     })
 
-    test('Uses RecipientId for email-style recipients', async () => {
+    test("Uses RecipientId for email-style recipients", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.Recipients).toEqual([{ RecipientId: 'buyer@example.com' }])
+      expect(result.Recipients).toEqual([{ RecipientId: "buyer@example.com" }])
     })
 
-    test('Uses GlobalUserId for GUID recipients', async () => {
-      const data = { ...baseData, recipients: ['123e4567-e89b-12d3-a456-426614174000'] }
+    test("Uses GlobalUserId for GUID recipients", async () => {
+      const data = { ...baseData, recipients: ["123e4567-e89b-12d3-a456-426614174000"] }
       const result = await buildNotificationFromEvent(baseEventDef, data)
-      expect(result.Recipients).toEqual([{ GlobalUserId: '123e4567-e89b-12d3-a456-426614174000' }])
+      expect(result.Recipients).toEqual([{ GlobalUserId: "123e4567-e89b-12d3-a456-426614174000" }])
     })
 
-    test('Handles mixed GUID and email recipients', async () => {
-      const data = { ...baseData, recipients: ['123e4567-e89b-12d3-a456-426614174000', 'email@example.com'] }
+    test("Handles mixed GUID and email recipients", async () => {
+      const data = { ...baseData, recipients: ["123e4567-e89b-12d3-a456-426614174000", "email@example.com"] }
       const result = await buildNotificationFromEvent(baseEventDef, data)
       expect(result.Recipients).toEqual([
-        { GlobalUserId: '123e4567-e89b-12d3-a456-426614174000' },
-        { RecipientId: 'email@example.com' }
+        { GlobalUserId: "123e4567-e89b-12d3-a456-426614174000" },
+        { RecipientId: "email@example.com" }
       ])
     })
 
-    test('Defaults Priority to NEUTRAL when annotation is absent', async () => {
+    test("Defaults Priority to NEUTRAL when annotation is absent", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, baseData)
-      expect(result.Priority).toBe('NEUTRAL')
+      expect(result.Priority).toBe("NEUTRAL")
     })
 
-    test('Resolves enum priority annotation (#High -> HIGH)', async () => {
-      const def = { ...baseEventDef, '@notification.priority': { '#': 'High' } }
+    test("Resolves enum priority annotation (#High -> HIGH)", async () => {
+      const def = { ...baseEventDef, "@notification.priority": { "#": "High" } }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.Priority).toBe('HIGH')
+      expect(result.Priority).toBe("HIGH")
     })
 
-    test('Accepts plain string priority annotation', async () => {
-      const def = { ...baseEventDef, '@notification.priority': 'LOW' }
+    test("Accepts plain string priority annotation", async () => {
+      const def = { ...baseEventDef, "@notification.priority": "LOW" }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.Priority).toBe('LOW')
+      expect(result.Priority).toBe("LOW")
     })
 
-    describe('Invalid static priority annotation', () => {
+    describe("Invalid static priority annotation", () => {
       const log = cds.test.log()
       beforeEach(() => log.clear())
 
-      test('Falls back to NEUTRAL and warns when plain string priority is invalid', async () => {
-        const def = { ...baseEventDef, '@notification.priority': 'CRITICAL' }
+      test("Falls back to NEUTRAL and warns when plain string priority is invalid", async () => {
+        const def = { ...baseEventDef, "@notification.priority": "CRITICAL" }
         const result = await buildNotificationFromEvent(def, baseData)
-        expect(result.Priority).toBe('NEUTRAL')
+        expect(result.Priority).toBe("NEUTRAL")
         expect(log.output).toMatch(/invalid|CRITICAL/i)
       })
 
-      test('Falls back to NEUTRAL and warns when enum priority annotation resolves to invalid value', async () => {
-        const def = { ...baseEventDef, '@notification.priority': { '#': 'CRITICAL' } }
+      test("Falls back to NEUTRAL and warns when enum priority annotation resolves to invalid value", async () => {
+        const def = { ...baseEventDef, "@notification.priority": { "#": "CRITICAL" } }
         const result = await buildNotificationFromEvent(def, baseData)
-        expect(result.Priority).toBe('NEUTRAL')
+        expect(result.Priority).toBe("NEUTRAL")
         expect(log.output).toMatch(/invalid|CRITICAL/i)
       })
     })
 
-    test('Maps @Common.SemanticObject to NavigationTargetObject', async () => {
-      const def = { ...baseEventDef, '@Common.SemanticObject': 'Orders' }
+    test("Maps @Common.SemanticObject to NavigationTargetObject", async () => {
+      const def = { ...baseEventDef, "@Common.SemanticObject": "Orders" }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.NavigationTargetObject).toBe('Orders')
+      expect(result.NavigationTargetObject).toBe("Orders")
     })
 
-    test('Maps @Common.SemanticObjectAction to NavigationTargetAction', async () => {
-      const def = { ...baseEventDef, '@Common.SemanticObjectAction': 'manage' }
+    test("Maps @Common.SemanticObjectAction to NavigationTargetAction", async () => {
+      const def = { ...baseEventDef, "@Common.SemanticObjectAction": "manage" }
       const result = await buildNotificationFromEvent(def, baseData)
-      expect(result.NavigationTargetAction).toBe('manage')
+      expect(result.NavigationTargetAction).toBe("manage")
     })
 
-    test('Works with empty data and no recipients', async () => {
+    test("Works with empty data and no recipients", async () => {
       const result = await buildNotificationFromEvent(baseEventDef, {})
       expect(result.Recipients).toEqual([])
       expect(result.Properties).toEqual([])
     })
   })
 
-  describe('replaceRefsInExpr', () => {
-    test('Passes through val nodes unchanged', () => {
+  describe("replaceRefsInExpr", () => {
+    test("Passes through val nodes unchanged", () => {
       expect(replaceRefsInExpr({ val: 42 }, {})).toEqual({ val: 42 })
     })
 
-    test('Passes through string operators unchanged', () => {
-      expect(replaceRefsInExpr('>', {})).toBe('>')
+    test("Passes through string operators unchanged", () => {
+      expect(replaceRefsInExpr(">", {})).toBe(">")
     })
 
-    test('Replaces {ref} with {val} when key exists in data', () => {
-      expect(replaceRefsInExpr({ ref: ['quantity'] }, { quantity: 10 })).toEqual({ val: 10, param: false })
+    test("Replaces {ref} with {val} when key exists in data", () => {
+      expect(replaceRefsInExpr({ ref: ["quantity"] }, { quantity: 10 })).toEqual({ val: 10, param: false })
     })
 
-    test('Substitutes null when key is not in data', () => {
-      expect(replaceRefsInExpr({ ref: ['unknown'] }, { quantity: 10 })).toEqual({ val: null, param: false })
+    test("Substitutes null when key is not in data", () => {
+      expect(replaceRefsInExpr({ ref: ["unknown"] }, { quantity: 10 })).toEqual({ val: null, param: false })
     })
 
-    test('Does not replace binding parameters ({ref, param: true})', () => {
-      const param = { ref: ['?'], param: true }
-      expect(replaceRefsInExpr(param, { '?': 'something' })).toEqual(param)
+    test("Does not replace binding parameters ({ref, param: true})", () => {
+      const param = { ref: ["?"], param: true }
+      expect(replaceRefsInExpr(param, { "?": "something" })).toEqual(param)
     })
 
-    test('Recursively replaces refs in flat xpr array', () => {
-      const xpr = [{ ref: ['quantity'] }, '>', { val: 5 }]
-      expect(replaceRefsInExpr(xpr, { quantity: 10 })).toEqual([{ val: 10, param: false }, '>', { val: 5 }])
+    test("Recursively replaces refs in flat xpr array", () => {
+      const xpr = [{ ref: ["quantity"] }, ">", { val: 5 }]
+      expect(replaceRefsInExpr(xpr, { quantity: 10 })).toEqual([{ val: 10, param: false }, ">", { val: 5 }])
     })
 
-    test('Recursively replaces refs in nested xpr object', () => {
-      const expr = { xpr: [{ ref: ['quantity'] }, '>', { val: 5 }] }
-      expect(replaceRefsInExpr(expr, { quantity: 10 })).toEqual({ xpr: [{ val: 10, param: false }, '>', { val: 5 }] })
+    test("Recursively replaces refs in nested xpr object", () => {
+      const expr = { xpr: [{ ref: ["quantity"] }, ">", { val: 5 }] }
+      expect(replaceRefsInExpr(expr, { quantity: 10 })).toEqual({ xpr: [{ val: 10, param: false }, ">", { val: 5 }] })
     })
 
     test("Converts enum symbol {'#': value} to {val: value}", () => {
-      expect(replaceRefsInExpr({ '#': 'High' }, {})).toEqual({ val: 'High', param: false })
+      expect(replaceRefsInExpr({ "#": "High" }, {})).toEqual({ val: "High", param: false })
     })
 
-    test('Replaces refs in function call args', () => {
-      const func = { func: 'days_between', args: [{ ref: ['startDate'] }, { ref: ['endDate'] }] }
-      expect(replaceRefsInExpr(func, { startDate: '2024-01-01', endDate: '2024-06-01' })).toEqual({
-        func: 'days_between',
+    test("Replaces refs in function call args", () => {
+      const func = { func: "days_between", args: [{ ref: ["startDate"] }, { ref: ["endDate"] }] }
+      expect(replaceRefsInExpr(func, { startDate: "2024-01-01", endDate: "2024-06-01" })).toEqual({
+        func: "days_between",
         args: [
-          { val: '2024-01-01', param: false },
-          { val: '2024-06-01', param: false }
+          { val: "2024-01-01", param: false },
+          { val: "2024-06-01", param: false }
         ]
       })
     })
 
-    test('Handles deep nesting: xpr containing xpr containing refs', () => {
+    test("Handles deep nesting: xpr containing xpr containing refs", () => {
       const expr = {
-        xpr: ['case', 'when', { xpr: [{ ref: ['a'] }, '<', { val: 1 }] }, 'then', { ref: ['b'] }, 'end']
+        xpr: ["case", "when", { xpr: [{ ref: ["a"] }, "<", { val: 1 }] }, "then", { ref: ["b"] }, "end"]
       }
-      expect(replaceRefsInExpr(expr, { a: 0, b: 'High' })).toEqual({
+      expect(replaceRefsInExpr(expr, { a: 0, b: "High" })).toEqual({
         xpr: [
-          'case',
-          'when',
-          { xpr: [{ val: 0, param: false }, '<', { val: 1 }] },
-          'then',
-          { val: 'High', param: false },
-          'end'
+          "case",
+          "when",
+          { xpr: [{ val: 0, param: false }, "<", { val: 1 }] },
+          "then",
+          { val: "High", param: false },
+          "end"
         ]
       })
     })
 
-    test('Replaces refs inside list nodes', () => {
-      const expr = { list: [{ ref: ['a'] }, { ref: ['b'] }] }
+    test("Replaces refs inside list nodes", () => {
+      const expr = { list: [{ ref: ["a"] }, { ref: ["b"] }] }
       expect(replaceRefsInExpr(expr, { a: 1, b: 2 })).toEqual({
         list: [
           { val: 1, param: false },
@@ -691,198 +691,198 @@ describe('Test utils', () => {
       })
     })
 
-    test('Replaces refs in named function args', () => {
-      const func = { func: 'foo', args: { p: { ref: ['x'] } } }
-      expect(replaceRefsInExpr(func, { x: 42 })).toEqual({ func: 'foo', args: { p: { val: 42, param: false } } })
+    test("Replaces refs in named function args", () => {
+      const func = { func: "foo", args: { p: { ref: ["x"] } } }
+      expect(replaceRefsInExpr(func, { x: 42 })).toEqual({ func: "foo", args: { p: { val: 42, param: false } } })
     })
 
-    test('Leaves multi-segment refs unchanged — path traversal is not supported', () => {
-      const expr = { ref: ['assoc', 'field'] }
-      expect(replaceRefsInExpr(expr, { assoc: 'something' })).toEqual({ ref: ['assoc', 'field'] })
-    })
-  })
-
-  describe('mapCdsTypeToANSType', () => {
-    test.each([
-      ['cds.String', 'String'],
-      ['cds.UUID', 'String'],
-      ['cds.Boolean', 'String'],
-      ['String', 'String']
-    ])('%s -> %s', (cdsType, expected) => {
-      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
-    })
-
-    test.each([
-      ['cds.Integer', 'Integer'],
-      ['cds.Integer64', 'Integer'],
-      ['cds.Int16', 'Integer'],
-      ['cds.Int32', 'Integer'],
-      ['cds.Int64', 'Integer'],
-      ['cds.UInt8', 'Integer'],
-      ['cds.Decimal', 'String'],
-      ['cds.Double', 'String'],
-      ['cds.Float', 'String']
-    ])('%s -> %s', (cdsType, expected) => {
-      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
-    })
-
-    test.each([
-      ['cds.Date', 'Date'],
-      ['cds.DateTime', 'Date'],
-      ['cds.Timestamp', 'Date'],
-      ['cds.Time', 'Date']
-    ])('%s -> %s', (cdsType, expected) => {
-      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
-    })
-
-    test('Returns String for undefined type', () => {
-      expect(mapCdsTypeToANSType(undefined)).toBe('String')
+    test("Leaves multi-segment refs unchanged — path traversal is not supported", () => {
+      const expr = { ref: ["assoc", "field"] }
+      expect(replaceRefsInExpr(expr, { assoc: "something" })).toEqual({ ref: ["assoc", "field"] })
     })
   })
 
-  describe('Configuration', () => {
+  describe("mapCdsTypeToANSType", () => {
+    test.each([
+      ["cds.String", "String"],
+      ["cds.UUID", "String"],
+      ["cds.Boolean", "String"],
+      ["String", "String"]
+    ])("%s -> %s", (cdsType, expected) => {
+      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
+    })
+
+    test.each([
+      ["cds.Integer", "Integer"],
+      ["cds.Integer64", "Integer"],
+      ["cds.Int16", "Integer"],
+      ["cds.Int32", "Integer"],
+      ["cds.Int64", "Integer"],
+      ["cds.UInt8", "Integer"],
+      ["cds.Decimal", "String"],
+      ["cds.Double", "String"],
+      ["cds.Float", "String"]
+    ])("%s -> %s", (cdsType, expected) => {
+      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
+    })
+
+    test.each([
+      ["cds.Date", "Date"],
+      ["cds.DateTime", "Date"],
+      ["cds.Timestamp", "Date"],
+      ["cds.Time", "Date"]
+    ])("%s -> %s", (cdsType, expected) => {
+      expect(mapCdsTypeToANSType(cdsType)).toBe(expected)
+    })
+
+    test("Returns String for undefined type", () => {
+      expect(mapCdsTypeToANSType(undefined)).toBe("String")
+    })
+  })
+
+  describe("Configuration", () => {
     const log = cds.test.log()
     afterEach(() => {
       delete cds.env.requires.notifications?.authenticationIdentifier
     })
 
-    it('Use GlobalUserId as the recipient key when authenticationIdentifier is set to UserUUID', () => {
+    it("Use GlobalUserId as the recipient key when authenticationIdentifier is set to UserUUID", () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = 'UserUUID'
+      cds.env.requires.notifications.authenticationIdentifier = "UserUUID"
 
       const result = buildNotification({
-        recipients: ['user-uuid-123'],
-        title: 'Test Title'
+        recipients: ["user-uuid-123"],
+        title: "Test Title"
       })
 
-      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: 'user-uuid-123' })
+      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: "user-uuid-123" })
     })
 
-    it('Auto mode picks GlobalUserId for UUID recipients', () => {
+    it("Auto mode picks GlobalUserId for UUID recipients", () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = 'auto'
+      cds.env.requires.notifications.authenticationIdentifier = "auto"
 
       const result = buildNotification({
-        recipients: ['550e8400-e29b-41d4-a716-446655440000'],
-        title: 'Test Title'
+        recipients: ["550e8400-e29b-41d4-a716-446655440000"],
+        title: "Test Title"
       })
 
-      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: '550e8400-e29b-41d4-a716-446655440000' })
+      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: "550e8400-e29b-41d4-a716-446655440000" })
     })
 
-    it('Auto mode picks RecipientId for email recipients', () => {
+    it("Auto mode picks RecipientId for email recipients", () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = 'auto'
+      cds.env.requires.notifications.authenticationIdentifier = "auto"
 
       const result = buildNotification({
-        recipients: ['test.mail@mail.com'],
-        title: 'Test Title'
+        recipients: ["test.mail@mail.com"],
+        title: "Test Title"
       })
 
-      expect(result.Recipients[0]).toMatchObject({ RecipientId: 'test.mail@mail.com' })
+      expect(result.Recipients[0]).toMatchObject({ RecipientId: "test.mail@mail.com" })
     })
 
-    it('Auto mode supports mixed UUID and email recipients in one notification', () => {
+    it("Auto mode supports mixed UUID and email recipients in one notification", () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = 'auto'
+      cds.env.requires.notifications.authenticationIdentifier = "auto"
 
       const result = buildNotification({
-        recipients: ['550e8400-e29b-41d4-a716-446655440000', 'test.mail@mail.com'],
-        title: 'Test Title'
+        recipients: ["550e8400-e29b-41d4-a716-446655440000", "test.mail@mail.com"],
+        title: "Test Title"
       })
 
       expect(result.Recipients).toEqual([
-        { GlobalUserId: '550e8400-e29b-41d4-a716-446655440000' },
-        { RecipientId: 'test.mail@mail.com' }
+        { GlobalUserId: "550e8400-e29b-41d4-a716-446655440000" },
+        { RecipientId: "test.mail@mail.com" }
       ])
     })
 
-    it('Auto mode warns and falls back to RecipientId when value is neither UUID nor email', () => {
+    it("Auto mode warns and falls back to RecipientId when value is neither UUID nor email", () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = 'auto'
+      cds.env.requires.notifications.authenticationIdentifier = "auto"
       log.clear()
 
       const result = buildNotification({
-        recipients: ['not-a-uuid-or-email'],
-        title: 'Test Title'
+        recipients: ["not-a-uuid-or-email"],
+        title: "Test Title"
       })
 
-      expect(result.Recipients[0]).toMatchObject({ RecipientId: 'not-a-uuid-or-email' })
-      expect(log.output).toContain('neither a UUID nor an email')
+      expect(result.Recipients[0]).toMatchObject({ RecipientId: "not-a-uuid-or-email" })
+      expect(log.output).toContain("neither a UUID nor an email")
     })
 
-    it('Auto is the default when authenticationIdentifier is not configured', () => {
+    it("Auto is the default when authenticationIdentifier is not configured", () => {
       cds.env.requires.notifications ??= {}
       delete cds.env.requires.notifications.authenticationIdentifier
 
       const result = buildNotification({
-        recipients: ['550e8400-e29b-41d4-a716-446655440000'],
-        title: 'Test Title'
+        recipients: ["550e8400-e29b-41d4-a716-446655440000"],
+        title: "Test Title"
       })
 
-      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: '550e8400-e29b-41d4-a716-446655440000' })
+      expect(result.Recipients[0]).toMatchObject({ GlobalUserId: "550e8400-e29b-41d4-a716-446655440000" })
     })
 
-    it('Explicit RecipientId mode never resolves to GlobalUserId even for UUID values', () => {
+    it("Explicit RecipientId mode never resolves to GlobalUserId even for UUID values", () => {
       cds.env.requires.notifications ??= {}
-      cds.env.requires.notifications.authenticationIdentifier = 'RecipientId'
+      cds.env.requires.notifications.authenticationIdentifier = "RecipientId"
 
       const result = buildNotification({
-        recipients: ['550e8400-e29b-41d4-a716-446655440000'],
-        title: 'Test Title'
+        recipients: ["550e8400-e29b-41d4-a716-446655440000"],
+        title: "Test Title"
       })
 
-      expect(result.Recipients[0]).toMatchObject({ RecipientId: '550e8400-e29b-41d4-a716-446655440000' })
+      expect(result.Recipients[0]).toMatchObject({ RecipientId: "550e8400-e29b-41d4-a716-446655440000" })
     })
 
-    it('Fall back to basename of cds.root as prefix when package.json cannot be read', () => {
+    it("Fall back to basename of cds.root as prefix when package.json cannot be read", () => {
       let result
       jest.isolateModules(() => {
-        const cds = require('@sap/cds')
+        const cds = require("@sap/cds")
         const originalRoot = cds.root
         cds.env.requires.notifications ??= {}
-        cds.env.requires.notifications.prefix = '$app-name'
-        cds.root = '/nonexistent-path-for-testing'
+        cds.env.requires.notifications.prefix = "$app-name"
+        cds.root = "/nonexistent-path-for-testing"
         try {
-          const { getNotificationTypesKeyWithPrefix } = require('../../../lib/utils')
-          result = getNotificationTypesKeyWithPrefix('TestType')
+          const { getNotificationTypesKeyWithPrefix } = require("../../../lib/utils")
+          result = getNotificationTypesKeyWithPrefix("TestType")
         } finally {
           cds.root = originalRoot
           delete cds.env.requires.notifications.prefix
         }
       })
-      expect(result).toBe('nonexistent-path-for-testing/TestType')
+      expect(result).toBe("nonexistent-path-for-testing/TestType")
     })
   })
 
-  describe('applyValueLengthConstraints', () => {
-    const longValue251 = 'a'.repeat(MAX_TARGET_PARAM_VALUE_LENGTH + 1)
-    const longValue256 = 'a'.repeat(MAX_PROPERTY_VALUE_LENGTH + 1)
-    const value255 = 'a'.repeat(MAX_PROPERTY_VALUE_LENGTH)
-    const value250 = 'a'.repeat(MAX_TARGET_PARAM_VALUE_LENGTH)
+  describe("applyValueLengthConstraints", () => {
+    const longValue251 = "a".repeat(MAX_TARGET_PARAM_VALUE_LENGTH + 1)
+    const longValue256 = "a".repeat(MAX_PROPERTY_VALUE_LENGTH + 1)
+    const value255 = "a".repeat(MAX_PROPERTY_VALUE_LENGTH)
+    const value250 = "a".repeat(MAX_TARGET_PARAM_VALUE_LENGTH)
 
-    test('Returns notification unchanged when all values are within limits', () => {
+    test("Returns notification unchanged when all values are within limits", () => {
       const notification = {
-        Properties: [{ Key: 'k', Value: value255 }],
-        TargetParameters: [{ Key: 'k', Value: value250 }]
+        Properties: [{ Key: "k", Value: value255 }],
+        TargetParameters: [{ Key: "k", Value: value250 }]
       }
       expect(applyValueLengthConstraints(notification)).toStrictEqual(notification)
     })
 
-    test('Throws when a Property value exceeds 255 characters', () => {
+    test("Throws when a Property value exceeds 255 characters", () => {
       const notification = {
-        Properties: [{ Key: 'k', Value: longValue256 }]
+        Properties: [{ Key: "k", Value: longValue256 }]
       }
       expect(() => applyValueLengthConstraints(notification)).toThrow(
         `Property value exceeds the maximum length of ${MAX_PROPERTY_VALUE_LENGTH} characters.`
       )
     })
 
-    test('Throws on the first Property value over 255 even when others are valid', () => {
+    test("Throws on the first Property value over 255 even when others are valid", () => {
       const notification = {
         Properties: [
-          { Key: 'ok', Value: 'short' },
-          { Key: 'bad', Value: longValue256 }
+          { Key: "ok", Value: "short" },
+          { Key: "bad", Value: longValue256 }
         ]
       }
       expect(() => applyValueLengthConstraints(notification)).toThrow(
@@ -890,32 +890,32 @@ describe('Test utils', () => {
       )
     })
 
-    test('Removes TargetParameter entries whose value exceeds 250 characters', () => {
+    test("Removes TargetParameter entries whose value exceeds 250 characters", () => {
       const notification = {
         TargetParameters: [
-          { Key: 'short', Value: value250 },
-          { Key: 'long', Value: longValue251 }
+          { Key: "short", Value: value250 },
+          { Key: "long", Value: longValue251 }
         ]
       }
       const result = applyValueLengthConstraints(notification)
-      expect(result.TargetParameters).toEqual([{ Key: 'short', Value: value250 }])
+      expect(result.TargetParameters).toEqual([{ Key: "short", Value: value250 }])
     })
 
-    test('Removes all TargetParameters when all values exceed 250 characters', () => {
+    test("Removes all TargetParameters when all values exceed 250 characters", () => {
       const notification = {
-        TargetParameters: [{ Key: 'k', Value: longValue251 }]
+        TargetParameters: [{ Key: "k", Value: longValue251 }]
       }
       const result = applyValueLengthConstraints(notification)
       expect(result.TargetParameters).toEqual([])
     })
 
-    test('Returns null/undefined unchanged', () => {
+    test("Returns null/undefined unchanged", () => {
       expect(applyValueLengthConstraints(null)).toBeNull()
       expect(applyValueLengthConstraints(undefined)).toBeUndefined()
     })
 
-    test('Handles notification with no Properties or TargetParameters', () => {
-      const notification = { NotificationTypeKey: 'Test' }
+    test("Handles notification with no Properties or TargetParameters", () => {
+      const notification = { NotificationTypeKey: "Test" }
       expect(applyValueLengthConstraints(notification)).toBe(notification)
     })
   })

--- a/tests/unit/srv/notifyToRest.test.js
+++ b/tests/unit/srv/notifyToRest.test.js
@@ -1,15 +1,15 @@
-const cds = require("@sap/cds")
-const { messages, buildNotification } = require("../../../lib/utils")
-const NotifyToRest = require("../../../srv/notifyToRest")
+const cds = require('@sap/cds')
+const { messages, buildNotification } = require('../../../lib/utils')
+const NotifyToRest = require('../../../srv/notifyToRest')
 
-jest.mock("@sap-cloud-sdk/connectivity", () => ({ buildHeadersForDestination: jest.fn().mockResolvedValue({}) }))
-jest.mock("@sap-cloud-sdk/http-client", () => ({ executeHttpRequest: jest.fn() }))
-jest.mock("../../../lib/utils", () => ({
-  ...jest.requireActual("../../../lib/utils"),
+jest.mock('@sap-cloud-sdk/connectivity', () => ({ buildHeadersForDestination: jest.fn().mockResolvedValue({}) }))
+jest.mock('@sap-cloud-sdk/http-client', () => ({ executeHttpRequest: jest.fn() }))
+jest.mock('../../../lib/utils', () => ({
+  ...jest.requireActual('../../../lib/utils'),
   getNotificationDestination: jest.fn().mockResolvedValue({})
 }))
 
-describe("Notify to rest", () => {
+describe('Notify to rest', () => {
   let log = cds.test.log()
   let notifyToRest
 
@@ -17,13 +17,13 @@ describe("Notify to rest", () => {
     notifyToRest = new NotifyToRest()
   })
 
-  describe("Warnings", () => {
-    test("No object is passed", async () => {
+  describe('Warnings', () => {
+    test('No object is passed', async () => {
       notifyToRest.notify()
       expect(log.output).toContain(messages.NO_OBJECT_FOR_NOTIFY)
     })
 
-    test("Empty object is passed", async () => {
+    test('Empty object is passed', async () => {
       notifyToRest.notify({})
       expect(log.output).toContain(messages.EMPTY_OBJECT_FOR_NOTIFY)
     })
@@ -34,64 +34,64 @@ describe("Notify to rest", () => {
     })
 
     test("Title isn't a string in default notification", async () => {
-      notifyToRest.notify({ title: 1, recipients: ["abc@abc.com"] })
+      notifyToRest.notify({ title: 1, recipients: ['abc@abc.com'] })
       expect(log.output).toContain(messages.TITLE_IS_NOT_STRING)
     })
 
     test("Priority isn't valid in default notification", async () => {
-      notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"], priority: "abc" })
-      expect(log.output).toContain("Invalid priority abc. Allowed priorities are LOW, NEUTRAL, MEDIUM, HIGH")
+      notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'], priority: 'abc' })
+      expect(log.output).toContain('Invalid priority abc. Allowed priorities are LOW, NEUTRAL, MEDIUM, HIGH')
     })
 
     test("Description isn't valid in default notification", async () => {
-      notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"], priority: "low", description: true })
+      notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'], priority: 'low', description: true })
       expect(log.output).toContain(messages.DESCRIPTION_IS_NOT_STRING)
     })
   })
 
-  describe("Error handling", () => {
+  describe('Error handling', () => {
     let httpClient
 
     beforeEach(() => {
-      httpClient = require("@sap-cloud-sdk/http-client")
+      httpClient = require('@sap-cloud-sdk/http-client')
       notifyToRest.init()
     })
 
-    test("Throws a cds.error with the ANS error message on failure", async () => {
+    test('Throws a cds.error with the ANS error message on failure', async () => {
       httpClient.executeHttpRequest.mockRejectedValueOnce({
-        response: { status: 500, data: { error: { message: { value: "Internal Server Error" } } } }
+        response: { status: 500, data: { error: { message: { value: 'Internal Server Error' } } } }
       })
-      await expect(notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"] })).rejects.toThrow(
-        "Internal Server Error"
+      await expect(notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'] })).rejects.toThrow(
+        'Internal Server Error'
       )
     })
 
-    test("Marks 4xx errors as unrecoverable", async () => {
+    test('Marks 4xx errors as unrecoverable', async () => {
       httpClient.executeHttpRequest.mockRejectedValueOnce({
-        response: { status: 400, data: { error: { message: { value: "Bad Request" } } } }
+        response: { status: 400, data: { error: { message: { value: 'Bad Request' } } } }
       })
-      const err = await notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"] }).catch(e => e)
+      const err = await notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'] }).catch(e => e)
       expect(err.unrecoverable).toBe(true)
     })
 
-    test("Does not mark 429 as unrecoverable", async () => {
+    test('Does not mark 429 as unrecoverable', async () => {
       httpClient.executeHttpRequest.mockRejectedValueOnce({
-        response: { status: 429, data: { error: { message: { value: "Too Many Requests" } } } }
+        response: { status: 429, data: { error: { message: { value: 'Too Many Requests' } } } }
       })
-      const err = await notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"] }).catch(e => e)
+      const err = await notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'] }).catch(e => e)
       expect(err.unrecoverable).toBeUndefined()
     })
 
-    test("Does not mark 5xx errors as unrecoverable", async () => {
+    test('Does not mark 5xx errors as unrecoverable', async () => {
       httpClient.executeHttpRequest.mockRejectedValueOnce({
-        response: { status: 500, data: { error: { message: { value: "Server Error" } } } }
+        response: { status: 500, data: { error: { message: { value: 'Server Error' } } } }
       })
-      const err = await notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"] }).catch(e => e)
+      const err = await notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'] }).catch(e => e)
       expect(err.unrecoverable).toBeUndefined()
     })
   })
 
-  describe("Posting notifications", () => {
+  describe('Posting notifications', () => {
     let postedNotification
 
     beforeEach(() => {
@@ -99,19 +99,19 @@ describe("Notify to rest", () => {
       notifyToRest.init()
     })
 
-    test("Correct body is sent the notification should be posted", async () => {
-      const body = { title: "abc", recipients: ["abc@abc.com"], priority: "low" }
+    test('Correct body is sent the notification should be posted', async () => {
+      const body = { title: 'abc', recipients: ['abc@abc.com'], priority: 'low' }
       await notifyToRest.notify(body)
       expect(postedNotification).toMatchObject(buildNotification(body))
     })
 
-    test("Emit is called with an outbox request object", async () => {
+    test('Emit is called with an outbox request object', async () => {
       const req = {
-        event: "IncidentResolved",
+        event: 'IncidentResolved',
         data: {
-          NotificationTypeKey: "IncidentResolved",
-          NotificationTypeVersion: "1",
-          Priority: "NEUTRAL",
+          NotificationTypeKey: 'IncidentResolved',
+          NotificationTypeVersion: '1',
+          Priority: 'NEUTRAL',
           Properties: [],
           Recipients: []
         },
@@ -121,24 +121,24 @@ describe("Notify to rest", () => {
       expect(postedNotification).toMatchObject(req.data)
     })
 
-    test("Notify is called with a single object-containing type", async () => {
-      const body = { type: "IncidentResolved", recipients: ["abc@abc.com"], data: { title: "test" } }
+    test('Notify is called with a single object-containing type', async () => {
+      const body = { type: 'IncidentResolved', recipients: ['abc@abc.com'], data: { title: 'test' } }
       await notifyToRest.notify(body)
       expect(postedNotification).toMatchObject(buildNotification(body))
     })
 
-    test("Notify is called with type as first arg and message as second", async () => {
-      await notifyToRest.notify("IncidentResolved", { recipients: ["abc@abc.com"], data: { title: "test" } })
+    test('Notify is called with type as first arg and message as second', async () => {
+      await notifyToRest.notify('IncidentResolved', { recipients: ['abc@abc.com'], data: { title: 'test' } })
       expect(postedNotification).toMatchObject(
-        buildNotification({ type: "IncidentResolved", recipients: ["abc@abc.com"], data: { title: "test" } })
+        buildNotification({ type: 'IncidentResolved', recipients: ['abc@abc.com'], data: { title: 'test' } })
       )
     })
 
-    test("Notify is called with a single object containing NotificationTypeKey and no type", async () => {
+    test('Notify is called with a single object containing NotificationTypeKey and no type', async () => {
       const body = {
-        NotificationTypeKey: "IncidentResolved",
-        NotificationTypeVersion: "1",
-        Priority: "NEUTRAL",
+        NotificationTypeKey: 'IncidentResolved',
+        NotificationTypeVersion: '1',
+        Priority: 'NEUTRAL',
         Properties: [],
         Recipients: []
       }
@@ -147,30 +147,30 @@ describe("Notify to rest", () => {
       expect(postedNotification).toMatchObject(expected)
     })
 
-    test("Notify is called with type and array of messages for batch", async () => {
+    test('Notify is called with type and array of messages for batch', async () => {
       const messages = [
-        { recipients: ["alice@example.com"], data: { title: "Batch 1" } },
-        { recipients: ["bob@example.com"], data: { title: "Batch 2" } }
+        { recipients: ['alice@example.com'], data: { title: 'Batch 1' } },
+        { recipients: ['bob@example.com'], data: { title: 'Batch 2' } }
       ]
       let postedNotifications = []
       notifyToRest.postNotification = n => {
         postedNotifications = n
       }
-      await notifyToRest.notify("IncidentResolved", messages)
+      await notifyToRest.notify('IncidentResolved', messages)
       expect(Array.isArray(postedNotifications)).toBe(true)
       expect(postedNotifications).toHaveLength(2)
       expect(postedNotifications[0]).toMatchObject(
-        buildNotification({ type: "IncidentResolved", recipients: ["alice@example.com"], data: { title: "Batch 1" } })
+        buildNotification({ type: 'IncidentResolved', recipients: ['alice@example.com'], data: { title: 'Batch 1' } })
       )
       expect(postedNotifications[1]).toMatchObject(
-        buildNotification({ type: "IncidentResolved", recipients: ["bob@example.com"], data: { title: "Batch 2" } })
+        buildNotification({ type: 'IncidentResolved', recipients: ['bob@example.com'], data: { title: 'Batch 2' } })
       )
     })
 
-    test("Notify is called with array of default notifications for batch", async () => {
+    test('Notify is called with array of default notifications for batch', async () => {
       const messages = [
-        { recipients: ["alice@example.com"], title: "Hello Alice" },
-        { recipients: ["bob@example.com"], title: "Hello Bob" }
+        { recipients: ['alice@example.com'], title: 'Hello Alice' },
+        { recipients: ['bob@example.com'], title: 'Hello Bob' }
       ]
       let postedNotifications = []
       notifyToRest.postNotification = n => {
@@ -180,15 +180,15 @@ describe("Notify to rest", () => {
       expect(Array.isArray(postedNotifications)).toBe(true)
       expect(postedNotifications).toHaveLength(2)
       expect(postedNotifications[0]).toMatchObject(
-        buildNotification({ recipients: ["alice@example.com"], title: "Hello Alice" })
+        buildNotification({ recipients: ['alice@example.com'], title: 'Hello Alice' })
       )
       expect(postedNotifications[1]).toMatchObject(
-        buildNotification({ recipients: ["bob@example.com"], title: "Hello Bob" })
+        buildNotification({ recipients: ['bob@example.com'], title: 'Hello Bob' })
       )
     })
   })
 
-  describe("Before hook", () => {
+  describe('Before hook', () => {
     let postedNotification
 
     beforeEach(() => {
@@ -198,16 +198,16 @@ describe("Notify to rest", () => {
 
     test("before('*') hook receives msg.event and msg.data before notification is sent", async () => {
       let capturedEvent, capturedData
-      notifyToRest.before("*", msg => {
+      notifyToRest.before('*', msg => {
         capturedEvent = msg.event
         capturedData = msg.data
       })
 
-      const body = { recipients: ["user@example.com"], data: { title: "Test" } }
-      await notifyToRest.notify("IncidentResolved", body)
+      const body = { recipients: ['user@example.com'], data: { title: 'Test' } }
+      await notifyToRest.notify('IncidentResolved', body)
 
-      expect(capturedEvent).toBe("IncidentResolved")
-      expect(capturedData).toMatchObject(buildNotification({ type: "IncidentResolved", ...body }))
+      expect(capturedEvent).toBe('IncidentResolved')
+      expect(capturedData).toMatchObject(buildNotification({ type: 'IncidentResolved', ...body }))
       expect(postedNotification).toBeDefined()
     })
   })

--- a/tests/unit/srv/notifyToRest.test.js
+++ b/tests/unit/srv/notifyToRest.test.js
@@ -1,15 +1,15 @@
-const cds = require('@sap/cds')
-const { messages, buildNotification } = require('../../../lib/utils')
-const NotifyToRest = require('../../../srv/notifyToRest')
+const cds = require("@sap/cds")
+const { messages, buildNotification } = require("../../../lib/utils")
+const NotifyToRest = require("../../../srv/notifyToRest")
 
-jest.mock('@sap-cloud-sdk/connectivity', () => ({ buildHeadersForDestination: jest.fn().mockResolvedValue({}) }))
-jest.mock('@sap-cloud-sdk/http-client', () => ({ executeHttpRequest: jest.fn() }))
-jest.mock('../../../lib/utils', () => ({
-  ...jest.requireActual('../../../lib/utils'),
+jest.mock("@sap-cloud-sdk/connectivity", () => ({ buildHeadersForDestination: jest.fn().mockResolvedValue({}) }))
+jest.mock("@sap-cloud-sdk/http-client", () => ({ executeHttpRequest: jest.fn() }))
+jest.mock("../../../lib/utils", () => ({
+  ...jest.requireActual("../../../lib/utils"),
   getNotificationDestination: jest.fn().mockResolvedValue({})
 }))
 
-describe('Notify to rest', () => {
+describe("Notify to rest", () => {
   let log = cds.test.log()
   let notifyToRest
 
@@ -17,13 +17,13 @@ describe('Notify to rest', () => {
     notifyToRest = new NotifyToRest()
   })
 
-  describe('Warnings', () => {
-    test('No object is passed', async () => {
+  describe("Warnings", () => {
+    test("No object is passed", async () => {
       notifyToRest.notify()
       expect(log.output).toContain(messages.NO_OBJECT_FOR_NOTIFY)
     })
 
-    test('Empty object is passed', async () => {
+    test("Empty object is passed", async () => {
       notifyToRest.notify({})
       expect(log.output).toContain(messages.EMPTY_OBJECT_FOR_NOTIFY)
     })
@@ -34,64 +34,64 @@ describe('Notify to rest', () => {
     })
 
     test("Title isn't a string in default notification", async () => {
-      notifyToRest.notify({ title: 1, recipients: ['abc@abc.com'] })
+      notifyToRest.notify({ title: 1, recipients: ["abc@abc.com"] })
       expect(log.output).toContain(messages.TITLE_IS_NOT_STRING)
     })
 
     test("Priority isn't valid in default notification", async () => {
-      notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'], priority: 'abc' })
-      expect(log.output).toContain('Invalid priority abc. Allowed priorities are LOW, NEUTRAL, MEDIUM, HIGH')
+      notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"], priority: "abc" })
+      expect(log.output).toContain("Invalid priority abc. Allowed priorities are LOW, NEUTRAL, MEDIUM, HIGH")
     })
 
     test("Description isn't valid in default notification", async () => {
-      notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'], priority: 'low', description: true })
+      notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"], priority: "low", description: true })
       expect(log.output).toContain(messages.DESCRIPTION_IS_NOT_STRING)
     })
   })
 
-  describe('Error handling', () => {
+  describe("Error handling", () => {
     let httpClient
 
     beforeEach(() => {
-      httpClient = require('@sap-cloud-sdk/http-client')
+      httpClient = require("@sap-cloud-sdk/http-client")
       notifyToRest.init()
     })
 
-    test('Throws a cds.error with the ANS error message on failure', async () => {
+    test("Throws a cds.error with the ANS error message on failure", async () => {
       httpClient.executeHttpRequest.mockRejectedValueOnce({
-        response: { status: 500, data: { error: { message: { value: 'Internal Server Error' } } } }
+        response: { status: 500, data: { error: { message: { value: "Internal Server Error" } } } }
       })
-      await expect(notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'] })).rejects.toThrow(
-        'Internal Server Error'
+      await expect(notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"] })).rejects.toThrow(
+        "Internal Server Error"
       )
     })
 
-    test('Marks 4xx errors as unrecoverable', async () => {
+    test("Marks 4xx errors as unrecoverable", async () => {
       httpClient.executeHttpRequest.mockRejectedValueOnce({
-        response: { status: 400, data: { error: { message: { value: 'Bad Request' } } } }
+        response: { status: 400, data: { error: { message: { value: "Bad Request" } } } }
       })
-      const err = await notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'] }).catch(e => e)
+      const err = await notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"] }).catch(e => e)
       expect(err.unrecoverable).toBe(true)
     })
 
-    test('Does not mark 429 as unrecoverable', async () => {
+    test("Does not mark 429 as unrecoverable", async () => {
       httpClient.executeHttpRequest.mockRejectedValueOnce({
-        response: { status: 429, data: { error: { message: { value: 'Too Many Requests' } } } }
+        response: { status: 429, data: { error: { message: { value: "Too Many Requests" } } } }
       })
-      const err = await notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'] }).catch(e => e)
+      const err = await notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"] }).catch(e => e)
       expect(err.unrecoverable).toBeUndefined()
     })
 
-    test('Does not mark 5xx errors as unrecoverable', async () => {
+    test("Does not mark 5xx errors as unrecoverable", async () => {
       httpClient.executeHttpRequest.mockRejectedValueOnce({
-        response: { status: 500, data: { error: { message: { value: 'Server Error' } } } }
+        response: { status: 500, data: { error: { message: { value: "Server Error" } } } }
       })
-      const err = await notifyToRest.notify({ title: 'abc', recipients: ['abc@abc.com'] }).catch(e => e)
+      const err = await notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"] }).catch(e => e)
       expect(err.unrecoverable).toBeUndefined()
     })
   })
 
-  describe('Posting notifications', () => {
+  describe("Posting notifications", () => {
     let postedNotification
 
     beforeEach(() => {
@@ -99,19 +99,19 @@ describe('Notify to rest', () => {
       notifyToRest.init()
     })
 
-    test('Correct body is sent the notification should be posted', async () => {
-      const body = { title: 'abc', recipients: ['abc@abc.com'], priority: 'low' }
+    test("Correct body is sent the notification should be posted", async () => {
+      const body = { title: "abc", recipients: ["abc@abc.com"], priority: "low" }
       await notifyToRest.notify(body)
       expect(postedNotification).toMatchObject(buildNotification(body))
     })
 
-    test('Emit is called with an outbox request object', async () => {
+    test("Emit is called with an outbox request object", async () => {
       const req = {
-        event: 'IncidentResolved',
+        event: "IncidentResolved",
         data: {
-          NotificationTypeKey: 'IncidentResolved',
-          NotificationTypeVersion: '1',
-          Priority: 'NEUTRAL',
+          NotificationTypeKey: "IncidentResolved",
+          NotificationTypeVersion: "1",
+          Priority: "NEUTRAL",
           Properties: [],
           Recipients: []
         },
@@ -121,24 +121,24 @@ describe('Notify to rest', () => {
       expect(postedNotification).toMatchObject(req.data)
     })
 
-    test('Notify is called with a single object-containing type', async () => {
-      const body = { type: 'IncidentResolved', recipients: ['abc@abc.com'], data: { title: 'test' } }
+    test("Notify is called with a single object-containing type", async () => {
+      const body = { type: "IncidentResolved", recipients: ["abc@abc.com"], data: { title: "test" } }
       await notifyToRest.notify(body)
       expect(postedNotification).toMatchObject(buildNotification(body))
     })
 
-    test('Notify is called with type as first arg and message as second', async () => {
-      await notifyToRest.notify('IncidentResolved', { recipients: ['abc@abc.com'], data: { title: 'test' } })
+    test("Notify is called with type as first arg and message as second", async () => {
+      await notifyToRest.notify("IncidentResolved", { recipients: ["abc@abc.com"], data: { title: "test" } })
       expect(postedNotification).toMatchObject(
-        buildNotification({ type: 'IncidentResolved', recipients: ['abc@abc.com'], data: { title: 'test' } })
+        buildNotification({ type: "IncidentResolved", recipients: ["abc@abc.com"], data: { title: "test" } })
       )
     })
 
-    test('Notify is called with a single object containing NotificationTypeKey and no type', async () => {
+    test("Notify is called with a single object containing NotificationTypeKey and no type", async () => {
       const body = {
-        NotificationTypeKey: 'IncidentResolved',
-        NotificationTypeVersion: '1',
-        Priority: 'NEUTRAL',
+        NotificationTypeKey: "IncidentResolved",
+        NotificationTypeVersion: "1",
+        Priority: "NEUTRAL",
         Properties: [],
         Recipients: []
       }
@@ -147,30 +147,30 @@ describe('Notify to rest', () => {
       expect(postedNotification).toMatchObject(expected)
     })
 
-    test('Notify is called with type and array of messages for batch', async () => {
+    test("Notify is called with type and array of messages for batch", async () => {
       const messages = [
-        { recipients: ['alice@example.com'], data: { title: 'Batch 1' } },
-        { recipients: ['bob@example.com'], data: { title: 'Batch 2' } }
+        { recipients: ["alice@example.com"], data: { title: "Batch 1" } },
+        { recipients: ["bob@example.com"], data: { title: "Batch 2" } }
       ]
       let postedNotifications = []
       notifyToRest.postNotification = n => {
         postedNotifications = n
       }
-      await notifyToRest.notify('IncidentResolved', messages)
+      await notifyToRest.notify("IncidentResolved", messages)
       expect(Array.isArray(postedNotifications)).toBe(true)
       expect(postedNotifications).toHaveLength(2)
       expect(postedNotifications[0]).toMatchObject(
-        buildNotification({ type: 'IncidentResolved', recipients: ['alice@example.com'], data: { title: 'Batch 1' } })
+        buildNotification({ type: "IncidentResolved", recipients: ["alice@example.com"], data: { title: "Batch 1" } })
       )
       expect(postedNotifications[1]).toMatchObject(
-        buildNotification({ type: 'IncidentResolved', recipients: ['bob@example.com'], data: { title: 'Batch 2' } })
+        buildNotification({ type: "IncidentResolved", recipients: ["bob@example.com"], data: { title: "Batch 2" } })
       )
     })
 
-    test('Notify is called with array of default notifications for batch', async () => {
+    test("Notify is called with array of default notifications for batch", async () => {
       const messages = [
-        { recipients: ['alice@example.com'], title: 'Hello Alice' },
-        { recipients: ['bob@example.com'], title: 'Hello Bob' }
+        { recipients: ["alice@example.com"], title: "Hello Alice" },
+        { recipients: ["bob@example.com"], title: "Hello Bob" }
       ]
       let postedNotifications = []
       notifyToRest.postNotification = n => {
@@ -180,15 +180,15 @@ describe('Notify to rest', () => {
       expect(Array.isArray(postedNotifications)).toBe(true)
       expect(postedNotifications).toHaveLength(2)
       expect(postedNotifications[0]).toMatchObject(
-        buildNotification({ recipients: ['alice@example.com'], title: 'Hello Alice' })
+        buildNotification({ recipients: ["alice@example.com"], title: "Hello Alice" })
       )
       expect(postedNotifications[1]).toMatchObject(
-        buildNotification({ recipients: ['bob@example.com'], title: 'Hello Bob' })
+        buildNotification({ recipients: ["bob@example.com"], title: "Hello Bob" })
       )
     })
   })
 
-  describe('Before hook', () => {
+  describe("Before hook", () => {
     let postedNotification
 
     beforeEach(() => {
@@ -198,16 +198,16 @@ describe('Notify to rest', () => {
 
     test("before('*') hook receives msg.event and msg.data before notification is sent", async () => {
       let capturedEvent, capturedData
-      notifyToRest.before('*', msg => {
+      notifyToRest.before("*", msg => {
         capturedEvent = msg.event
         capturedData = msg.data
       })
 
-      const body = { recipients: ['user@example.com'], data: { title: 'Test' } }
-      await notifyToRest.notify('IncidentResolved', body)
+      const body = { recipients: ["user@example.com"], data: { title: "Test" } }
+      await notifyToRest.notify("IncidentResolved", body)
 
-      expect(capturedEvent).toBe('IncidentResolved')
-      expect(capturedData).toMatchObject(buildNotification({ type: 'IncidentResolved', ...body }))
+      expect(capturedEvent).toBe("IncidentResolved")
+      expect(capturedData).toMatchObject(buildNotification({ type: "IncidentResolved", ...body }))
       expect(postedNotification).toBeDefined()
     })
   })

--- a/tests/unit/srv/notifyToRest.test.js
+++ b/tests/unit/srv/notifyToRest.test.js
@@ -1,10 +1,13 @@
-const cds = require('@sap/cds')
+const cds = require("@sap/cds")
 const { messages, buildNotification } = require("../../../lib/utils")
 const NotifyToRest = require("../../../srv/notifyToRest")
 
 jest.mock("@sap-cloud-sdk/connectivity", () => ({ buildHeadersForDestination: jest.fn().mockResolvedValue({}) }))
 jest.mock("@sap-cloud-sdk/http-client", () => ({ executeHttpRequest: jest.fn() }))
-jest.mock("../../../lib/utils", () => ({ ...jest.requireActual("../../../lib/utils"), getNotificationDestination: jest.fn().mockResolvedValue({}) }))
+jest.mock("../../../lib/utils", () => ({
+  ...jest.requireActual("../../../lib/utils"),
+  getNotificationDestination: jest.fn().mockResolvedValue({})
+}))
 
 describe("Notify to rest", () => {
   let log = cds.test.log()
@@ -58,8 +61,9 @@ describe("Notify to rest", () => {
       httpClient.executeHttpRequest.mockRejectedValueOnce({
         response: { status: 500, data: { error: { message: { value: "Internal Server Error" } } } }
       })
-      await expect(notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"] }))
-        .rejects.toThrow("Internal Server Error")
+      await expect(notifyToRest.notify({ title: "abc", recipients: ["abc@abc.com"] })).rejects.toThrow(
+        "Internal Server Error"
+      )
     })
 
     test("Marks 4xx errors as unrecoverable", async () => {
@@ -91,18 +95,28 @@ describe("Notify to rest", () => {
     let postedNotification
 
     beforeEach(() => {
-      notifyToRest.postNotification = n => postedNotification = n
+      notifyToRest.postNotification = n => (postedNotification = n)
       notifyToRest.init()
     })
 
     test("Correct body is sent the notification should be posted", async () => {
-      const body = { title: "abc", recipients: ["abc@abc.com"], priority: "low" } 
+      const body = { title: "abc", recipients: ["abc@abc.com"], priority: "low" }
       await notifyToRest.notify(body)
       expect(postedNotification).toMatchObject(buildNotification(body))
     })
 
     test("Emit is called with an outbox request object", async () => {
-      const req = { event: "IncidentResolved", data: { NotificationTypeKey: "IncidentResolved", NotificationTypeVersion: "1", Priority: "NEUTRAL", Properties: [], Recipients: [] }, headers: {} }
+      const req = {
+        event: "IncidentResolved",
+        data: {
+          NotificationTypeKey: "IncidentResolved",
+          NotificationTypeVersion: "1",
+          Priority: "NEUTRAL",
+          Properties: [],
+          Recipients: []
+        },
+        headers: {}
+      }
       await notifyToRest.emit(req)
       expect(postedNotification).toMatchObject(req.data)
     })
@@ -115,11 +129,19 @@ describe("Notify to rest", () => {
 
     test("Notify is called with type as first arg and message as second", async () => {
       await notifyToRest.notify("IncidentResolved", { recipients: ["abc@abc.com"], data: { title: "test" } })
-      expect(postedNotification).toMatchObject(buildNotification({ type: "IncidentResolved", recipients: ["abc@abc.com"], data: { title: "test" } }))
+      expect(postedNotification).toMatchObject(
+        buildNotification({ type: "IncidentResolved", recipients: ["abc@abc.com"], data: { title: "test" } })
+      )
     })
 
     test("Notify is called with a single object containing NotificationTypeKey and no type", async () => {
-      const body = { NotificationTypeKey: "IncidentResolved", NotificationTypeVersion: "1", Priority: "NEUTRAL", Properties: [], Recipients: [] }
+      const body = {
+        NotificationTypeKey: "IncidentResolved",
+        NotificationTypeVersion: "1",
+        Priority: "NEUTRAL",
+        Properties: [],
+        Recipients: []
+      }
       const expected = buildNotification({ ...body })
       await notifyToRest.notify(body)
       expect(postedNotification).toMatchObject(expected)
@@ -128,29 +150,41 @@ describe("Notify to rest", () => {
     test("Notify is called with type and array of messages for batch", async () => {
       const messages = [
         { recipients: ["alice@example.com"], data: { title: "Batch 1" } },
-        { recipients: ["bob@example.com"], data: { title: "Batch 2" } },
+        { recipients: ["bob@example.com"], data: { title: "Batch 2" } }
       ]
       let postedNotifications = []
-      notifyToRest.postNotification = n => { postedNotifications = n }
+      notifyToRest.postNotification = n => {
+        postedNotifications = n
+      }
       await notifyToRest.notify("IncidentResolved", messages)
       expect(Array.isArray(postedNotifications)).toBe(true)
       expect(postedNotifications).toHaveLength(2)
-      expect(postedNotifications[0]).toMatchObject(buildNotification({ type: "IncidentResolved", recipients: ["alice@example.com"], data: { title: "Batch 1" } }))
-      expect(postedNotifications[1]).toMatchObject(buildNotification({ type: "IncidentResolved", recipients: ["bob@example.com"], data: { title: "Batch 2" } }))
+      expect(postedNotifications[0]).toMatchObject(
+        buildNotification({ type: "IncidentResolved", recipients: ["alice@example.com"], data: { title: "Batch 1" } })
+      )
+      expect(postedNotifications[1]).toMatchObject(
+        buildNotification({ type: "IncidentResolved", recipients: ["bob@example.com"], data: { title: "Batch 2" } })
+      )
     })
 
     test("Notify is called with array of default notifications for batch", async () => {
       const messages = [
         { recipients: ["alice@example.com"], title: "Hello Alice" },
-        { recipients: ["bob@example.com"], title: "Hello Bob" },
+        { recipients: ["bob@example.com"], title: "Hello Bob" }
       ]
       let postedNotifications = []
-      notifyToRest.postNotification = n => { postedNotifications = n }
+      notifyToRest.postNotification = n => {
+        postedNotifications = n
+      }
       await notifyToRest.notify(messages)
       expect(Array.isArray(postedNotifications)).toBe(true)
       expect(postedNotifications).toHaveLength(2)
-      expect(postedNotifications[0]).toMatchObject(buildNotification({ recipients: ["alice@example.com"], title: "Hello Alice" }))
-      expect(postedNotifications[1]).toMatchObject(buildNotification({ recipients: ["bob@example.com"], title: "Hello Bob" }))
+      expect(postedNotifications[0]).toMatchObject(
+        buildNotification({ recipients: ["alice@example.com"], title: "Hello Alice" })
+      )
+      expect(postedNotifications[1]).toMatchObject(
+        buildNotification({ recipients: ["bob@example.com"], title: "Hello Bob" })
+      )
     })
   })
 
@@ -158,13 +192,13 @@ describe("Notify to rest", () => {
     let postedNotification
 
     beforeEach(() => {
-      notifyToRest.postNotification = n => postedNotification = n
+      notifyToRest.postNotification = n => (postedNotification = n)
       notifyToRest.init()
     })
 
     test("before('*') hook receives msg.event and msg.data before notification is sent", async () => {
       let capturedEvent, capturedData
-      notifyToRest.before('*', msg => {
+      notifyToRest.before("*", msg => {
         capturedEvent = msg.event
         capturedData = msg.data
       })


### PR DESCRIPTION
# Add Lint & Prettier CI Workflow

### Chore

🔧 Introduced a GitHub Actions workflow to automatically run ESLint and Prettier checks on push to `main` and on pull request events, ensuring consistent code style and quality across the project.

### Changes

* `.github/workflows/lint-prettier.yml`: New workflow that runs on `push` to `main` and on pull request events (`opened`, `synchronize`, `reopened`, `auto_merge_enabled`). Executes `npm run lint` and `npm run prettier:check` with concurrency control to cancel in-progress runs on new commits.
* `package.json`: Added two new scripts — `prettier` for auto-formatting files and `prettier:check` for verifying formatting without making changes, both using Prettier v3.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.18`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `dda790d0-923e-11f1-8aed-e4897c943798`
</details>
