### PR TITLE
1.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.1.0 - 2026-09-04
+
+### Added
+
+- Support for adding `@notification` annotations directly onto entities.
+
+
 ## Version 1.0.0 - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Support for adding `@notification` annotations directly onto entities.
 
-
 ## Version 1.0.0 - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- Support for adding `@notification` annotations directly onto entities.
+- Support for adding `@notifications` annotations directly onto entities.
 
 ## Version 1.0.0 - 2026-08-07
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The `@cap-js/notifications` package is a [CDS plugin](https://cap.cloud.sap/docs
 - [Running the Sample](#running-the-sample)
 - [Define Notification Types](#define-notification-types)
 - [Send Notifications](#send-notifications)
+- [Entity Notifications](#entity-notifications)
 - [API Reference](#api-reference)
 - [Test-drive Locally](#test-drive-locally)
 - [Run in Production](#run-in-production)
@@ -427,6 +428,50 @@ await alert.notify([
   { type: "BookOrdered", recipients: [buyer2.id], data: { title: book2.title, buyer: buyer2.name } }
 ])
 ```
+
+## Entity Notifications
+
+Entity notifications let you declaratively fire notifications when entity data is read or changed, without writing any handler code. Add a `@notifications` annotation directly to a CDS entity, each entry in the array defines one notification:
+
+```cds
+service CatalogService {
+  @notifications: [{
+    type      : 'BookOrdered',
+    on        : ['READ'],
+    recipients: ($self.createdBy),
+    where     : ($self.stock < 5),
+    priority  : #High
+  }]
+  entity Books as projection on my.Books;
+}
+```
+
+### Annotation properties
+
+| Property     | Required | Description                                                                 |
+| ------------ | -------- | --------------------------------------------------------------------------- |
+| `type`       | yes      | The name for this notification type (e.g. 'BookOrdered'). The plugin registers it automatically. |
+| `on`         | yes      | Array of CDS events to listen on: `'READ'`, `'CREATE'`, `'UPDATE'`, `'DELETE'` |
+| `recipients` | yes      | Field reference (e.g. `$self.createdBy`) or literal recipient identifier    |
+| `where`      | no       | Filter expression: only entities matching this condition fire a notification |
+| `priority`   | no       | `#Low`, `#Neutral`, `#Medium`, or `#High`                                   |
+| `parameters` | no       | Explicit mapping of notification template placeholders to entity fields     |
+
+### Notification properties
+
+By default, all entity fields are passed to the notification template. Use `parameters` to map only specific fields instead:
+
+```cds
+@notifications: [{
+  type      : 'BookOrdered',
+  on        : ['READ'],
+  recipients: ($self.createdBy),
+  parameters: { bookTitle: $self.title, bookId: $self.ID }
+}]
+entity Books as projection on my.Books;
+```
+
+This produces a notification with only the `bookTitle` and `bookId` properties set, matching the placeholders in the notification type template.
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ service CatalogService {
 | Property     | Required | Description                                                                                      |
 | ------------ | -------- | ------------------------------------------------------------------------------------------------ |
 | `type`       | yes      | The name for this notification type (e.g. 'BookOrdered'). The plugin registers it automatically. |
-| `on`         | yes      | Array of CDS events to listen on: `'READ'`, `'CREATE'`, `'UPDATE'`, `'DELETE'`                   |
+| `on`         | yes      | Array of CDS events to listen on: `'READ'`, `'CREATE'`, `'UPDATE'`                               |
 | `recipients` | yes      | Field reference (e.g. `$self.createdBy`) or literal recipient identifier                         |
 | `where`      | no       | Filter expression: only entities matching this condition fire a notification                     |
 | `priority`   | no       | `#Low`, `#Neutral`, `#Medium`, or `#High`                                                        |

--- a/README.md
+++ b/README.md
@@ -448,14 +448,14 @@ service CatalogService {
 
 ### Annotation properties
 
-| Property     | Required | Description                                                                 |
-| ------------ | -------- | --------------------------------------------------------------------------- |
+| Property     | Required | Description                                                                                      |
+| ------------ | -------- | ------------------------------------------------------------------------------------------------ |
 | `type`       | yes      | The name for this notification type (e.g. 'BookOrdered'). The plugin registers it automatically. |
-| `on`         | yes      | Array of CDS events to listen on: `'READ'`, `'CREATE'`, `'UPDATE'`, `'DELETE'` |
-| `recipients` | yes      | Field reference (e.g. `$self.createdBy`) or literal recipient identifier    |
-| `where`      | no       | Filter expression: only entities matching this condition fire a notification |
-| `priority`   | no       | `#Low`, `#Neutral`, `#Medium`, or `#High`                                   |
-| `parameters` | no       | Explicit mapping of notification template placeholders to entity fields     |
+| `on`         | yes      | Array of CDS events to listen on: `'READ'`, `'CREATE'`, `'UPDATE'`, `'DELETE'`                   |
+| `recipients` | yes      | Field reference (e.g. `$self.createdBy`) or literal recipient identifier                         |
+| `where`      | no       | Filter expression: only entities matching this condition fire a notification                     |
+| `priority`   | no       | `#Low`, `#Neutral`, `#Medium`, or `#High`                                                        |
+| `parameters` | no       | Explicit mapping of notification template placeholders to entity fields                          |
 
 ### Notification properties
 

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -39,23 +39,19 @@ cds.on("serving", service => {
     if (!matching.length) return
     const notifications = await cds.connect.to("notifications")
     for (const n of matching) {
-      if (n.where) {
-        const rawXpr = resolveWhereXpr(n.where)
-        if (!rawXpr) continue
-        const where = rawXpr.map(token => (token?.ref?.[0] === "$self" ? { ref: token.ref.slice(1) } : token))
-        const keyParams = req.params?.[0]
-        let checkWhere = where
-        if (keyParams) {
-          const keyFilter = Object.entries(keyParams).flatMap(([k, v], i) =>
-            (i > 0 ? ["and"] : []).concat([{ ref: [k] }, "=", { val: v }])
-          )
-          checkWhere = [...keyFilter, "and", ...where]
-        }
-        const exists = await SELECT.one.from(req.target).where(checkWhere)
-        if (!exists) continue
-      }
+      const rawXpr = n.where ? resolveWhereXpr(n.where) : null
+      const where = rawXpr?.map(token => (token?.ref?.[0] === "$self" ? { ref: token.ref.slice(1) } : token))
       const entities = Array.isArray(results) ? results : [results]
       for (const entity of entities) {
+        if (where) {
+          const keys = Object.keys(req.target.keys ?? {})
+          const keyFilter = keys.flatMap((k, i) =>
+            (i > 0 ? ["and"] : []).concat([{ ref: [k] }, "=", { val: entity[k] }])
+          )
+          const checkWhere = keyFilter.length ? [...keyFilter, "and", ...where] : where
+          const exists = await SELECT.one.from(req.target).where(checkWhere)
+          if (!exists) continue
+        }
         const notification = await buildNotificationFromEntity(n, entity)
         try {
           await notifications.notify(notification)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/notifications",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CDS plugin providing support for business notifications in SAP Build WorkZone.",
   "repository": "cap-js/notifications",
   "author": "SAP SE (https://www.sap.com)",

--- a/tests/integration/entityNotification.test.js
+++ b/tests/integration/entityNotification.test.js
@@ -79,6 +79,23 @@ describe("Entity @notifications", () => {
         alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
       }
     })
+
+    test("Collection READ only fires notifications for entities matching the where clause", async () => {
+      const captured = []
+      const handler = msg => captured.push(msg.data)
+      alert.before("*", handler)
+
+      try {
+        await GET("/odata/v4/catalog-test/Books")
+        const titles = captured.map(n => n.Properties?.find(p => p.Key === "title")?.Value)
+        expect(titles).toContain("Wuthering Heights")
+        expect(titles).not.toContain("The Raven")
+        expect(titles).not.toContain("Eleonora")
+        expect(titles).not.toContain("Catweazle")
+      } finally {
+        alert._handlers.before.splice(alert._handlers.before.indexOf(handler), 1)
+      }
+    })
   })
 
   describe("READ event with explicit parameters", () => {


### PR DESCRIPTION
# Release v1.1.0: Entity Notifications Support

### New Features

✨ Introduces **entity notifications** — a declarative way to fire notifications when entity data is read or changed, without writing any handler code. Users can now add `@notifications` annotations directly onto CDS entities to define notification triggers.

### Changes

* `CHANGELOG.md`: Added v1.1.0 release entry documenting the new `@notification` annotation support on entities.
* `README.md`: Added a new **Entity Notifications** section to the table of contents and documentation, including:
  - Annotation usage example with `type`, `on`, `recipients`, `where`, and `priority` properties
  - Reference table for all annotation properties
  - Example of using `parameters` for explicit field mapping to notification template placeholders
* `package.json`: Bumped version from `1.0.0` to `1.1.0`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.14`

- Event Trigger: `pull_request.opened`
- Correlation ID: `163ad040-a871-11f1-9c5b-62a611393415`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
